### PR TITLE
fix: add json definitions to board ranking and board member structs

### DIFF
--- a/internal/domain/board_member.go
+++ b/internal/domain/board_member.go
@@ -6,11 +6,11 @@ import (
 )
 
 type BoardMember struct {
-	BoardID   string
-	UserID    string
-	Role      BoardMemberRole
-	CreatedAt time.Time
-	UserName  string // optional, populated when joining user
+	BoardID   string          `json:"board_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+	UserID    string          `json:"user_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+	Role      BoardMemberRole `json:"role" example:"member"`
+	CreatedAt time.Time       `json:"created_at" example:"2026-01-15T10:30:00Z"`
+	UserName  string          `json:"username" example:"johndoe"` // optional, populated when joining user
 }
 
 type BoardMemberRole string

--- a/internal/domain/board_ranking.go
+++ b/internal/domain/board_ranking.go
@@ -3,14 +3,14 @@ package domain
 import "context"
 
 type BoardRanking struct {
-	BoardID         string
-	UserID          string
-	TotalPoints     int
-	GlobalPoints    int
-	DetailedPoints  int
-	ExactHits       int
-	CorrectOutcomes int
-	UpdatedAt       string
+	BoardID         string `json:"board_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+	UserID          string `json:"user_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+	TotalPoints     int    `json:"total_points" example:"100"`
+	GlobalPoints    int    `json:"global_points" example:"50"`
+	DetailedPoints  int    `json:"detailed_points" example:"50"`
+	ExactHits       int    `json:"exact_hits" example:"5"`
+	CorrectOutcomes int    `json:"correct_outcomes" example:"10"`
+	UpdatedAt       string `json:"updated_at" example:"2026-01-15T10:30:00Z"`
 }
 
 type BoardRankingRepository interface {


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses -->
Closes #39 

## What changed
<!-- Brief description of what was added or modified -->
- Added json definitions to board struct definitions

## How to test
<!-- Steps to verify the changes -->
- Make a GET request to `/boards/{id}/members`
- Make a GET request to `/boards/{id}/ranking`
