### PR TITLE
feat(pickems): add per-group lock endpoint and lock-driven progress

### DIFF
--- a/cmd/db/migrations/000007_create_pickem_tables.down.sql
+++ b/cmd/db/migrations/000007_create_pickem_tables.down.sql
@@ -2,4 +2,5 @@ DROP TABLE IF EXISTS score_events;
 DROP TABLE IF EXISTS user_match_score_picks;
 DROP TABLE IF EXISTS user_bracket_picks;
 DROP TABLE IF EXISTS user_best_third_picks;
+DROP TABLE IF EXISTS user_group_locks;
 DROP TABLE IF EXISTS user_group_picks;

--- a/cmd/db/migrations/000007_create_pickem_tables.up.sql
+++ b/cmd/db/migrations/000007_create_pickem_tables.up.sql
@@ -12,6 +12,16 @@ CREATE TABLE IF NOT EXISTS user_group_picks (
 CREATE INDEX IF NOT EXISTS idx_user_group_picks_user_id         ON user_group_picks(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_group_picks_team_group_code ON user_group_picks(team_group_code);
 
+CREATE TABLE IF NOT EXISTS user_group_locks (
+  user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  group_code CHAR(1) NOT NULL CHECK (
+    group_code IN ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L')
+  ),
+  PRIMARY KEY (user_id, group_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_group_locks_user_id ON user_group_locks(user_id);
+
 CREATE TABLE IF NOT EXISTS user_best_third_picks (
   user_id        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   team_fifa_code VARCHAR(8) NOT NULL REFERENCES teams(fifa_code),

--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -209,6 +209,20 @@ func (s *Seeder) seedPickemData(ctx context.Context, users []*domain.User) {
 			continue
 		}
 
+		// Seeded pickem users have committed their predictions, so every group ships pre-locked
+		lockPlaceholders := make([]string, 0, len(groupCodes))
+		lockArgs := make([]any, 0, len(groupCodes)*2)
+		for i, code := range groupCodes {
+			base := i * 2
+			lockPlaceholders = append(lockPlaceholders, fmt.Sprintf("($%d, $%d)", base+1, base+2))
+			lockArgs = append(lockArgs, user.ID, code)
+		}
+		lockQuery := `INSERT INTO user_group_locks (user_id, group_code) VALUES ` +
+			strings.Join(lockPlaceholders, ", ") + ` ON CONFLICT DO NOTHING`
+		if _, err := s.db.ExecContext(ctx, lockQuery, lockArgs...); err != nil {
+			s.logger.Error("Error seeding group locks", logging.Error, err.Error())
+		}
+
 		mathrand.Shuffle(len(thirdPlaceTeams), func(a, b int) {
 			thirdPlaceTeams[a], thirdPlaceTeams[b] = thirdPlaceTeams[b], thirdPlaceTeams[a]
 		})

--- a/internal/app/routes_pickems.go
+++ b/internal/app/routes_pickems.go
@@ -11,6 +11,7 @@ func pickemRoutes(c *Container) chi.Router {
 
 	r.Get("/", c.PickemHandler.GetUserPickem)
 	r.Put("/groups", c.PickemHandler.SaveGroupPicks)
+	r.Put("/groups/lock", c.PickemHandler.SetGroupLock)
 	r.Put("/best-thirds", c.PickemHandler.SaveBestThirds)
 	r.Put("/bracket", c.PickemHandler.SaveBracketPicks)
 

--- a/internal/domain/pickem.go
+++ b/internal/domain/pickem.go
@@ -12,6 +12,7 @@ type UserPickem struct {
 
 type ResolvedGroupPick struct {
 	GroupCode string       `json:"group_code"`
+	Locked    bool         `json:"locked"`
 	Teams     []RankedTeam `json:"teams"`
 }
 
@@ -80,4 +81,7 @@ type PickemRepository interface {
 	GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*UserBracketPick, error) // for scoring
 	GetChampionPick(ctx context.Context, userID string) (*string, error)
 	GetUserProgressCounts(ctx context.Context, userID string) (PickemProgressCounts, error)
+	GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error)
+	SetGroupLock(ctx context.Context, userID, groupCode string, locked bool, picks []*UserGroupPick) error
+	ClearGroupLocks(ctx context.Context, userID string, groupCodes []string) error
 }

--- a/internal/dtos/pickem_dto.go
+++ b/internal/dtos/pickem_dto.go
@@ -9,6 +9,12 @@ type GroupPickDto struct {
 	TeamFifaCodes []string `json:"team_fifa_codes" validate:"required,len=4,unique,dive,required,fifa_code" example:"MEX,RSA,KOR,CZE"` // index 0 = pos 1, index 3 = pos 4
 }
 
+type SetGroupLockDto struct {
+	GroupCode     string   `json:"group_code" validate:"required,len=1,oneof=A B C D E F G H I J K L" example:"A"`
+	Locked        bool     `json:"locked" example:"true"`
+	TeamFifaCodes []string `json:"team_fifa_codes" validate:"required,len=4,unique,dive,required,fifa_code" example:"MEX,RSA,KOR,CZE"`
+}
+
 type SaveBestThirdsDto struct {
 	TeamFifaCodes []string `json:"team_fifa_codes" validate:"required,len=8,unique,dive,required,fifa_code" example:"MEX,RSA,KOR,CZE,BRA,MAR,HAI,SCO"`
 }

--- a/internal/handlers/pickem_handler.go
+++ b/internal/handlers/pickem_handler.go
@@ -97,6 +97,52 @@ func (h *PickemHandler) SaveGroupPicks(w http.ResponseWriter, r *http.Request) {
 	httpx.RespondWithData(w, http.StatusOK, pickem)
 }
 
+// SetGroupLock locks (confirms) or unlocks a single group's ordering. Locking persists the
+// submitted team order for that group AND sets the lock flag in one transaction; if the order
+// differs from what's stored, best-thirds and bracket picks are cascade-cleared. Unlocking only
+// clears the lock — the saved order is untouched.
+//
+//	@Summary	Lock or unlock a group
+//	@Tags		pickems
+//	@Accept		json
+//	@Produce	json
+//	@Param		body	body		dtos.SetGroupLockDto	true	"Group lock request"
+//	@Success	200		{object}	domain.UserPickem		"User's pickem state"
+//	@Failure	400		{object}	httpx.ErrorResponse		"Invalid request body"
+//	@Failure	401		{object}	httpx.ErrorResponse		"Missing or invalid Bearer token"
+//	@Security	BearerAuth
+//	@Router		/pickems/groups/lock [put]
+func (h *PickemHandler) SetGroupLock(w http.ResponseWriter, r *http.Request) {
+	user := httpctx.GetAuthenticatedUser(r.Context())
+
+	var body dtos.SetGroupLockDto
+	if err := httpx.ReadAndValidateJSON(w, r, &body, h.validator); err != nil {
+		return
+	}
+
+	picks := make([]*domain.UserGroupPick, 0, len(body.TeamFifaCodes))
+	for i, code := range body.TeamFifaCodes {
+		picks = append(picks, &domain.UserGroupPick{
+			TeamFifaCode:      code,
+			TeamGroupCode:     body.GroupCode,
+			PredictedPosition: i + 1,
+		})
+	}
+
+	if err := h.pickemService.SetGroupLock(r.Context(), user.ID, body.GroupCode, body.Locked, picks); err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	pickem, err := h.pickemService.GetUserPickem(r.Context(), user.ID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, pickem)
+}
+
 // SaveBestThirds saves the user's 8 best-third picks. Requires all 12 group picks
 // to be saved and complete before this endpoint accepts input.
 //

--- a/internal/repositories/pickem_repository.go
+++ b/internal/repositories/pickem_repository.go
@@ -347,14 +347,10 @@ func (r *PickemRepository) GetUserProgressCounts(ctx context.Context, userID str
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
+	// `groups_completed` is the number of locked groups
 	query := `
 		SELECT
-			(SELECT COUNT(*) FROM (
-				SELECT 1 FROM user_group_picks
-				WHERE user_id = $1
-				GROUP BY team_group_code
-				HAVING COUNT(*) = 4
-			) g) AS groups_completed,
+			(SELECT COUNT(*) FROM user_group_locks WHERE user_id = $1) AS groups_completed,
 			(SELECT COUNT(*) FROM user_best_third_picks WHERE user_id = $1) AS best_thirds_completed,
 			(SELECT COUNT(*) FROM user_bracket_picks WHERE user_id = $1) AS bracket_completed
 	`
@@ -367,6 +363,155 @@ func (r *PickemRepository) GetUserProgressCounts(ctx context.Context, userID str
 	}
 
 	return counts, nil
+}
+
+func (r *PickemRepository) GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	rows, err := r.db.QueryContext(ctx, `SELECT group_code FROM user_group_locks WHERE user_id = $1`, userID)
+	if err != nil {
+		return nil, handleDBError(err, resourcePickem)
+	}
+	defer rows.Close()
+
+	codes := []string{}
+	for rows.Next() {
+		var code string
+		if err := rows.Scan(&code); err != nil {
+			return nil, handleDBError(err, resourcePickem)
+		}
+		codes = append(codes, code)
+	}
+
+	return codes, rows.Err()
+}
+
+func (r *PickemRepository) SetGroupLock(
+	ctx context.Context,
+	userID, groupCode string,
+	locked bool,
+	picks []*domain.UserGroupPick,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return handleDBError(err, resourcePickem)
+	}
+	defer tx.Rollback()
+
+	// Unlocking: the lock row is removed
+	if !locked {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_group_locks WHERE user_id = $1 AND group_code = $2`, userID, groupCode); err != nil {
+			return handleDBError(err, resourcePickem)
+		}
+
+		return tx.Commit()
+	}
+
+	// Locking: detect whether the incoming order differs from what's stored. If so, replace this group's picks and cascade-clear best-thirds + bracket.
+	// If not, only the lock row is upserted (no downstream cascade)
+	existingRows, err := tx.QueryContext(
+		ctx,
+		`SELECT team_fifa_code, predicted_position FROM user_group_picks WHERE user_id = $1 AND team_group_code = $2`,
+		userID, groupCode,
+	)
+	if err != nil {
+		return handleDBError(err, resourcePickem)
+	}
+
+	existingByPos := make(map[int]string, 4)
+	for existingRows.Next() {
+		var code string
+		var pos int
+
+		if err := existingRows.Scan(&code, &pos); err != nil {
+			existingRows.Close()
+			return handleDBError(err, resourcePickem)
+		}
+
+		existingByPos[pos] = code
+	}
+	existingRows.Close()
+	if err := existingRows.Err(); err != nil {
+		return handleDBError(err, resourcePickem)
+	}
+
+	orderChanged := len(existingByPos) != len(picks)
+	if !orderChanged {
+		for _, p := range picks {
+			if existingByPos[p.PredictedPosition] != p.TeamFifaCode {
+				orderChanged = true
+				break
+			}
+		}
+	}
+
+	// If group order changed, delete the existing picks for best-thirds and bracket
+	if orderChanged {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_group_picks WHERE user_id = $1 AND team_group_code = $2`, userID, groupCode); err != nil {
+			return handleDBError(err, resourcePickem)
+		}
+
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_best_third_picks WHERE user_id = $1`, userID); err != nil {
+			return handleDBError(err, resourcePickem)
+		}
+
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_bracket_picks WHERE user_id = $1`, userID); err != nil {
+			return handleDBError(err, resourcePickem)
+		}
+
+		var values []string
+		var args []any
+		argIndex := 1
+		for _, p := range picks {
+			values = append(values, "($"+strconv.Itoa(argIndex)+",$"+strconv.Itoa(argIndex+1)+",$"+strconv.Itoa(argIndex+2)+",$"+strconv.Itoa(argIndex+3)+")")
+			args = append(args, userID, p.TeamFifaCode, p.TeamGroupCode, p.PredictedPosition)
+			argIndex += 4
+		}
+
+		query := `INSERT INTO user_group_picks (
+			user_id,
+			team_fifa_code,
+			team_group_code,
+			predicted_position
+		) VALUES ` + strings.Join(values, ",")
+
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return handleDBError(err, resourcePickem)
+		}
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO user_group_locks (user_id, group_code) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		userID, groupCode,
+	); err != nil {
+		return handleDBError(err, resourcePickem)
+	}
+
+	return tx.Commit()
+}
+
+func (r *PickemRepository) ClearGroupLocks(ctx context.Context, userID string, groupCodes []string) error {
+	if len(groupCodes) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	if _, err := r.db.ExecContext(
+		ctx,
+		`DELETE FROM user_group_locks WHERE user_id = $1 AND group_code = ANY($2)`,
+		userID, pq.Array(groupCodes),
+	); err != nil {
+		return handleDBError(err, resourcePickem)
+	}
+
+	return nil
 }
 
 func (r *PickemRepository) GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error) {

--- a/internal/services/pickem_service.go
+++ b/internal/services/pickem_service.go
@@ -19,6 +19,7 @@ type PickemServiceInterface interface {
 	GetChampionPick(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	SetGroupLock(ctx context.Context, userID, groupCode string, locked bool, picks []*domain.UserGroupPick) error
 	SaveBestThirds(ctx context.Context, userID string, teamFifaCodes []string) error
 	SaveBracketPicks(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
 }
@@ -63,6 +64,7 @@ func (s *PickemService) GetUserPickem(ctx context.Context, userID string) (*doma
 		groupPicks   []*domain.UserGroupPick
 		bestThirds   []*domain.UserBestThirdPick
 		bracketPicks []*domain.UserBracketPick
+		lockedCodes  []string
 	)
 
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -70,20 +72,25 @@ func (s *PickemService) GetUserPickem(ctx context.Context, userID string) (*doma
 	eg.Go(func() (err error) { groupPicks, err = s.pickemRepo.GetGroupPicks(egCtx, userID); return })
 	eg.Go(func() (err error) { bestThirds, err = s.pickemRepo.GetBestThirdPicks(egCtx, userID); return })
 	eg.Go(func() (err error) { bracketPicks, err = s.pickemRepo.GetBracketPicks(egCtx, userID); return })
+	eg.Go(func() (err error) { lockedCodes, err = s.pickemRepo.GetLockedGroupCodes(egCtx, userID); return })
 
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
 
 	groupPicksByGroup := groupPicksByGroupCode(groupPicks)
+	lockedByGroup := make(map[string]bool, len(lockedCodes))
+	for _, code := range lockedCodes {
+		lockedByGroup[code] = true
+	}
 	bracket := s.projectBracket(groupPicksByGroup, bestThirds, bracketPicks)
 
 	return &domain.UserPickem{
-		GroupPicks: s.buildGroupPicksView(groupPicksByGroup),
+		GroupPicks: s.buildGroupPicksView(groupPicksByGroup, lockedByGroup),
 		BestThirds: s.buildBestThirdsView(bestThirds),
 		Bracket:    bracket,
 		Progress: domain.PickemProgress{
-			Groups:     computeGroupsProgress(groupPicksByGroup),
+			Groups:     stepProgress(len(lockedCodes), 12),
 			BestThirds: computeBestThirdsProgress(bestThirds),
 			Bracket:    computeBracketProgress(bracketPicks),
 		},
@@ -136,7 +143,31 @@ func (s *PickemService) SaveGroupPicks(
 		return nil
 	}
 
-	return s.pickemRepo.UpsertGroupPicks(ctx, userID, picks)
+	if err := s.pickemRepo.UpsertGroupPicks(ctx, userID, picks); err != nil {
+		return err
+	}
+
+	changedCodes := changedGroupCodes(existing, picks)
+	if len(changedCodes) > 0 {
+		if err := s.pickemRepo.ClearGroupLocks(ctx, userID, changedCodes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *PickemService) SetGroupLock(
+	ctx context.Context,
+	userID, groupCode string,
+	locked bool,
+	picks []*domain.UserGroupPick,
+) error {
+	if s.isPickemLocked() {
+		return domain.ErrPickemLocked
+	}
+
+	return s.pickemRepo.SetGroupLock(ctx, userID, groupCode, locked, picks)
 }
 
 func (s *PickemService) SaveBestThirds(ctx context.Context, userID string, teamFifaCodes []string) error {
@@ -152,7 +183,7 @@ func (s *PickemService) SaveBestThirds(ctx context.Context, userID string, teamF
 
 	groupPicksByGroup := groupPicksByGroupCode(groupPicks)
 
-	if !computeGroupsProgress(groupPicksByGroup).IsComplete() {
+	if !groupOrderingComplete(groupPicksByGroup) {
 		return domain.ErrGroupPicksRequired
 	}
 
@@ -214,7 +245,7 @@ func (s *PickemService) SaveBracketPicks(ctx context.Context, userID string, bra
 	groupPicksByGroup := groupPicksByGroupCode(groupPicks)
 
 	// Check if all 12 groups and 8 best-thirds are complete before bracket picks are accepted
-	groupsAndThirdsComplete := computeGroupsProgress(groupPicksByGroup).IsComplete() && len(bestThirds) == 8
+	groupsAndThirdsComplete := groupOrderingComplete(groupPicksByGroup) && len(bestThirds) == 8
 	if !groupsAndThirdsComplete {
 		return domain.ErrGroupPicksRequired
 	}
@@ -241,7 +272,10 @@ func (s *PickemService) isPickemLocked() bool {
 	return time.Now().UTC().After(s.lockTime)
 }
 
-func computeGroupsProgress(groupPicks map[string][]*domain.UserGroupPick) domain.StepProgress {
+// groupOrderingComplete reports whether every group has exactly 4 picks in positions 1–4.
+// Group ordering completeness no longer drives step-1 progress (locks do), but it remains a
+// precondition for accepting best-thirds and bracket picks.
+func groupOrderingComplete(groupPicks map[string][]*domain.UserGroupPick) bool {
 	completed := 0
 	for _, picks := range groupPicks {
 		if len(picks) == 4 {
@@ -249,7 +283,33 @@ func computeGroupsProgress(groupPicks map[string][]*domain.UserGroupPick) domain
 		}
 	}
 
-	return stepProgress(completed, 12)
+	return completed == 12
+}
+
+func changedGroupCodes(existing, incoming []*domain.UserGroupPick) []string {
+	type pickKey struct {
+		groupCode string
+		position  int
+	}
+
+	existingByKey := make(map[pickKey]string, len(existing))
+	for _, p := range existing {
+		existingByKey[pickKey{p.TeamGroupCode, p.PredictedPosition}] = p.TeamFifaCode
+	}
+
+	changed := make(map[string]bool, 12)
+	for _, p := range incoming {
+		if existingByKey[pickKey{p.TeamGroupCode, p.PredictedPosition}] != p.TeamFifaCode {
+			changed[p.TeamGroupCode] = true
+		}
+	}
+
+	codes := make([]string, 0, len(changed))
+	for code := range changed {
+		codes = append(codes, code)
+	}
+
+	return codes
 }
 
 func computeBestThirdsProgress(bestThirds []*domain.UserBestThirdPick) domain.StepProgress {
@@ -424,22 +484,24 @@ func groupPicksByGroupCode(picks []*domain.UserGroupPick) map[string][]*domain.U
 	return byGroup
 }
 
-func (s *PickemService) buildGroupPicksView(picksByGroup map[string][]*domain.UserGroupPick) []domain.ResolvedGroupPick {
-	if len(picksByGroup) == 0 {
-		return s.defaultGroupPicksView()
-	}
+func (s *PickemService) buildGroupPicksView(picksByGroup map[string][]*domain.UserGroupPick, lockedByGroup map[string]bool) []domain.ResolvedGroupPick {
+	defaults := s.defaultGroupPicksView()
 
-	groupPicks := make([]domain.ResolvedGroupPick, 0, len(picksByGroup))
-	for groupCode, picks := range picksByGroup {
-		teams := make([]domain.RankedTeam, 0, len(picks))
-		for _, pick := range picks {
-			teams = append(teams, domain.RankedTeam{Position: pick.PredictedPosition, Team: *s.teamLookup[pick.TeamFifaCode]})
+	for i, group := range defaults {
+		saved, ok := picksByGroup[group.GroupCode]
+		if ok && len(saved) > 0 {
+			teams := make([]domain.RankedTeam, 0, len(saved))
+
+			for _, pick := range saved {
+				teams = append(teams, domain.RankedTeam{Position: pick.PredictedPosition, Team: *s.teamLookup[pick.TeamFifaCode]})
+			}
+
+			defaults[i].Teams = teams
 		}
-
-		groupPicks = append(groupPicks, domain.ResolvedGroupPick{GroupCode: groupCode, Teams: teams})
+		defaults[i].Locked = lockedByGroup[group.GroupCode]
 	}
 
-	return groupPicks
+	return defaults
 }
 
 func (s *PickemService) defaultGroupPicksView() []domain.ResolvedGroupPick {

--- a/internal/test/mocks/pickem_service_mock.go
+++ b/internal/test/mocks/pickem_service_mock.go
@@ -11,6 +11,7 @@ type MockPickemService struct {
 	GetChampionPickFunc       func(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgressFunc func(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	SetGroupLockFunc          func(ctx context.Context, userID, groupCode string, locked bool, picks []*domain.UserGroupPick) error
 	SaveBestThirdsFunc        func(ctx context.Context, userID string, teamFifaCodes []string) error
 	SaveBracketPicksFunc      func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
 }
@@ -41,6 +42,13 @@ func (m *MockPickemService) SaveGroupPicks(ctx context.Context, userID string, p
 		return m.SaveGroupPicksFunc(ctx, userID, picks)
 	}
 	panic("SaveGroupPicks called unexpectedly")
+}
+
+func (m *MockPickemService) SetGroupLock(ctx context.Context, userID, groupCode string, locked bool, picks []*domain.UserGroupPick) error {
+	if m.SetGroupLockFunc != nil {
+		return m.SetGroupLockFunc(ctx, userID, groupCode, locked, picks)
+	}
+	panic("SetGroupLock called unexpectedly")
 }
 
 func (m *MockPickemService) SaveBestThirds(ctx context.Context, userID string, teamFifaCodes []string) error {


### PR DESCRIPTION
## Related issue

N/A

## What changed

- Add `PUT /pickems/groups/lock` to lock or unlock a single group; locking persists the submitted order in the same transaction and cascade-clears best-thirds + bracket if the order differs from what's stored.
- New `user_group_locks` table (migration 000007) tracks locked groups per user; primary key `(user_id, group_code)`.
- Groups step of `PickemProgress` is now driven by lock count (0–12), not group-pick completeness; best-thirds and bracket preconditions still require all 12 groups filled.
- `SaveGroupPicks` clears locks for any groups whose order changed.
- `ResolvedGroupPick` gains a `locked` field surfaced via `GetUserPickem`.

## How to test

- [ ] `make db-migrate-up && make db-test-migrate-up`
- [ ] Save 4 picks for group A via `PUT /pickems/groups` then `PUT /pickems/groups/lock` with `{group_code:"A", locked:true, team_fifa_codes:[...]}` — response shows `locked:true` for A and `progress.groups.completed = 1`.
- [ ] Re-call lock for A with a different team order — confirm `user_best_third_picks` and `user_bracket_picks` rows for that user are cleared.
- [ ] `PUT /pickems/groups/lock` with `locked:false` — lock row removed, group picks untouched.
- [ ] `PUT /pickems/groups` changing any saved order — corresponding lock rows disappear.
- [ ] `PUT /pickems/best-thirds` rejected with `ErrGroupPicksRequired` until all 12 groups have 4 picks each (independent of lock state).