### PR TITLE
feat: update board member joining and add more test coverage to service files

### DIFF
--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -159,7 +159,7 @@ func (s *Seeder) seedBoards(ctx context.Context, users []*domain.User) {
 
 		// Insert the members into the board
 		for j := 0; j < memberCount && j < len(candidates); j++ {
-			if err := s.boardMemberRepository.CreateBoardMember(ctx, joinCode, candidates[j].ID); err != nil {
+			if _, err := s.boardMemberRepository.CreateBoardMember(ctx, joinCode, candidates[j].ID); err != nil {
 				s.logger.Error(
 					"Error seeding board member",
 					logging.Error, err.Error(),

--- a/internal/domain/board.go
+++ b/internal/domain/board.go
@@ -28,15 +28,16 @@ type UserBoardListItem struct {
 }
 
 type BoardDetails struct {
-	ID              string       `json:"id" example:"123e4567-e89b-12d3-a456-426614174000"`
-	Name            string       `json:"name" example:"My Board"`
-	OwnerUserID     *string      `json:"owner_user_id,omitempty" example:"123e4567-e89b-12d3-a456-426614174000"`
-	JoinCode        *string      `json:"join_code,omitempty" example:"ABCD1234"`
-	Privacy         BoardPrivacy `json:"privacy" example:"private"`
-	CreatedAt       time.Time    `json:"created_at" example:"2026-01-15T10:30:00Z"`
-	JoinedAt        time.Time    `json:"joined_at" example:"2026-01-16T10:30:00Z"`
-	UserRank        int          `json:"user_rank" example:"3"`
-	UserTotalPoints int          `json:"user_total_points" example:"150"`
+	Board
+	Viewer BoardViewer `json:"viewer"`
+}
+
+type BoardViewer struct {
+	Role        BoardMemberRole `json:"role" example:"member"`
+	IsOwner     bool            `json:"is_owner" example:"false"`
+	JoinedAt    time.Time       `json:"joined_at" example:"2026-01-16T10:30:00Z"`
+	Rank        int             `json:"rank" example:"3"`
+	TotalPoints int             `json:"total_points" example:"150"`
 }
 
 type BoardMembersPage struct {

--- a/internal/domain/board_member.go
+++ b/internal/domain/board_member.go
@@ -21,7 +21,7 @@ const (
 )
 
 type BoardMemberRepository interface {
-	CreateBoardMember(ctx context.Context, joinCode string, userID string) error
+	CreateBoardMember(ctx context.Context, joinCode string, userID string) (string, error)
 	GetBoardMember(ctx context.Context, boardID string, userID string) (*BoardMember, error)
 	UpdateBoardMemberRole(ctx context.Context, boardID string, userID string, role BoardMemberRole) error
 	RemoveBoardMember(ctx context.Context, boardID string, userID string) error

--- a/internal/dtos/board_dto.go
+++ b/internal/dtos/board_dto.go
@@ -10,6 +10,10 @@ type JoinBoardDto struct {
 	JoinCode string `json:"join_code" validate:"required,min=8,max=8" example:"ABCD1234"`
 }
 
+type JoinBoardResponseDto struct {
+	BoardID string `json:"board_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+}
+
 type UpdateBoardDto struct {
 	Name string `json:"name" validate:"required,max=120" example:"League of Dummies"`
 }

--- a/internal/handlers/board_handler.go
+++ b/internal/handlers/board_handler.go
@@ -98,8 +98,8 @@ func (h *BoardHandler) GetUserBoards(w http.ResponseWriter, r *http.Request) {
 //	@Tags			boards
 //	@Accept			json
 //	@Produce		json
-//	@Param			joinCode	body	dtos.JoinBoardDto	true	"Join code"
-//	@Success		204			"Joined board successfully"
+//	@Param			joinCode	body		dtos.JoinBoardDto	true	"Join code"
+//	@Success		201			{object}	httpx.Response		"Joined board successfully"
 //	@Failure		400			{object}	httpx.ErrorResponse	"Invalid request body or validation error"
 //	@Failure		401			{object}	httpx.ErrorResponse	"Unauthorized - missing or invalid authentication"
 //	@Failure		401			{object}	httpx.ErrorResponse	"Invalid or expired board join code"
@@ -116,12 +116,15 @@ func (h *BoardHandler) JoinBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.boardMemberService.JoinBoard(r.Context(), body.JoinCode, user.ID); err != nil {
+	boardID, err := h.boardMemberService.JoinBoard(r.Context(), body.JoinCode, user.ID)
+	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return
 	}
 
-	httpx.RespondWithData(w, http.StatusNoContent, nil)
+	httpx.RespondWithData(w, http.StatusCreated, &dtos.JoinBoardResponseDto{
+		BoardID: boardID,
+	})
 }
 
 // GetBoardByID godoc

--- a/internal/handlers/board_handler_test.go
+++ b/internal/handlers/board_handler_test.go
@@ -268,16 +268,17 @@ func TestBoardHandler_JoinBoard(t *testing.T) {
 		)
 	}
 
-	t.Run("return 204 when join is successful", func(t *testing.T) {
+	t.Run("returns 201 with board id when join is successful", func(t *testing.T) {
 		t.Parallel()
 
 		body := dtos.JoinBoardDto{
 			JoinCode: "ABCD1234",
 		}
+		expectedBoardID := gofakeit.UUID()
 
 		bms := &mocks.MockBoardMemberService{
-			JoinBoardFunc: func(ctx context.Context, joinCode string, userID string) error {
-				return nil
+			JoinBoardFunc: func(ctx context.Context, joinCode string, userID string) (string, error) {
+				return expectedBoardID, nil
 			},
 		}
 
@@ -288,7 +289,14 @@ func TestBoardHandler_JoinBoard(t *testing.T) {
 
 		h.JoinBoard(w, req)
 
-		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var resp struct {
+			Data dtos.JoinBoardResponseDto `json:"data"`
+		}
+
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, expectedBoardID, resp.Data.BoardID)
 	})
 
 	t.Run("returns 400 on validation fails", func(t *testing.T) {
@@ -356,8 +364,8 @@ func TestBoardHandler_JoinBoard(t *testing.T) {
 		}
 
 		bms := &mocks.MockBoardMemberService{
-			JoinBoardFunc: func(ctx context.Context, joinCode string, userID string) error {
-				return errors.New("db error")
+			JoinBoardFunc: func(ctx context.Context, joinCode string, userID string) (string, error) {
+				return "", errors.New("db error")
 			},
 		}
 
@@ -400,12 +408,18 @@ func TestBoardHandler_GetBoardByID(t *testing.T) {
 		bs := &mocks.MockBoardService{
 			GetBoardByIDFunc: func(ctx context.Context, boardID string, userID string) (*domain.BoardDetails, error) {
 				return &domain.BoardDetails{
-					ID:       boardID,
-					Name:     "Test Board",
-					JoinCode: &joinCode,
-					Privacy:  domain.BoardPrivacyPrivate,
-					JoinedAt: time.Now(),
-					UserRank: 5,
+					Board: domain.Board{
+						ID:       boardID,
+						Name:     "Test Board",
+						JoinCode: &joinCode,
+						Privacy:  domain.BoardPrivacyPrivate,
+					},
+					Viewer: domain.BoardViewer{
+						Role:     domain.BoardMemberRoleAdmin,
+						IsOwner:  true,
+						JoinedAt: time.Now(),
+						Rank:     5,
+					},
 				}, nil
 			},
 		}
@@ -427,7 +441,9 @@ func TestBoardHandler_GetBoardByID(t *testing.T) {
 		assert.Equal(t, "Test Board", resp.Data.Name)
 		assert.NotNil(t, resp.Data.JoinCode)
 		assert.Equal(t, joinCode, *resp.Data.JoinCode)
-		assert.Equal(t, 5, resp.Data.UserRank)
+		assert.Equal(t, 5, resp.Data.Viewer.Rank)
+		assert.Equal(t, domain.BoardMemberRoleAdmin, resp.Data.Viewer.Role)
+		assert.True(t, resp.Data.Viewer.IsOwner)
 	})
 
 	t.Run("propagates service error", func(t *testing.T) {

--- a/internal/repositories/board_member_repository.go
+++ b/internal/repositories/board_member_repository.go
@@ -28,7 +28,7 @@ func (r *BoardMemberRepository) CreateBoardMember(
 	ctx context.Context,
 	joinCode string,
 	userID string,
-) error {
+) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
@@ -47,12 +47,12 @@ func (r *BoardMemberRepository) CreateBoardMember(
 	err := r.db.QueryRowContext(ctx, query, joinCode, userID).Scan(&boardID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return domain.ErrBoardInvalidJoinCode
+			return "", domain.ErrBoardInvalidJoinCode
 		}
-		return handleDBError(err, resourceBoardMember)
+		return "", handleDBError(err, resourceBoardMember)
 	}
 
-	return nil
+	return boardID, nil
 }
 
 func (r *BoardMemberRepository) GetBoardMember(

--- a/internal/repositories/board_repository.go
+++ b/internal/repositories/board_repository.go
@@ -105,6 +105,7 @@ func (r *BoardRepository) GetBoardDetails(
 		WITH ranked AS (
 			SELECT
 				bm.user_id,
+				bm.role,
 				bm.created_at AS joined_at,
 				RANK() OVER (
 					ORDER BY us.total_points DESC, us.updated_at ASC, bm.user_id ASC
@@ -121,6 +122,7 @@ func (r *BoardRepository) GetBoardDetails(
 			b.join_code,
 			b.privacy,
 			b.created_at,
+			r.role,
 			r.joined_at,
 			r.rank,
 			r.total_points
@@ -131,8 +133,9 @@ func (r *BoardRepository) GetBoardDetails(
 
 	var details domain.BoardDetails
 	var ownerUserID, joinCode sql.NullString
+	var role sql.NullString
 	var joinedAt sql.NullTime
-	var userRank, totalPoints sql.NullInt64
+	var rank, totalPoints sql.NullInt64
 
 	err := r.db.QueryRowContext(ctx, query, boardID, userID).Scan(
 		&details.ID,
@@ -141,8 +144,9 @@ func (r *BoardRepository) GetBoardDetails(
 		&joinCode,
 		&details.Privacy,
 		&details.CreatedAt,
+		&role,
 		&joinedAt,
-		&userRank,
+		&rank,
 		&totalPoints,
 	)
 	if err != nil {
@@ -151,22 +155,27 @@ func (r *BoardRepository) GetBoardDetails(
 
 	if ownerUserID.Valid {
 		details.OwnerUserID = &ownerUserID.String
+		details.Viewer.IsOwner = ownerUserID.String == userID
 	}
 
 	if joinCode.Valid {
 		details.JoinCode = &joinCode.String
 	}
 
-	if joinedAt.Valid {
-		details.JoinedAt = joinedAt.Time
+	if role.Valid {
+		details.Viewer.Role = domain.BoardMemberRole(role.String)
 	}
 
-	if userRank.Valid {
-		details.UserRank = int(userRank.Int64)
+	if joinedAt.Valid {
+		details.Viewer.JoinedAt = joinedAt.Time
+	}
+
+	if rank.Valid {
+		details.Viewer.Rank = int(rank.Int64)
 	}
 
 	if totalPoints.Valid {
-		details.UserTotalPoints = int(totalPoints.Int64)
+		details.Viewer.TotalPoints = int(totalPoints.Int64)
 	}
 
 	return &details, nil

--- a/internal/services/board_member_service.go
+++ b/internal/services/board_member_service.go
@@ -8,7 +8,7 @@ import (
 )
 
 type BoardMemberServiceInterface interface {
-	JoinBoard(ctx context.Context, joinCode string, userID string) error
+	JoinBoard(ctx context.Context, joinCode string, userID string) (string, error)
 	GetBoardMember(ctx context.Context, boardID string, userID string) (*domain.BoardMember, error)
 	GetBoardMembers(ctx context.Context, boardID string, page, limit int) (*domain.BoardMembersPage, error)
 	UpdateBoardMemberRole(ctx context.Context, boardID string, userID string, role domain.BoardMemberRole, payload dtos.UpdateBoardMemberRoleDto) error
@@ -35,7 +35,7 @@ func (s *BoardMemberService) JoinBoard(
 	ctx context.Context,
 	joinCode string,
 	userID string,
-) error {
+) (string, error) {
 	return s.boardMemberRepository.CreateBoardMember(ctx, joinCode, userID)
 }
 

--- a/internal/services/board_member_service_test.go
+++ b/internal/services/board_member_service_test.go
@@ -25,25 +25,27 @@ func newTestBoardMemberService(
 func TestBoardMemberService_JoinBoard(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns nil on success", func(t *testing.T) {
+	t.Run("returns board ID on success", func(t *testing.T) {
 		t.Parallel()
 
 		joinCode := "ABCD1234"
 		userID := gofakeit.UUID()
+		expectedBoardID := gofakeit.UUID()
 
 		bmr := &mocks.MockBoardMemberRepository{
-			CreateBoardMemberFunc: func(ctx context.Context, jc string, uid string) error {
+			CreateBoardMemberFunc: func(ctx context.Context, jc string, uid string) (string, error) {
 				assert.Equal(t, joinCode, jc)
 				assert.Equal(t, userID, uid)
-				return nil
+				return expectedBoardID, nil
 			},
 		}
 
 		service := newTestBoardMemberService(nil, bmr)
 
-		err := service.JoinBoard(context.Background(), joinCode, userID)
+		boardID, err := service.JoinBoard(context.Background(), joinCode, userID)
 
 		assert.NoError(t, err)
+		assert.Equal(t, expectedBoardID, boardID)
 	})
 
 	t.Run("propagates repository error", func(t *testing.T) {
@@ -53,17 +55,18 @@ func TestBoardMemberService_JoinBoard(t *testing.T) {
 		userID := gofakeit.UUID()
 
 		bmr := &mocks.MockBoardMemberRepository{
-			CreateBoardMemberFunc: func(ctx context.Context, jc string, uid string) error {
-				return errors.New("database error")
+			CreateBoardMemberFunc: func(ctx context.Context, jc string, uid string) (string, error) {
+				return "", errors.New("database error")
 			},
 		}
 
 		service := newTestBoardMemberService(nil, bmr)
 
-		err := service.JoinBoard(context.Background(), joinCode, userID)
+		boardID, err := service.JoinBoard(context.Background(), joinCode, userID)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database error")
+		assert.Empty(t, boardID)
 	})
 }
 

--- a/internal/services/board_service.go
+++ b/internal/services/board_service.go
@@ -140,6 +140,7 @@ func (s *BoardService) DeleteBoard(ctx context.Context, boardID string, userID s
 func (s *BoardService) isAdminMember(role domain.BoardMemberRole) bool {
 	return role == domain.BoardMemberRoleAdmin
 }
+
 func assertPrivateBoard(ctx context.Context, boardRepository domain.BoardRepository, boardID string) error {
 	board, err := boardRepository.GetBoardByID(ctx, boardID)
 	if err != nil {

--- a/internal/services/board_service_test.go
+++ b/internal/services/board_service_test.go
@@ -159,11 +159,17 @@ func TestBoardService_GetBoardByID(t *testing.T) {
 		joinedAt := gofakeit.Date()
 
 		repoBoard := &domain.BoardDetails{
-			ID:       boardID,
-			Name:     "Test Board",
-			Privacy:  domain.BoardPrivacyPrivate,
-			JoinedAt: joinedAt,
-			UserRank: 3,
+			Board: domain.Board{
+				ID:      boardID,
+				Name:    "Test Board",
+				Privacy: domain.BoardPrivacyPrivate,
+			},
+			Viewer: domain.BoardViewer{
+				Role:     domain.BoardMemberRoleAdmin,
+				IsOwner:  true,
+				JoinedAt: joinedAt,
+				Rank:     3,
+			},
 		}
 
 		br := &mocks.MockBoardRepository{
@@ -180,8 +186,10 @@ func TestBoardService_GetBoardByID(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, domain.BoardPrivacyPrivate, result.Privacy)
-		assert.Equal(t, 3, result.UserRank)
-		assert.Equal(t, joinedAt, result.JoinedAt)
+		assert.Equal(t, domain.BoardMemberRoleAdmin, result.Viewer.Role)
+		assert.True(t, result.Viewer.IsOwner)
+		assert.Equal(t, 3, result.Viewer.Rank)
+		assert.Equal(t, joinedAt, result.Viewer.JoinedAt)
 	})
 
 	t.Run("propagates board repository error", func(t *testing.T) {

--- a/internal/services/board_service_test.go
+++ b/internal/services/board_service_test.go
@@ -366,6 +366,26 @@ func TestBoardService_UpdateBoard(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database error")
 	})
+
+	t.Run("propagates assert private board error", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.UUID()
+		payload := dtos.UpdateBoardDto{Name: "Updated Board"}
+
+		br := &mocks.MockBoardRepository{
+			GetBoardByIDFunc: func(ctx context.Context, bid string) (*domain.Board, error) {
+				return nil, errors.New("database error")
+			},
+		}
+
+		service := newTestBoardService(br)
+
+		err := service.UpdateBoard(context.Background(), boardID, domain.BoardMemberRoleAdmin, payload)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database error")
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/services/fifa_world_ranking.go
+++ b/internal/services/fifa_world_ranking.go
@@ -1,0 +1,124 @@
+package services
+
+// fifaWorldRanking lists FIFA member associations in the order of the most
+// recent published edition of the FIFA/Coca-Cola Men's World Ranking, from
+// highest to lowest rank
+
+// Used to implement FIFA Article 13 rule g (final tiebreaker after rules a-f):
+// when teams cannot be separated by points, head-to-head, overall goal
+// difference, overall goals scored, or fair play, they are ranked according
+// to their position here
+var fifaWorldRanking = []string{
+	"FRA", // 1
+	"ESP", // 2
+	"ARG", // 3
+	"ENG", // 4
+	"POR", // 5
+	"BRA", // 6
+	"NED", // 7
+	"MAR", // 8
+	"BEL", // 9
+	"GER", // 10
+	"CRO", // 11
+	"ITA", // 12
+	"COL", // 13
+	"SEN", // 14
+	"MEX", // 15
+	"USA", // 16
+	"URU", // 17
+	"JPN", // 18
+	"SUI", // 19
+	"DEN", // 20
+	"IRN", // 21
+	"TUR", // 22
+	"ECU", // 23
+	"AUT", // 24
+	"KOR", // 25
+	"NGA", // 26
+	"AUS", // 27
+	"ALG", // 28
+	"EGY", // 29
+	"CAN", // 30
+	"NOR", // 31
+	"UKR", // 32
+	"PAN", // 33
+	"CIV", // 34
+	"POL", // 35
+	"RUS", // 36
+	"WAL", // 37
+	"SWE", // 38
+	"SRB", // 39
+	"PAR", // 40
+	"CZE", // 41
+	"HUN", // 42
+	"SCO", // 43
+	"TUN", // 44
+	"CMR", // 45
+	"COD", // 46
+	"GRE", // 47
+	"SVK", // 48
+	"VEN", // 49
+	"UZB", // 50
+	"CRC", // 51
+	"MLI", // 52
+	"PER", // 53
+	"CHI", // 54
+	"QAT", // 55
+	"ROU", // 56
+	"IRQ", // 57
+	"SVN", // 58
+	"IRL", // 59
+	"RSA", // 60
+	"KSA", // 61
+	"BFA", // 62
+	"JOR", // 63
+	"ALB", // 64
+	"BIH", // 65
+	"HON", // 66
+	"MKD", // 67
+	"UAE", // 68
+	"CPV", // 69
+	"NIR", // 70
+	"JAM", // 71
+	"GEO", // 72
+	"FIN", // 73
+	"GHA", // 74
+	"ISL", // 75
+	"BOL", // 76
+	"ISR", // 77
+	"KOS", // 78
+	"OMA", // 79
+	"GUI", // 80
+	"MNE", // 81
+	"CUW", // 82
+	"HAI", // 83
+	"SYR", // 84
+	"NZL", // 85
+	"BUL", // 86
+	"GAB", // 87
+	"UGA", // 88
+	"ANG", // 89
+	"BEN", // 90
+	"BHR", // 91
+	"ZAM", // 92
+	"THA", // 93
+	"CHN", // 94
+	"PLE", // 95
+	"GUA", // 96
+	"BLR", // 97
+	"LUX", // 98
+	"VIE", // 99
+	"SLV", // 100
+}
+
+// fifaWorldRankingPosition is a code-to-index lookup over fifaWorldRanking
+// Lower index means higher FIFA rank
+var fifaWorldRankingPosition = func() map[string]int {
+	positions := make(map[string]int, len(fifaWorldRanking))
+
+	for index, fifaCode := range fifaWorldRanking {
+		positions[fifaCode] = index
+	}
+
+	return positions
+}()

--- a/internal/services/group_standing_service.go
+++ b/internal/services/group_standing_service.go
@@ -38,7 +38,6 @@ func (s *GroupStandingService) GetGroupStandings(ctx context.Context, groupCodes
 }
 
 func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
-	// Get all finished matches for the group stage
 	matches, err := s.matchRepository.GetMatches(ctx, domain.MatchFilters{
 		Status:     domain.MatchStatusFinished,
 		StageCodes: []domain.MatchStageCode{domain.MatchStageCodeGroupStage},
@@ -47,9 +46,9 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 		return err
 	}
 
-	matchesGroupedByGroup := make(map[string][]*domain.Match)
+	matchesByGroup := make(map[string][]*domain.Match)
 	for _, match := range matches {
-		matchesGroupedByGroup[*match.GroupCode] = append(matchesGroupedByGroup[*match.GroupCode], match)
+		matchesByGroup[*match.GroupCode] = append(matchesByGroup[*match.GroupCode], match)
 	}
 
 	groupCodes := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}
@@ -62,7 +61,7 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 		wg.Add(1)
 		go func(groupCode string) {
 			defer wg.Done()
-			if err := s.recalculateStandingsByGroup(ctx, matchesGroupedByGroup[groupCode]); err != nil {
+			if err := s.recalculateStandingsByGroup(ctx, matchesByGroup[groupCode]); err != nil {
 				mu.Lock()
 				errs = append(errs, err)
 				mu.Unlock()
@@ -78,288 +77,273 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 	return nil
 }
 
-func (s *GroupStandingService) recalculateStandingsByGroup(
-	ctx context.Context,
-	groupMatches []*domain.Match,
-) error {
-	teamStats := calculateOverallStats(groupMatches)
-
-	// Convert map to slice for sorting
-	var standings []*domain.GroupStanding
-	for _, stat := range teamStats {
-		standings = append(standings, stat)
-	}
-
-	standings = sortByOverallStats(standings)
-	tiedGroups := identifyTiedGroups(standings)
-
-	// Build FIFA code map once (only if there are tied groups)
-	var fifaCodeToIndex map[string]int
-
-	if len(tiedGroups) > 0 {
-		fifaCodeToIndex = make(map[string]int)
-		for i, standing := range standings {
-			fifaCodeToIndex[standing.Team.FifaCode] = i
-		}
-	}
-
-	// Process tied groups only if any exist
-	for _, tiedGroup := range tiedGroups {
-		h2hMatches := filterHeadToHeadMatches(tiedGroup, groupMatches)
-		h2hStats := calculateHeadToHeadStats(tiedGroup, h2hMatches)
-		sortedGroup := sortTiedGroupByHeadToHead(tiedGroup, h2hStats)
-
-		if isStillTied(sortedGroup, h2hStats) {
-			// Fallback to overall stats (FIFA rules d, e)
-			sortedGroup = sortByOverallStats(sortedGroup)
-		}
-
-		// Update the original standings with the sorted group
-		// Replace in original standings array
-		for _, team := range sortedGroup {
-			originalIndex := fifaCodeToIndex[team.Team.FifaCode]
-			standings[originalIndex] = team
-		}
-	}
-
-	for i, standing := range standings {
-		standing.Position = i + 1
-	}
-
+func (s *GroupStandingService) recalculateStandingsByGroup(ctx context.Context, groupMatches []*domain.Match) error {
+	standings := rankGroup(groupMatches)
 	return s.groupStandingRepository.UpdateGroupStandings(ctx, standings)
 }
 
-func identifyTiedGroups(standings []*domain.GroupStanding) [][]*domain.GroupStanding {
-	if len(standings) == 0 {
-		return nil
-	}
-
-	var tiedGroups [][]*domain.GroupStanding
-	currentGroup := []*domain.GroupStanding{standings[0]}
-
-	for i := 1; i < len(standings); i++ {
-		prev := standings[i-1]
-		curr := standings[i]
-
-		// Check if current team has identical stats to previous
-		if prev.Points == curr.Points &&
-			prev.GoalDifference == curr.GoalDifference &&
-			prev.GoalsFor == curr.GoalsFor {
-			// Still tied, add to current group
-			currentGroup = append(currentGroup, curr)
-		} else {
-			// No longer tied, save current group and start new one
-			if len(currentGroup) > 1 {
-				tiedGroups = append(tiedGroups, currentGroup)
-			}
-			currentGroup = []*domain.GroupStanding{curr}
-		}
-	}
-
-	// Last group
-	if len(currentGroup) > 1 {
-		tiedGroups = append(tiedGroups, currentGroup)
-	}
-
-	return tiedGroups
+// rankGroup is the full FIFA Article 13 ranking pipeline
+func rankGroup(matches []*domain.Match) []*domain.GroupStanding {
+	standings := computeStandings(matches)
+	sortBy(standings, overallSortChain)
+	breakPointsTies(standings, matches)
+	assignPositions(standings)
+	return standings
 }
 
-func filterHeadToHeadMatches(tiedTeams []*domain.GroupStanding, allMatches []*domain.Match) []*domain.Match {
-	// Get FIFA codes of tied teams
-	tiedCodes := make(map[string]bool)
-	for _, team := range tiedTeams {
-		tiedCodes[team.Team.FifaCode] = true
-	}
+// Builds a GroupStanding per team from a slice of matches
+// Reused for both the overall table and h2h mini-tables
+// The returned slice has no defined order
+func computeStandings(matches []*domain.Match) []*domain.GroupStanding {
+	// Map team FIFA code to group standing stats
+	statsByTeam := make(map[string]*domain.GroupStanding)
 
-	// Filter matches where both teams are in the tied group
-	var h2hMatches []*domain.Match
-	for _, match := range allMatches {
-		homeCode := match.HomeTeam.FifaCode
-		awayCode := match.AwayTeam.FifaCode
-		if tiedCodes[homeCode] && tiedCodes[awayCode] {
-			h2hMatches = append(h2hMatches, match)
-		}
-	}
-
-	return h2hMatches
-}
-
-func calculateOverallStats(matches []*domain.Match) map[string]*domain.GroupStanding {
-	stats := make(map[string]*domain.GroupStanding)
-
+	// For each match, update the group standing stats for the home and away teams
 	for _, match := range matches {
-		homeCode := match.HomeTeam.FifaCode
-		awayCode := match.AwayTeam.FifaCode
+		homeTeam := match.HomeTeam.FifaCode
+		awayTeam := match.AwayTeam.FifaCode
 
-		// Initialize stats with team data
-		if _, ok := stats[homeCode]; !ok {
-			stats[homeCode] = &domain.GroupStanding{
-				Team: *match.HomeTeam,
-			}
+		if _, ok := statsByTeam[homeTeam]; !ok {
+			statsByTeam[homeTeam] = &domain.GroupStanding{Team: *match.HomeTeam}
 		}
 
-		if _, ok := stats[awayCode]; !ok {
-			stats[awayCode] = &domain.GroupStanding{
-				Team: *match.AwayTeam,
-			}
+		if _, ok := statsByTeam[awayTeam]; !ok {
+			statsByTeam[awayTeam] = &domain.GroupStanding{Team: *match.AwayTeam}
 		}
 
-		homeScore := *match.HomeScore
-		awayScore := *match.AwayScore
-
-		// Update matches played
-		stats[homeCode].MatchesPlayed++
-		stats[awayCode].MatchesPlayed++
-
-		// Update goals
-		stats[homeCode].GoalsFor += homeScore
-		stats[homeCode].GoalsAgainst += awayScore
-		stats[homeCode].GoalDifference = stats[homeCode].GoalsFor - stats[homeCode].GoalsAgainst
-
-		stats[awayCode].GoalsFor += awayScore
-		stats[awayCode].GoalsAgainst += homeScore
-		stats[awayCode].GoalDifference = stats[awayCode].GoalsFor - stats[awayCode].GoalsAgainst
-
-		// Update points and wins / draws / losses
-		if homeScore > awayScore {
-			stats[homeCode].Wins++
-			stats[homeCode].Points += 3
-			stats[awayCode].Losses++
-		} else if awayScore > homeScore {
-			stats[awayCode].Wins++
-			stats[awayCode].Points += 3
-			stats[homeCode].Losses++
-		} else {
-			stats[homeCode].Draws++
-			stats[homeCode].Points += 1
-			stats[awayCode].Draws++
-			stats[awayCode].Points += 1
-		}
+		applyMatchToStandings(
+			statsByTeam[homeTeam],
+			statsByTeam[awayTeam],
+			*match.HomeScore,
+			*match.AwayScore,
+		)
 	}
 
-	return stats
-}
-
-func calculateHeadToHeadStats(tiedTeams []*domain.GroupStanding, h2hMatches []*domain.Match) map[string]*domain.GroupStanding {
-	teamMap := make(map[string]*domain.GroupStanding)
-	for _, team := range tiedTeams {
-		teamMap[team.Team.FifaCode] = team
+	standings := make([]*domain.GroupStanding, 0, len(statsByTeam))
+	for _, s := range statsByTeam {
+		standings = append(standings, s)
 	}
-
-	stats := make(map[string]*domain.GroupStanding)
-
-	for _, match := range h2hMatches {
-		homeCode := match.HomeTeam.FifaCode
-		awayCode := match.AwayTeam.FifaCode
-
-		// Initialize stats with team data from teamMap
-		if _, ok := stats[homeCode]; !ok {
-			stats[homeCode] = &domain.GroupStanding{
-				Team: teamMap[homeCode].Team,
-			}
-		}
-
-		if _, ok := stats[awayCode]; !ok {
-			stats[awayCode] = &domain.GroupStanding{
-				Team: teamMap[awayCode].Team,
-			}
-		}
-
-		homeScore := *match.HomeScore
-		awayScore := *match.AwayScore
-
-		// Update matches played
-		stats[homeCode].MatchesPlayed++
-		stats[awayCode].MatchesPlayed++
-
-		// Update goals
-		stats[homeCode].GoalsFor += homeScore
-		stats[homeCode].GoalsAgainst += awayScore
-		stats[homeCode].GoalDifference = stats[homeCode].GoalsFor - stats[homeCode].GoalsAgainst
-
-		stats[awayCode].GoalsFor += awayScore
-		stats[awayCode].GoalsAgainst += homeScore
-		stats[awayCode].GoalDifference = stats[awayCode].GoalsFor - stats[awayCode].GoalsAgainst
-
-		// Update points and wins / draws / losses
-		if homeScore > awayScore {
-			stats[homeCode].Wins++
-			stats[homeCode].Points += 3
-			stats[awayCode].Losses++
-		} else if awayScore > homeScore {
-			stats[awayCode].Wins++
-			stats[awayCode].Points += 3
-			stats[homeCode].Losses++
-		} else {
-			stats[homeCode].Draws++
-			stats[homeCode].Points += 1
-			stats[awayCode].Draws++
-			stats[awayCode].Points += 1
-		}
-	}
-
-	return stats
-}
-
-func sortByOverallStats(standings []*domain.GroupStanding) []*domain.GroupStanding {
-	sort.Slice(standings, func(i, j int) bool {
-		teamA := standings[i]
-		teamB := standings[j]
-
-		if teamA.Points != teamB.Points {
-			return teamA.Points > teamB.Points
-		}
-
-		if teamA.GoalDifference != teamB.GoalDifference {
-			return teamA.GoalDifference > teamB.GoalDifference
-		}
-
-		return teamA.GoalsFor > teamB.GoalsFor
-	})
 
 	return standings
 }
 
-func sortTiedGroupByHeadToHead(tiedTeams []*domain.GroupStanding, h2hStats map[string]*domain.GroupStanding) []*domain.GroupStanding {
-	sort.Slice(tiedTeams, func(i, j int) bool {
-		teamA := tiedTeams[i]
-		teamB := tiedTeams[j]
-		statsA := h2hStats[teamA.Team.FifaCode]
-		statsB := h2hStats[teamB.Team.FifaCode]
+func applyMatchToStandings(home, away *domain.GroupStanding, homeScore, awayScore int) {
+	// Update the matches played count
+	home.MatchesPlayed++
+	away.MatchesPlayed++
 
-		// Rule a: Head-to-head points
-		if statsA.Points != statsB.Points {
-			return statsA.Points > statsB.Points
-		}
+	// Update the goals for, against counts and goal difference
+	home.GoalsFor += homeScore
+	home.GoalsAgainst += awayScore
+	home.GoalDifference = home.GoalsFor - home.GoalsAgainst
 
-		// Rule b: Head-to-head goal difference
-		if statsA.GoalDifference != statsB.GoalDifference {
-			return statsA.GoalDifference > statsB.GoalDifference
-		}
+	away.GoalsFor += awayScore
+	away.GoalsAgainst += homeScore
+	away.GoalDifference = away.GoalsFor - away.GoalsAgainst
 
-		// Rule c: Head-to-head goals for
-		return statsA.GoalsFor > statsB.GoalsFor
-	})
-
-	return tiedTeams
+	// Update the wins, draws, losses and points counts
+	switch {
+	case homeScore > awayScore:
+		home.Wins++
+		home.Points += 3
+		away.Losses++
+	case awayScore > homeScore:
+		away.Wins++
+		away.Points += 3
+		home.Losses++
+	default:
+		home.Draws++
+		home.Points++
+		away.Draws++
+		away.Points++
+	}
 }
 
-func isStillTied(sortedGroup []*domain.GroupStanding, h2hStats map[string]*domain.GroupStanding) bool {
-	if len(sortedGroup) <= 1 {
-		return false
+// breakPointsTies finds consecutive runs of teams equal on Points and re-orders
+// each run via the FIFA Article 13 tiebreaker chain (Step 1 + Step 2 with recursion)
+// Modifies `standings` in place
+func breakPointsTies(standings []*domain.GroupStanding, allMatches []*domain.Match) {
+	i := 0 // Index of the current team
+
+	// Iterate over the standings
+	for i < len(standings) {
+		j := i + 1 // Index of the next team
+
+		// Iterate over the standings until the points are not equal
+		for j < len(standings) && standings[j].Points == standings[i].Points {
+			j++ // If the next team has the same points, move to the next team
+		}
+
+		// If there are at least two teams with the same points, rank them
+		if j-i > 1 {
+			ranked := rankTiedSubgroup(standings[i:j], allMatches)
+			// Replace the tied teams with the ranked teams
+			for k, team := range ranked {
+				standings[i+k] = team
+			}
+		}
+
+		// Move to the next group of teams with the same points
+		i = j
+	}
+}
+
+// rankTiedSubgroup applies FIFA Article 13 a/b/c (head-to-head) to a subgroup of
+// teams equal on points, then recurses on any sub-run that remains tied on h2h
+// criteria (Step 2, first sentence). If the entire input remains h2h-tied (no
+// separation possible), falls back to the overall sort chain (rules d, e, [f])
+func rankTiedSubgroup(tiedTeams []*domain.GroupStanding, allMatches []*domain.Match) []*domain.GroupStanding {
+	// Get the matches between the tied teams
+	h2hMatches := matchesBetween(tiedTeams, allMatches)
+	// Compute the standings for the head-to-head matches
+	h2hStandings := computeStandings(h2hMatches)
+	// Map the head-to-head standings by team FIFA code
+	h2hByTeam := make(map[string]*domain.GroupStanding, len(h2hStandings))
+
+	for _, s := range h2hStandings {
+		h2hByTeam[s.Team.FifaCode] = s
 	}
 
-	firstCode := sortedGroup[0].Team.FifaCode
-	firstStats := h2hStats[firstCode]
+	// Sort the head-to-head standings by the head-to-head sort chain (points, GD, GF)
+	sortBy(h2hStandings, headToHeadSortChain)
 
-	for _, team := range sortedGroup[1:] {
-		teamStats := h2hStats[team.Team.FifaCode]
-		if teamStats.Points != firstStats.Points ||
-			teamStats.GoalDifference != firstStats.GoalDifference ||
-			teamStats.GoalsFor != firstStats.GoalsFor {
-			return false
+	tiedByCode := make(map[string]*domain.GroupStanding, len(tiedTeams))
+	for _, t := range tiedTeams {
+		tiedByCode[t.Team.FifaCode] = t
+	}
+
+	ordered := make([]*domain.GroupStanding, 0, len(tiedTeams))
+	for _, s := range h2hStandings {
+		if t, ok := tiedByCode[s.Team.FifaCode]; ok {
+			ordered = append(ordered, t)
 		}
 	}
 
-	return true
+	subgroups := partitionByH2HCriteria(ordered, h2hByTeam)
+
+	result := make([]*domain.GroupStanding, 0, len(tiedTeams))
+	for _, subgroup := range subgroups {
+		switch {
+		case len(subgroup) == 1:
+			result = append(result, subgroup...)
+		case len(subgroup) < len(tiedTeams):
+			// If there are fewer teams in the subgroup than the tied teams,
+			// recursively rank the subgroup
+			result = append(result, rankTiedSubgroup(subgroup, allMatches)...)
+		default:
+			sortBy(subgroup, overallSortChain)
+			result = append(result, subgroup...)
+		}
+	}
+
+	return result
+}
+
+// Returns the matches in allMatches where both teams are in `teams`
+func matchesBetween(teams []*domain.GroupStanding, allMatches []*domain.Match) []*domain.Match {
+	codes := make(map[string]bool, len(teams))
+	for _, t := range teams {
+		codes[t.Team.FifaCode] = true
+	}
+
+	var filtered []*domain.Match
+	for _, match := range allMatches {
+		if codes[match.HomeTeam.FifaCode] && codes[match.AwayTeam.FifaCode] {
+			filtered = append(filtered, match)
+		}
+	}
+	return filtered
+}
+
+// partitionByH2HCriteria splits a slice (already sorted by the head-to-head
+// chain) into consecutive runs of teams identical on h2h Points + GoalDifference + GoalsFor
+func partitionByH2HCriteria(sortedTeams []*domain.GroupStanding, h2hByCode map[string]*domain.GroupStanding) [][]*domain.GroupStanding {
+	if len(sortedTeams) == 0 {
+		return nil
+	}
+
+	var groups [][]*domain.GroupStanding
+	current := []*domain.GroupStanding{sortedTeams[0]}
+
+	for i := 1; i < len(sortedTeams); i++ {
+		prev := h2hByCode[sortedTeams[i-1].Team.FifaCode]
+		curr := h2hByCode[sortedTeams[i].Team.FifaCode]
+		if prev.Points == curr.Points &&
+			prev.GoalDifference == curr.GoalDifference &&
+			prev.GoalsFor == curr.GoalsFor {
+			current = append(current, sortedTeams[i])
+		} else {
+			groups = append(groups, current)
+			current = []*domain.GroupStanding{sortedTeams[i]}
+		}
+	}
+	groups = append(groups, current)
+
+	return groups
+}
+
+func assignPositions(standings []*domain.GroupStanding) {
+	for i, s := range standings {
+		s.Position = i + 1
+	}
+}
+
+// tiebreaker returns a negative value if a ranks above b, positive if b above a,
+// zero if equal on this criterion
+type tiebreaker func(a, b *domain.GroupStanding) int
+
+var (
+	byPoints tiebreaker = func(a, b *domain.GroupStanding) int {
+		return b.Points - a.Points
+	}
+
+	byGoalDifference tiebreaker = func(a, b *domain.GroupStanding) int {
+		return b.GoalDifference - a.GoalDifference
+	}
+
+	byGoalsFor tiebreaker = func(a, b *domain.GroupStanding) int {
+		return b.GoalsFor - a.GoalsFor
+	}
+
+	// FIFA rule f (fair play / cards) is not implemented yet. To enable:
+	//   1. Add a FairPlayScore int field on domain.GroupStanding
+	//   2. Populate it inside applyMatchToStandings from card data on domain.Match
+	//   3. Define byFairPlay below and append it to overallSortChain (before byFifaWorldRanking)
+	// No structural changes elsewhere are required
+	//
+	// byFairPlay tiebreaker = func(a, b *domain.GroupStanding) int {
+	//     return b.FairPlayScore - a.FairPlayScore
+	// }
+
+	// FIFA rule g — most recent published FIFA/Coca-Cola Men's World Ranking
+	byFifaWorldRanking tiebreaker = func(a, b *domain.GroupStanding) int {
+		return fifaWorldRankingPosition[a.Team.FifaCode] - fifaWorldRankingPosition[b.Team.FifaCode]
+	}
+)
+
+var overallSortChain = []tiebreaker{
+	byPoints,
+	byGoalDifference, // FIFA rule d
+	byGoalsFor,       // FIFA rule e
+	// byFairPlay,      // FIFA rule f - enable when card data exists
+	byFifaWorldRanking, // FIFA rule g
+}
+
+var headToHeadSortChain = []tiebreaker{
+	byPoints,
+	byGoalDifference,
+	byGoalsFor,
+}
+
+func sortBy(standings []*domain.GroupStanding, chain []tiebreaker) {
+	sort.SliceStable(standings, func(i, j int) bool {
+		// For each criterion in the chain, compare the standings at the current indices
+		for _, criterion := range chain {
+			if comparison := criterion(standings[i], standings[j]); comparison != 0 {
+				return comparison < 0
+			}
+		}
+
+		return false
+	})
 }

--- a/internal/services/group_standing_service_test.go
+++ b/internal/services/group_standing_service_test.go
@@ -1,0 +1,299 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestGroupStandingService(
+	gr *mocks.MockGroupStandingRepository,
+	mr *mocks.MockMatchRepository,
+	logger *mocks.MockLogger,
+) GroupStandingServiceInterface {
+	return NewGroupStandingService(gr, mr, logger)
+}
+
+func intScorePtr(n int) *int {
+	v := n
+	return &v
+}
+
+func stringPtr(s string) *string {
+	v := s
+	return &v
+}
+
+// ---------------------------------------------------------------------------
+// TestGroupStandingService_GetGroupStandings
+// ---------------------------------------------------------------------------
+func TestGroupStandingService_GetGroupStandings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns group standings", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &mocks.MockGroupStandingRepository{
+			GetGroupStandingsFunc: func(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error) {
+				return []*domain.GroupStanding{
+					{
+						Position: 1,
+						Team:     domain.Team{FifaCode: "GER"},
+					},
+				}, nil
+			},
+		}
+
+		service := newTestGroupStandingService(gr, nil, nil)
+
+		groupStandings, err := service.GetGroupStandings(context.Background(), []string{"A"}, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, groupStandings, groupStandings)
+	})
+
+	t.Run("propagates repository error", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &mocks.MockGroupStandingRepository{
+			GetGroupStandingsFunc: func(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error) {
+				return nil, errors.New("database error")
+			},
+		}
+
+		service := newTestGroupStandingService(gr, nil, nil)
+
+		groupStandings, err := service.GetGroupStandings(context.Background(), []string{"A"}, nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database error")
+		assert.Nil(t, groupStandings)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestGroupStandingService_RecalculateStandings
+// ---------------------------------------------------------------------------
+func TestGroupStandingService_RecalculateStandings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil on success", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				rows := []struct {
+					id                   int64
+					groupCode            string
+					homeFifa, awayFifa   string
+					homeScore, awayScore int
+				}{
+					{1, "A", "MEX", "RSA", 2, 1},
+					{2, "A", "KOR", "CZE", 0, 3},
+					{25, "A", "CZE", "RSA", 4, 0},
+					{28, "A", "MEX", "KOR", 1, 2},
+					{53, "A", "RSA", "KOR", 0, 1},
+					{54, "A", "CZE", "MEX", 2, 2},
+				}
+
+				now := time.Now()
+				matches := make([]*domain.Match, len(rows))
+				for i, r := range rows {
+					matches[i] = &domain.Match{
+						ID:        r.id,
+						GroupCode: stringPtr(r.groupCode),
+						Status:    domain.MatchStatusFinished,
+						StageCode: domain.MatchStageCodeGroupStage,
+						HomeTeam:  &domain.Team{FifaCode: r.homeFifa},
+						AwayTeam:  &domain.Team{FifaCode: r.awayFifa},
+						HomeScore: intScorePtr(r.homeScore),
+						AwayScore: intScorePtr(r.awayScore),
+						UpdatedAt: now,
+					}
+				}
+
+				return matches, nil
+			},
+		}
+
+		gr := &mocks.MockGroupStandingRepository{
+			UpdateGroupStandingsFunc: func(ctx context.Context, standings []*domain.GroupStanding) error {
+				return nil
+			},
+		}
+
+		service := newTestGroupStandingService(gr, mr, nil)
+
+		err := service.RecalculateStandings(context.Background())
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("propagates match repository error", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return nil, errors.New("database error")
+			},
+		}
+
+		service := newTestGroupStandingService(nil, mr, nil)
+
+		err := service.RecalculateStandings(context.Background())
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database error")
+	})
+
+	t.Run("propagates group standing repository error when recalculating standings by group", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return nil, nil
+			},
+		}
+
+		gr := &mocks.MockGroupStandingRepository{
+			UpdateGroupStandingsFunc: func(ctx context.Context, standings []*domain.GroupStanding) error {
+				return errors.New("database error")
+			},
+		}
+
+		service := newTestGroupStandingService(gr, mr, nil)
+
+		err := service.RecalculateStandings(context.Background())
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database error")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestGroupStandingService_rankGroup
+// ---------------------------------------------------------------------------
+func TestGroupStandingService_rankGroup(t *testing.T) {
+	t.Parallel()
+
+	type matchScore struct {
+		home, away           string
+		homeScore, awayScore int
+	}
+
+	buildMatches := func(scores []matchScore) []*domain.Match {
+		matches := make([]*domain.Match, len(scores))
+		for i, s := range scores {
+			matches[i] = &domain.Match{
+				HomeTeam:  &domain.Team{FifaCode: s.home},
+				AwayTeam:  &domain.Team{FifaCode: s.away},
+				HomeScore: intScorePtr(s.homeScore),
+				AwayScore: intScorePtr(s.awayScore),
+			}
+		}
+
+		return matches
+	}
+
+	testCases := []struct {
+		name          string
+		scores        []matchScore
+		expectedOrder []string
+	}{
+		{
+			name: "mid-tournament: tied teams haven't played each other yet",
+			scores: []matchScore{
+				{"MEX", "RSA", 1, 0},
+				{"KOR", "CZE", 1, 0},
+			},
+			expectedOrder: []string{"MEX", "KOR", "CZE", "RSA"},
+		},
+		{
+			name: "no ties",
+			scores: []matchScore{
+				{"MEX", "RSA", 0, 2},
+				{"KOR", "CZE", 1, 0},
+				{"CZE", "RSA", 0, 1},
+				{"MEX", "KOR", 1, 1},
+				{"RSA", "KOR", 2, 0},
+				{"CZE", "MEX", 3, 0},
+			},
+			expectedOrder: []string{"RSA", "KOR", "CZE", "MEX"},
+		},
+		{
+			name: "2 teams tied on points and goal difference",
+			scores: []matchScore{
+				{"MEX", "RSA", 0, 2},
+				{"KOR", "CZE", 0, 0},
+				{"CZE", "RSA", 1, 0},
+				{"MEX", "KOR", 0, 1},
+				{"RSA", "KOR", 1, 1},
+				{"CZE", "MEX", 2, 0},
+			},
+			expectedOrder: []string{"CZE", "KOR", "RSA", "MEX"},
+		},
+		{
+			name: "3 teams tied on points",
+			scores: []matchScore{
+				{"MEX", "RSA", 0, 1},
+				{"KOR", "CZE", 1, 0},
+				{"CZE", "RSA", 1, 0},
+				{"MEX", "KOR", 0, 2},
+				{"RSA", "KOR", 1, 0},
+				{"CZE", "MEX", 3, 0},
+			},
+			expectedOrder: []string{"CZE", "KOR", "RSA", "MEX"},
+		},
+		{
+			name: "3 teams tied on points and goal difference",
+			scores: []matchScore{
+				{"MEX", "RSA", 0, 2},
+				{"KOR", "CZE", 0, 0},
+				{"CZE", "RSA", 1, 1},
+				{"MEX", "KOR", 0, 2},
+				{"RSA", "KOR", 2, 2},
+				{"CZE", "MEX", 2, 0},
+			},
+			expectedOrder: []string{"RSA", "KOR", "CZE", "MEX"},
+		},
+		{
+			name: "4 teams tied on points",
+			scores: []matchScore{
+				{"MEX", "RSA", 1, 1},
+				{"KOR", "CZE", 1, 1},
+				{"CZE", "RSA", 0, 1},
+				{"MEX", "KOR", 1, 0},
+				{"RSA", "KOR", 0, 1},
+				{"CZE", "MEX", 2, 0},
+			},
+			expectedOrder: []string{"CZE", "KOR", "RSA", "MEX"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			standings := rankGroup(buildMatches(tc.scores))
+
+			actualOrder := make([]string, len(standings))
+			for i, s := range standings {
+				actualOrder[i] = s.Team.FifaCode
+			}
+
+			// ? Debug output
+			// for _, s := range standings {
+			// 	if tc.name == "no ties" {
+			// 		fmt.Printf("Team: %s, Points: %d, GD: %d, GF: %d, GA: %d\n", s.Team.FifaCode, s.Points, s.GoalDifference, s.GoalsFor, s.GoalsAgainst)
+			// 	}
+			// }
+
+			assert.Equal(t, tc.expectedOrder, actualOrder)
+		})
+	}
+}

--- a/internal/services/match_service.go
+++ b/internal/services/match_service.go
@@ -532,7 +532,7 @@ func loadThirdPlaceCombinations() []domain.ThirdPlaceCombination {
 	if err := json.Unmarshal(combinationsJSON, &combinations); err != nil {
 		panic("failed to parse embedded combinations.json: " + err.Error())
 	}
-	
+
 	return combinations
 }
 

--- a/internal/services/match_service.go
+++ b/internal/services/match_service.go
@@ -87,7 +87,7 @@ func (s *MatchService) UpdateMatchResult(ctx context.Context, matchID int64, pay
 		return nil, err
 	}
 
-	s.firePickemScoring(outcomes, []int64{matchID})
+	s.asyncScoreMatches(outcomes, []int64{matchID})
 	return outcomes, nil
 }
 
@@ -135,7 +135,7 @@ func (s *MatchService) UpdateMatchResultsBulk(ctx context.Context, payload dtos.
 		return nil, err
 	}
 
-	s.firePickemScoring(outcomes, matchIDs)
+	s.asyncScoreMatches(outcomes, matchIDs)
 	return outcomes, nil
 }
 
@@ -150,7 +150,7 @@ func (s *MatchService) ResetMatchResult(ctx context.Context, matchID int64) (*do
 	// rescore after correcting and re-finalizing the match result
 }
 
-func (s *MatchService) firePickemScoring(outcomes *domain.SyncGroupStageOutcomes, matchIDs []int64) {
+func (s *MatchService) asyncScoreMatches(outcomes *domain.SyncGroupStageOutcomes, matchIDs []int64) {
 	go func() {
 		bgCtx := context.Background()
 
@@ -529,7 +529,10 @@ func buildGroupPositionMatchUpdates(groupCode string, groupStandings []*domain.G
 
 func loadThirdPlaceCombinations() []domain.ThirdPlaceCombination {
 	var combinations []domain.ThirdPlaceCombination
-	json.Unmarshal(combinationsJSON, &combinations)
+	if err := json.Unmarshal(combinationsJSON, &combinations); err != nil {
+		panic("failed to parse embedded combinations.json: " + err.Error())
+	}
+	
 	return combinations
 }
 

--- a/internal/services/match_service_test.go
+++ b/internal/services/match_service_test.go
@@ -1,0 +1,715 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestMatchService(
+	matchRepository *mocks.MockMatchRepository,
+	groupStandingRepository *mocks.MockGroupStandingRepository,
+	groupStandingService *mocks.MockGroupStandingService,
+	scoringService *mocks.MockScoringService,
+	logger *mocks.MockLogger,
+) MatchServiceInterface {
+	return NewMatchService(
+		matchRepository,
+		groupStandingRepository,
+		groupStandingService,
+		scoringService,
+		logger,
+	)
+}
+
+func intPtr(v int) *int { return &v }
+
+// thirdPlaceTeamsNoConflict returns 8 third-place teams with clearly distinct rankings
+// (groups A-C-D-E-H-I-J-B, matching combination 470 for tests that exercise third-place promotion)
+func thirdPlaceTeamsNoConflict() []*domain.ThirdPlaceTeam {
+	return []*domain.ThirdPlaceTeam{
+		{FifaCode: "BRA", GroupCode: "C", Points: 9, GoalDifference: 6, GoalsFor: 10},
+		{FifaCode: "GER", GroupCode: "E", Points: 7, GoalDifference: 3, GoalsFor: 8},
+		{FifaCode: "FRA", GroupCode: "I", Points: 6, GoalDifference: 2, GoalsFor: 7},
+		{FifaCode: "ESP", GroupCode: "H", Points: 5, GoalDifference: 1, GoalsFor: 6},
+		{FifaCode: "ARG", GroupCode: "J", Points: 4, GoalDifference: 0, GoalsFor: 5},
+		{FifaCode: "MEX", GroupCode: "A", Points: 3, GoalDifference: 1, GoalsFor: 4},
+		{FifaCode: "USA", GroupCode: "D", Points: 3, GoalDifference: 1, GoalsFor: 4},
+		{FifaCode: "CAN", GroupCode: "B", Points: 2, GoalDifference: -2, GoalsFor: 3},
+	}
+}
+
+// thirdPlaceTeamsWithConflict returns 12 third-place teams where teams at positions 7 and 8
+// (POR from group I and NED from group A) are tied on all tiebreakers, creating a conflict.
+// The 7 guaranteed qualifiers come from groups E,F,G,H,J,K,L; the tied pair is I and A.
+// Selecting POR (group I) yields qualifying groups E,F,G,H,I,J,K,L → combination 1.
+func thirdPlaceTeamsWithConflict() []*domain.ThirdPlaceTeam {
+	return []*domain.ThirdPlaceTeam{
+		{FifaCode: "BRA", GroupCode: "E", Points: 9, GoalDifference: 6, GoalsFor: 10},
+		{FifaCode: "GER", GroupCode: "F", Points: 8, GoalDifference: 5, GoalsFor: 9},
+		{FifaCode: "FRA", GroupCode: "G", Points: 7, GoalDifference: 4, GoalsFor: 8},
+		{FifaCode: "ESP", GroupCode: "H", Points: 6, GoalDifference: 3, GoalsFor: 7},
+		{FifaCode: "ARG", GroupCode: "J", Points: 5, GoalDifference: 2, GoalsFor: 6},
+		{FifaCode: "MEX", GroupCode: "K", Points: 4, GoalDifference: 1, GoalsFor: 5},
+		{FifaCode: "ENG", GroupCode: "L", Points: 3, GoalDifference: 1, GoalsFor: 4},
+		{FifaCode: "POR", GroupCode: "I", Points: 2, GoalDifference: 0, GoalsFor: 3},
+		{FifaCode: "NED", GroupCode: "A", Points: 2, GoalDifference: 0, GoalsFor: 3},
+		{FifaCode: "ITA", GroupCode: "B", Points: 1, GoalDifference: -1, GoalsFor: 2},
+		{FifaCode: "CHI", GroupCode: "C", Points: 1, GoalDifference: -2, GoalsFor: 1},
+		{FifaCode: "URU", GroupCode: "D", Points: 0, GoalDifference: -3, GoalsFor: 0},
+	}
+}
+
+func groupStageMatch() *domain.Match {
+	return &domain.Match{
+		ID:        1,
+		HomeTeam:  &domain.Team{FifaCode: "MEX"},
+		AwayTeam:  &domain.Team{FifaCode: "USA"},
+		StageCode: domain.MatchStageCodeGroupStage,
+		Status:    domain.MatchStatusFinished,
+		HomeScore: intPtr(1),
+		AwayScore: intPtr(0),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_GetMatches
+// ---------------------------------------------------------------------------
+func TestMatchService_GetMatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns matches", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{
+					{ID: 1, HomeTeam: &domain.Team{FifaCode: "MEX"}, AwayTeam: &domain.Team{FifaCode: "USA"}},
+				}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		matches, err := service.GetMatches(context.Background(), domain.MatchFilters{MatchIDs: []int64{1}})
+
+		assert.NoError(t, err)
+		assert.Equal(t, matches, []*domain.Match{
+			{ID: 1, HomeTeam: &domain.Team{FifaCode: "MEX"}, AwayTeam: &domain.Team{FifaCode: "USA"}},
+		})
+	})
+
+	t.Run("propagates repository error", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return nil, errors.New("database error")
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		matches, err := service.GetMatches(context.Background(), domain.MatchFilters{MatchIDs: []int64{1}})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database error")
+		assert.Nil(t, matches)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestValidateMatchResultForStage
+// ---------------------------------------------------------------------------
+func TestValidateMatchResultForStage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("group stage without penalty returns nil", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeGroupStage, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(0),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("group stage with penalty returns ErrPenaltyForbidden", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeGroupStage, dtos.UpdateMatchResultDto{
+			HomeScore:        intPtr(1),
+			AwayScore:        intPtr(0),
+			HomePenaltyScore: intPtr(5),
+		})
+		assert.ErrorIs(t, err, domain.ErrPenaltyForbidden)
+	})
+
+	t.Run("knockout tied with penalty returns nil", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeRoundOf32, dtos.UpdateMatchResultDto{
+			HomeScore:        intPtr(1),
+			AwayScore:        intPtr(1),
+			HomePenaltyScore: intPtr(5),
+			AwayPenaltyScore: intPtr(4),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("knockout tied without penalty returns ErrPenaltyRequired", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeRoundOf32, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(1),
+		})
+		assert.ErrorIs(t, err, domain.ErrPenaltyRequired)
+	})
+
+	t.Run("knockout decided with penalty returns ErrPenaltyForbidden", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeRoundOf32, dtos.UpdateMatchResultDto{
+			HomeScore:        intPtr(2),
+			AwayScore:        intPtr(1),
+			HomePenaltyScore: intPtr(5),
+		})
+		assert.ErrorIs(t, err, domain.ErrPenaltyForbidden)
+	})
+
+	t.Run("knockout decided without penalty returns nil", func(t *testing.T) {
+		t.Parallel()
+		err := validateMatchResultForStage(domain.MatchStageCodeRoundOf32, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(2),
+			AwayScore: intPtr(1),
+		})
+		assert.NoError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_UpdateMatchResult
+// ---------------------------------------------------------------------------
+func TestMatchService_UpdateMatchResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns IsGroupStageFinished set to true and PromotionOutcome Status set to completed and fires pickem scoring on success when group is finished", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return true, nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				return nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc: func(ctx context.Context, matchIDs []int64) error {
+				return nil
+			},
+			ScoreBestThirdsFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		gsr := &mocks.MockGroupStandingRepository{
+			GetGroupStandingsFunc: func(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error) {
+				return []*domain.GroupStanding{
+					{
+						Position:       1,
+						Team:           domain.Team{FifaCode: "MEX"},
+						MatchesPlayed:  1,
+						Wins:           1,
+						GoalsFor:       1,
+						GoalDifference: 1,
+						Points:         3,
+					},
+				}, nil
+			},
+			GetThirdPlaceGroupsFunc: func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+				return thirdPlaceTeamsNoConflict(), nil
+			},
+		}
+
+		service := newTestMatchService(mr, gsr, gss, ss, nil)
+
+		syncGroupStageOutcomes, err := service.UpdateMatchResult(context.Background(), 1, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(0),
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, syncGroupStageOutcomes.IsGroupStageFinished, true)
+		assert.Equal(t, syncGroupStageOutcomes.PromotionOutcome.Status, domain.PromotionStatusCompleted)
+		assert.Equal(t, syncGroupStageOutcomes.PromotionOutcome.Assignments, []domain.ThirdPlaceAssignment{
+			{MatchID: 74, AwayTeamFifaCode: "BRA"},
+			{MatchID: 77, AwayTeamFifaCode: "USA"},
+			{MatchID: 79, AwayTeamFifaCode: "ESP"},
+			{MatchID: 80, AwayTeamFifaCode: "FRA"},
+			{MatchID: 81, AwayTeamFifaCode: "CAN"},
+			{MatchID: 82, AwayTeamFifaCode: "MEX"},
+			{MatchID: 85, AwayTeamFifaCode: "ARG"},
+			{MatchID: 87, AwayTeamFifaCode: "GER"},
+		})
+	})
+
+	t.Run("returns IsGroupStageFinished set to false and fires pickem scoring on success when input group is not finished", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return false, nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc: func(ctx context.Context, matchIDs []int64) error {
+				return nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, gss, ss, nil)
+
+		syncGroupStageOutcomes, err := service.UpdateMatchResult(context.Background(), 1, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(0),
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, syncGroupStageOutcomes, &domain.SyncGroupStageOutcomes{
+			IsGroupStageFinished: false,
+		})
+	})
+
+	t.Run("returns ErrMatchNotFound when match does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResult(context.Background(), 99, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(0),
+		})
+
+		assert.ErrorIs(t, err, domain.ErrMatchNotFound)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("returns ErrPenaltyForbidden for group stage match with penalty", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResult(context.Background(), 1, dtos.UpdateMatchResultDto{
+			HomeScore:        intPtr(1),
+			AwayScore:        intPtr(0),
+			HomePenaltyScore: intPtr(5),
+		})
+
+		assert.ErrorIs(t, err, domain.ErrPenaltyForbidden)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("propagates repository update error", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return errors.New("db write error")
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResult(context.Background(), 1, dtos.UpdateMatchResultDto{
+			HomeScore: intPtr(1),
+			AwayScore: intPtr(0),
+		})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "db write error")
+		assert.Nil(t, outcomes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_UpdateMatchResultsBulk
+// ---------------------------------------------------------------------------
+func TestMatchService_UpdateMatchResultsBulk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns IsGroupStageFinished set to false when group is not finished", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return false, nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc: func(ctx context.Context, matchIDs []int64) error { return nil },
+		}
+
+		service := newTestMatchService(mr, nil, gss, ss, nil)
+
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 1, UpdateMatchResultDto: dtos.UpdateMatchResultDto{HomeScore: intPtr(1), AwayScore: intPtr(0)}},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, outcomes, &domain.SyncGroupStageOutcomes{IsGroupStageFinished: false})
+	})
+
+	t.Run("returns IsGroupStageFinished set to true with PromotionStatusCompleted when group stage finishes", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return false, nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				return nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc:    func(ctx context.Context, matchIDs []int64) error { return nil },
+			ScoreBestThirdsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		gsr := &mocks.MockGroupStandingRepository{
+			GetThirdPlaceGroupsFunc: func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+				return thirdPlaceTeamsNoConflict(), nil
+			},
+		}
+
+		service := newTestMatchService(mr, gsr, gss, ss, nil)
+
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 1, UpdateMatchResultDto: dtos.UpdateMatchResultDto{HomeScore: intPtr(1), AwayScore: intPtr(0)}},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, outcomes.IsGroupStageFinished)
+		assert.Equal(t, outcomes.PromotionOutcome.Status, domain.PromotionStatusCompleted)
+	})
+
+	t.Run("returns ErrMatchesNotFound when a match ID is not in the database", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 99, UpdateMatchResultDto: dtos.UpdateMatchResultDto{HomeScore: intPtr(1), AwayScore: intPtr(0)}},
+			},
+		})
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &domain.MatchesNotFoundError{})
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("returns ErrPenaltyForbidden for group stage match with penalty", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 1, UpdateMatchResultDto: dtos.UpdateMatchResultDto{
+					HomeScore:        intPtr(1),
+					AwayScore:        intPtr(0),
+					HomePenaltyScore: intPtr(5),
+				}},
+			},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrPenaltyForbidden)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("propagates repository update error", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{groupStageMatch()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return errors.New("db write error")
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 1, UpdateMatchResultDto: dtos.UpdateMatchResultDto{HomeScore: intPtr(1), AwayScore: intPtr(0)}},
+			},
+		})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "db write error")
+		assert.Nil(t, outcomes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_ResetMatchResult
+// ---------------------------------------------------------------------------
+func TestMatchService_ResetMatchResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resets result and returns outcomes without triggering scoring", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			ResetMatchResultFunc: func(ctx context.Context, matchID int64) error {
+				return nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return false, nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		// No scoring mocks set — any call to ScoreMatches/ScoreBestThirds would panic,
+		// confirming that reset does not trigger pick'em scoring.
+		service := newTestMatchService(mr, nil, gss, nil, nil)
+
+		outcomes, err := service.ResetMatchResult(context.Background(), 1)
+
+		assert.NoError(t, err)
+		assert.Equal(t, outcomes, &domain.SyncGroupStageOutcomes{IsGroupStageFinished: false})
+	})
+
+	t.Run("propagates repository error", func(t *testing.T) {
+		t.Parallel()
+
+		mr := &mocks.MockMatchRepository{
+			ResetMatchResultFunc: func(ctx context.Context, matchID int64) error {
+				return errors.New("db reset error")
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, nil, nil)
+
+		outcomes, err := service.ResetMatchResult(context.Background(), 1)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "db reset error")
+		assert.Nil(t, outcomes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_ResolveThirdPlaceConflict
+// ---------------------------------------------------------------------------
+func TestMatchService_ResolveThirdPlaceConflict(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves conflict and returns group stage finished outcomes", func(t *testing.T) {
+		t.Parallel()
+
+		conflictTeams := thirdPlaceTeamsWithConflict()
+
+		mr := &mocks.MockMatchRepository{
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				return nil
+			},
+			IsGroupFinishedFunc: func(ctx context.Context, groupCode string) (bool, error) {
+				return false, nil
+			},
+			IsGroupStageFinishedFunc: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+		}
+
+		gss := &mocks.MockGroupStandingService{
+			RecalculateStandingsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreBestThirdsFunc: func(ctx context.Context) error { return nil },
+		}
+
+		gsr := &mocks.MockGroupStandingRepository{
+			GetThirdPlaceGroupsFunc: func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+				return conflictTeams, nil
+			},
+		}
+
+		service := newTestMatchService(mr, gsr, gss, ss, nil)
+
+		// Select POR (group I) over NED (group A) from the tied pair — both are valid candidates.
+		outcomes, err := service.ResolveThirdPlaceConflict(context.Background(), dtos.ResolveThirdPlaceConflictDto{
+			TeamFifaCodes: []string{"BRA", "GER", "FRA", "ESP", "ARG", "MEX", "ENG", "POR"},
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, outcomes.IsGroupStageFinished)
+	})
+
+	t.Run("returns ErrThirdPlaceNotInConflict when standings have no tie", func(t *testing.T) {
+		t.Parallel()
+
+		gsr := &mocks.MockGroupStandingRepository{
+			GetThirdPlaceGroupsFunc: func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+				return thirdPlaceTeamsNoConflict(), nil
+			},
+		}
+
+		service := newTestMatchService(nil, gsr, nil, nil, nil)
+
+		outcomes, err := service.ResolveThirdPlaceConflict(context.Background(), dtos.ResolveThirdPlaceConflictDto{
+			TeamFifaCodes: []string{"BRA", "GER", "FRA", "ESP", "ARG", "MEX", "USA", "CAN"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrThirdPlaceNotInConflict)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("returns ErrThirdPlaceInvalidSelection when a code is not in the candidate list", func(t *testing.T) {
+		t.Parallel()
+
+		gsr := &mocks.MockGroupStandingRepository{
+			GetThirdPlaceGroupsFunc: func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+				return thirdPlaceTeamsWithConflict(), nil
+			},
+		}
+
+		service := newTestMatchService(nil, gsr, nil, nil, nil)
+
+		// QAT is not among the 12 third-place teams
+		outcomes, err := service.ResolveThirdPlaceConflict(context.Background(), dtos.ResolveThirdPlaceConflictDto{
+			TeamFifaCodes: []string{"BRA", "GER", "FRA", "ESP", "ARG", "MEX", "ENG", "QAT"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrThirdPlaceInvalidSelection)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("returns ErrThirdPlaceInvalidSelection for duplicate codes", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestMatchService(nil, nil, nil, nil, nil)
+
+		outcomes, err := service.ResolveThirdPlaceConflict(context.Background(), dtos.ResolveThirdPlaceConflictDto{
+			TeamFifaCodes: []string{"BRA", "GER", "FRA", "ESP", "ARG", "MEX", "ENG", "BRA"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrThirdPlaceInvalidSelection)
+		assert.Nil(t, outcomes)
+	})
+
+	t.Run("returns ErrThirdPlaceInvalidSelection when payload does not contain exactly 8 codes", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestMatchService(nil, nil, nil, nil, nil)
+
+		outcomes, err := service.ResolveThirdPlaceConflict(context.Background(), dtos.ResolveThirdPlaceConflictDto{
+			TeamFifaCodes: []string{"BRA", "GER", "FRA", "ESP", "ARG", "MEX", "ENG"},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrThirdPlaceInvalidSelection)
+		assert.Nil(t, outcomes)
+	})
+}

--- a/internal/test/mocks/board_member_repository_mock.go
+++ b/internal/test/mocks/board_member_repository_mock.go
@@ -7,14 +7,14 @@ import (
 )
 
 type MockBoardMemberRepository struct {
-	CreateBoardMemberFunc     func(ctx context.Context, joinCode string, userID string) error
+	CreateBoardMemberFunc     func(ctx context.Context, joinCode string, userID string) (string, error)
 	GetBoardMemberFunc        func(ctx context.Context, boardID string, userID string) (*domain.BoardMember, error)
 	UpdateBoardMemberRoleFunc func(ctx context.Context, boardID string, userID string, role domain.BoardMemberRole) error
 	RemoveBoardMemberFunc     func(ctx context.Context, boardID string, userID string) error
 	LeaveBoardFunc            func(ctx context.Context, boardID string, userID string) error
 }
 
-func (m *MockBoardMemberRepository) CreateBoardMember(ctx context.Context, joinCode string, userID string) error {
+func (m *MockBoardMemberRepository) CreateBoardMember(ctx context.Context, joinCode string, userID string) (string, error) {
 	if m.CreateBoardMemberFunc != nil {
 		return m.CreateBoardMemberFunc(ctx, joinCode, userID)
 	}

--- a/internal/test/mocks/board_member_service_mock.go
+++ b/internal/test/mocks/board_member_service_mock.go
@@ -8,7 +8,7 @@ import (
 )
 
 type MockBoardMemberService struct {
-	JoinBoardFunc             func(ctx context.Context, joinCode string, userID string) error
+	JoinBoardFunc             func(ctx context.Context, joinCode string, userID string) (string, error)
 	GetBoardMemberFunc        func(ctx context.Context, boardID string, userID string) (*domain.BoardMember, error)
 	GetBoardMembersFunc       func(ctx context.Context, boardID string, page, limit int) (*domain.BoardMembersPage, error)
 	UpdateBoardMemberRoleFunc func(ctx context.Context, boardID string, userID string, role domain.BoardMemberRole, payload dtos.UpdateBoardMemberRoleDto) error
@@ -16,7 +16,7 @@ type MockBoardMemberService struct {
 	LeaveBoardFunc            func(ctx context.Context, boardID string, userID string) error
 }
 
-func (m *MockBoardMemberService) JoinBoard(ctx context.Context, joinCode string, userID string) error {
+func (m *MockBoardMemberService) JoinBoard(ctx context.Context, joinCode string, userID string) (string, error) {
 	if m.JoinBoardFunc != nil {
 		return m.JoinBoardFunc(ctx, joinCode, userID)
 	}

--- a/internal/test/mocks/group_standing_repository_mock.go
+++ b/internal/test/mocks/group_standing_repository_mock.go
@@ -1,0 +1,34 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockGroupStandingRepository struct {
+	GetGroupStandingsFunc    func(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error)
+	UpdateGroupStandingsFunc func(ctx context.Context, standings []*domain.GroupStanding) error
+	GetThirdPlaceGroupsFunc  func(ctx context.Context) ([]*domain.ThirdPlaceTeam, error)
+}
+
+func (m *MockGroupStandingRepository) GetGroupStandings(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error) {
+	if m.GetGroupStandingsFunc != nil {
+		return m.GetGroupStandingsFunc(ctx, groupCodes, position)
+	}
+	panic("GetGroupStandings called unexpectedly")
+}
+
+func (m *MockGroupStandingRepository) UpdateGroupStandings(ctx context.Context, standings []*domain.GroupStanding) error {
+	if m.UpdateGroupStandingsFunc != nil {
+		return m.UpdateGroupStandingsFunc(ctx, standings)
+	}
+	panic("UpdateGroupStandings called unexpectedly")
+}
+
+func (m *MockGroupStandingRepository) GetThirdPlaceGroups(ctx context.Context) ([]*domain.ThirdPlaceTeam, error) {
+	if m.GetThirdPlaceGroupsFunc != nil {
+		return m.GetThirdPlaceGroupsFunc(ctx)
+	}
+	panic("GetThirdPlaceGroups called unexpectedly")
+}

--- a/internal/test/mocks/group_standing_service.go
+++ b/internal/test/mocks/group_standing_service.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockGroupStandingService struct {
+	GetGroupStandingsFunc    func(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error)
+	RecalculateStandingsFunc func(ctx context.Context) error
+}
+
+func (m *MockGroupStandingService) GetGroupStandings(ctx context.Context, groupCodes []string, position *int64) ([]*domain.GroupStanding, error) {
+	if m.GetGroupStandingsFunc != nil {
+		return m.GetGroupStandingsFunc(ctx, groupCodes, position)
+	}
+	panic("GetGroupStandings called unexpectedly")
+}
+
+func (m *MockGroupStandingService) RecalculateStandings(ctx context.Context) error {
+	if m.RecalculateStandingsFunc != nil {
+		return m.RecalculateStandingsFunc(ctx)
+	}
+	panic("RecalculateStandings called unexpectedly")
+}

--- a/internal/test/mocks/match_repository_mock.go
+++ b/internal/test/mocks/match_repository_mock.go
@@ -1,0 +1,67 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockMatchRepository struct {
+	GetMatchesFunc                     func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error)
+	GetFirstGroupStageMatchKickoffFunc func(ctx context.Context) (time.Time, error)
+	UpdateMatchesResultFunc            func(ctx context.Context, updates []domain.MatchResultUpdate) error
+	UpdateMatchTeamsFunc               func(ctx context.Context, updates []domain.MatchTeamUpdate) error
+	ResetMatchResultFunc               func(ctx context.Context, matchID int64) error
+	IsGroupFinishedFunc                func(ctx context.Context, groupCode string) (bool, error)
+	IsGroupStageFinishedFunc           func(ctx context.Context) (bool, error)
+}
+
+func (m *MockMatchRepository) GetMatches(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+	if m.GetMatchesFunc != nil {
+		return m.GetMatchesFunc(ctx, filters)
+	}
+	panic("GetMatches called unexpectedly")
+}
+
+func (m *MockMatchRepository) GetFirstGroupStageMatchKickoff(ctx context.Context) (time.Time, error) {
+	if m.GetFirstGroupStageMatchKickoffFunc != nil {
+		return m.GetFirstGroupStageMatchKickoffFunc(ctx)
+	}
+	panic("GetFirstGroupStageMatchKickoff called unexpectedly")
+}
+
+func (m *MockMatchRepository) UpdateMatchTeams(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+	if m.UpdateMatchTeamsFunc != nil {
+		return m.UpdateMatchTeamsFunc(ctx, updates)
+	}
+	panic("UpdateMatchTeams called unexpectedly")
+}
+
+func (m *MockMatchRepository) UpdateMatchesResult(ctx context.Context, updates []domain.MatchResultUpdate) error {
+	if m.UpdateMatchesResultFunc != nil {
+		return m.UpdateMatchesResultFunc(ctx, updates)
+	}
+	panic("UpdateMatchesResult called unexpectedly")
+}
+
+func (m *MockMatchRepository) ResetMatchResult(ctx context.Context, matchID int64) error {
+	if m.ResetMatchResultFunc != nil {
+		return m.ResetMatchResultFunc(ctx, matchID)
+	}
+	panic("ResetMatchResult called unexpectedly")
+}
+
+func (m *MockMatchRepository) IsGroupFinished(ctx context.Context, groupCode string) (bool, error) {
+	if m.IsGroupFinishedFunc != nil {
+		return m.IsGroupFinishedFunc(ctx, groupCode)
+	}
+	panic("IsGroupFinished called unexpectedly")
+}
+
+func (m *MockMatchRepository) IsGroupStageFinished(ctx context.Context) (bool, error) {
+	if m.IsGroupStageFinishedFunc != nil {
+		return m.IsGroupStageFinishedFunc(ctx)
+	}
+	panic("IsGroupStageFinished called unexpectedly")
+}

--- a/internal/test/mocks/scoring_service_mock.go
+++ b/internal/test/mocks/scoring_service_mock.go
@@ -1,0 +1,22 @@
+package mocks
+
+import "context"
+
+type MockScoringService struct {
+	ScoreMatchesFunc    func(ctx context.Context, matchIDs []int64) error
+	ScoreBestThirdsFunc func(ctx context.Context) error
+}
+
+func (m *MockScoringService) ScoreMatches(ctx context.Context, matchIDs []int64) error {
+	if m.ScoreMatchesFunc != nil {
+		return m.ScoreMatchesFunc(ctx, matchIDs)
+	}
+	panic("ScoreMatches called unexpectedly")
+}
+
+func (m *MockScoringService) ScoreBestThirds(ctx context.Context) error {
+	if m.ScoreBestThirdsFunc != nil {
+		return m.ScoreBestThirdsFunc(ctx)
+	}
+	panic("ScoreBestThirds called unexpectedly")
+}


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses -->
Closes #49

## What changed
<!-- Brief description of what was added or modified -->
- Enhaned group standing service with tests
- Added initial tests for match service
- Update board member join endpoint to return board_id

## How to test
<!-- Steps to verify the changes -->
- Run `make test-unit` and tests should suceed
- Endpoint to join a bord should now return the id
