### PR TITLE
fix: implement trusted proxy middleware and update session handling logic

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -14,7 +14,7 @@ func (c *Container) NewRouter() *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	r.Use(middlewares.TrustedProxyRealIP(c.Config.Server.TrustedProxyCIDRs))
 	r.Use(middleware.Recoverer)
 	r.Use(middlewares.LogRequest(c.Logger))
 	r.Use(middleware.Timeout(c.Config.Server.ContextTimeout))
@@ -23,7 +23,7 @@ func (c *Container) NewRouter() *chi.Mux {
 		AllowedOrigins:   c.Config.Server.CORS.AllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
-		AllowCredentials: true,
+		AllowCredentials: false,
 		MaxAge:           300,
 	}))
 

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -191,10 +191,6 @@ func extractFieldName(errMsg string) string {
 func SetRefreshTokenCookie(w http.ResponseWriter, token string, expiry time.Time, secure bool) {
 	sameSite := http.SameSiteLaxMode
 
-	if secure {
-		sameSite = http.SameSiteNoneMode
-	}
-
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,
 		Value:    token,
@@ -209,10 +205,6 @@ func SetRefreshTokenCookie(w http.ResponseWriter, token string, expiry time.Time
 
 func ClearRefreshTokenCookie(w http.ResponseWriter, secure bool) {
 	sameSite := http.SameSiteLaxMode
-
-	if secure {
-		sameSite = http.SameSiteNoneMode
-	}
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -22,12 +22,13 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	ContextTimeout  time.Duration
-	WriteTimeout    time.Duration
-	ReadTimeout     time.Duration
-	IdleTimeout     time.Duration
-	ShutdownTimeout time.Duration
-	CORS            CORSConfig
+	ContextTimeout    time.Duration
+	WriteTimeout      time.Duration
+	ReadTimeout       time.Duration
+	IdleTimeout       time.Duration
+	ShutdownTimeout   time.Duration
+	CORS              CORSConfig
+	TrustedProxyCIDRs []string
 }
 
 type CORSConfig struct {
@@ -104,11 +105,12 @@ func NewConfig() *Config {
 		Port:       env.GetString("PORT", "8080"),
 		Env:        env.GetString("ENV", "development"),
 		Server: ServerConfig{
-			ContextTimeout:  env.GetDuration("SERVER_CONTEXT_TIMEOUT", 30*time.Second),
-			WriteTimeout:    env.GetDuration("SERVER_WRITE_TIMEOUT", 30*time.Second),
-			ReadTimeout:     env.GetDuration("SERVER_READ_TIMEOUT", 30*time.Second),
-			IdleTimeout:     env.GetDuration("SERVER_IDLE_TIMEOUT", 60*time.Second),
-			ShutdownTimeout: env.GetDuration("SERVER_SHUTDOWN_TIMEOUT", 3*time.Second),
+			ContextTimeout:    env.GetDuration("SERVER_CONTEXT_TIMEOUT", 30*time.Second),
+			WriteTimeout:      env.GetDuration("SERVER_WRITE_TIMEOUT", 30*time.Second),
+			ReadTimeout:       env.GetDuration("SERVER_READ_TIMEOUT", 30*time.Second),
+			IdleTimeout:       env.GetDuration("SERVER_IDLE_TIMEOUT", 60*time.Second),
+			ShutdownTimeout:   env.GetDuration("SERVER_SHUTDOWN_TIMEOUT", 3*time.Second),
+			TrustedProxyCIDRs: strings.Split(env.GetString("TRUSTED_PROXY_CIDRS", ""), ","),
 			CORS: CORSConfig{
 				AllowedOrigins: strings.Split(env.GetString("CORS_ALLOWED_ORIGINS", "*"), ","),
 			},

--- a/internal/middlewares/real_ip_middleware.go
+++ b/internal/middlewares/real_ip_middleware.go
@@ -1,0 +1,73 @@
+package middlewares
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func TrustedProxyRealIP(trustedCIDRs []string) func(http.Handler) http.Handler {
+	nets := parseCIDRs(trustedCIDRs)
+
+	return func(next http.Handler) http.Handler {
+		realIP := middleware.RealIP(next)
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(nets) == 0 || isFromTrustedProxy(r.RemoteAddr, nets) {
+				// Connection is from a known proxy — trust the forwarded headers.
+				realIP.ServeHTTP(w, r)
+			} else {
+				// Unknown source — ignore forwarded headers, use the raw TCP IP.
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+func parseCIDRs(cidrs []string) []*net.IPNet {
+	var nets []*net.IPNet
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+
+		// Accept plain IPs without a mask by appending /32 or /128.
+		if !strings.Contains(cidr, "/") {
+			if strings.Contains(cidr, ":") {
+				cidr += "/128"
+			} else {
+				cidr += "/32"
+			}
+		}
+
+		if _, network, err := net.ParseCIDR(cidr); err == nil {
+			nets = append(nets, network)
+		}
+	}
+
+	return nets
+}
+
+func isFromTrustedProxy(remoteAddr string, nets []*net.IPNet) bool {
+	// Strip port - remoteAddr may be "1.2.3.4:port" or "[::1]:port".
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	for _, network := range nets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/repositories/session_repository.go
+++ b/internal/repositories/session_repository.go
@@ -121,20 +121,19 @@ func (r *SessionRepository) UpdateLastUsedAt(
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	query := `UPDATE sessions SET last_used_at = NOW() WHERE id = $1`
+	query := `UPDATE sessions SET last_used_at = NOW() WHERE id = $1 AND expires_at > NOW()`
 	result, err := r.db.ExecContext(ctx, query, id)
 	if err != nil {
 		return handleDBError(err, resourceSession)
 	}
 
-	// Check if session exists
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		return handleDBError(err, resourceSession)
 	}
 
 	if rowsAffected == 0 {
-		return domain.ErrSessionNotFound
+		return domain.ErrRefreshTokenInvalidOrExpired
 	}
 
 	return nil


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses -->
Closes #34 

## What changed
<!-- Brief description of what was added or modified -->
- Implemented trusted proxy middleware
- Update query in session handling update

## How to test
<!-- Steps to verify the changes -->
- Call refresh token after session is expired, we should see `401` instead of `500`
