### PR TITLE
fix: update paths in Dockerfile and .air.docker.toml for swagger

### DIFF
--- a/.air.docker.toml
+++ b/.air.docker.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-  cmd = "/go/bin/swag init -g main.go -d ./cmd/api/,./internal/handlers,./internal/dtos,./internal/domain,./internal/packages/httputils -o ./docs && go build -o ./tmp/main ./cmd/api"
+  cmd = "/go/bin/swag init -g main.go -d ./cmd/api/,./internal/handlers,./internal/dtos,./internal/domain,./internal/httputils -o ./docs && go build -o ./tmp/main ./cmd/api"
   bin = "./tmp/main"
   include_ext = ["go", "tpl", "tmpl", "html"]
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "docs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 # Generate Swagger documentation from handler, DTO, and domain annotations.
 # Must run before go build since the docs package is imported by cmd/api.
 RUN swag init -g main.go \
-    -d ./cmd/api/,./internal/handlers,./internal/dtos,./internal/domain,./internal/packages/httputils \
+    -d ./cmd/api/,./internal/handlers,./internal/dtos,./internal/domain,./internal/httputils \
     -o ./docs
 
 # Build the binary.


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses -->
Closes #26 

## What changed
<!-- Brief description of what was added or modified -->
- Dockerfile was updated with correct file path

## How to test
<!-- Steps to verify the changes -->
- Build Docker image should suceed
