### PR TITLE
feat: enforce pick'em deletion and admin management restrictions

### DIFF
--- a/internal/domain/competition.go
+++ b/internal/domain/competition.go
@@ -75,6 +75,7 @@ type CompetitionLeaderboardPage struct {
 type CompetitionRepository interface {
 	CreateCompetition(ctx context.Context, competition *Competition) error
 	GetBoardCompetitions(ctx context.Context, boardID int64, viewerUserID string) ([]*CompetitionListItem, error)
+	GetCompetitionByID(ctx context.Context, boardID, competitionID int64) (*Competition, error)
 	DeleteCompetition(ctx context.Context, boardID, competitionID int64) error
 	GetAllPickemIDs(ctx context.Context) ([]int64, error)
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -55,6 +55,7 @@ var ErrBoardIsGlobal = errors.New("operation not allowed on global board")
 var ErrBoardMemberNotFound = errors.New("board member not found")
 var ErrBoardMemberAlreadyInBoard = errors.New("user is already a member of this board")
 var ErrCannotTransferOwnershipToSelf = errors.New("cannot transfer ownership to yourself")
+var ErrBoardManageAdminForbidden = errors.New("only the board owner can manage admins")
 
 // Group Standings
 var ErrInvalidGroupCode = errors.New("invalid group code")
@@ -108,6 +109,7 @@ var ErrCompetitionNotFound = errors.New("competition not found")
 var ErrCompetitionForbidden = errors.New("only board owner or admins can manage competitions")
 var ErrCompetitionPickemAlreadyExists = errors.New("a tournament pick'em competition already exists on this board")
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
+var ErrCompetitionPickemNotDeletable = errors.New("the tournament pick'em competition cannot be deleted")
 
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")

--- a/internal/handlers/board_handler.go
+++ b/internal/handlers/board_handler.go
@@ -244,8 +244,9 @@ func (h *BoardHandler) LeaveBoard(w http.ResponseWriter, r *http.Request) {
 //	@Router			/boards/{boardId}/regenerate-join-code [post]
 func (h *BoardHandler) RegenerateJoinCode(w http.ResponseWriter, r *http.Request) {
 	boardID := httpctx.GetBoardID(r.Context())
+	boardMemberRole := httpctx.GetBoardMemberRole(r.Context())
 
-	joinCode, err := h.boardService.RegenerateJoinCode(r.Context(), boardID)
+	joinCode, err := h.boardService.RegenerateJoinCode(r.Context(), boardID, boardMemberRole)
 	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return

--- a/internal/handlers/board_handler_test.go
+++ b/internal/handlers/board_handler_test.go
@@ -598,6 +598,7 @@ func TestBoardHandler_RegenerateJoinCode(t *testing.T) {
 		req := testutils.MakeJSONRequest(
 			t, http.MethodPost, "/boards/"+strconv.FormatInt(boardID, 10)+"/regenerate-join-code", nil,
 			testutils.WithBoardID(boardID),
+			testutils.WithBoardMemberRole(domain.BoardMemberRoleAdmin),
 		)
 
 		return req
@@ -609,7 +610,7 @@ func TestBoardHandler_RegenerateJoinCode(t *testing.T) {
 		newJoinCode := "NEWCODE1"
 
 		bs := &mocks.MockBoardService{
-			RegenerateJoinCodeFunc: func(ctx context.Context, boardID int64) (string, error) {
+			RegenerateJoinCodeFunc: func(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {
 				return newJoinCode, nil
 			},
 		}
@@ -635,7 +636,7 @@ func TestBoardHandler_RegenerateJoinCode(t *testing.T) {
 		t.Parallel()
 
 		bs := &mocks.MockBoardService{
-			RegenerateJoinCodeFunc: func(ctx context.Context, boardID int64) (string, error) {
+			RegenerateJoinCodeFunc: func(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {
 				return "", errors.New("db error")
 			},
 		}

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -30,6 +30,7 @@ const (
 	codeMaxBoardMembersExceeded        = "MAX_BOARD_MEMBERS_EXCEEDED"
 	codeCompetitionPickemAlreadyExists = "COMPETITION_PICKEM_ALREADY_EXISTS"
 	codeCompetitionNameAlreadyExists   = "COMPETITION_NAME_ALREADY_EXISTS"
+	codeCompetitionPickemNotDeletable  = "COMPETITION_PICKEM_NOT_DELETABLE"
 
 	// 401 Unauthorized
 	codeOTPInvalidOrExpired          = "OTP_INVALID_OR_EXPIRED"
@@ -43,10 +44,11 @@ const (
 	codeOTPCooldown        = "OTP_COOLDOWN"
 
 	// 403 Forbidden
-	codeForbidden               = "FORBIDDEN"
-	codeOAuthAccountNotVerified = "OAUTH_ACCOUNT_NOT_VERIFIED"
-	codeBoardIsGlobal           = "BOARD_IS_GLOBAL"
-	codeCompetitionForbidden    = "COMPETITION_FORBIDDEN"
+	codeForbidden                 = "FORBIDDEN"
+	codeOAuthAccountNotVerified   = "OAUTH_ACCOUNT_NOT_VERIFIED"
+	codeBoardIsGlobal             = "BOARD_IS_GLOBAL"
+	codeCompetitionForbidden      = "COMPETITION_FORBIDDEN"
+	codeBoardManageAdminForbidden = "BOARD_MANAGE_ADMIN_FORBIDDEN"
 
 	// 400 Bad Request
 	codeInvalidWinnerTeam          = "INVALID_WINNER_TEAM"
@@ -116,6 +118,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 	// 409 Conflict
 	case errors.Is(err, domain.ErrCompetitionPickemAlreadyExists):
 		httpx.Conflict(w, r, codeCompetitionPickemAlreadyExists, domain.ErrCompetitionPickemAlreadyExists.Error())
+	case errors.Is(err, domain.ErrCompetitionPickemNotDeletable):
+		httpx.Conflict(w, r, codeCompetitionPickemNotDeletable, domain.ErrCompetitionPickemNotDeletable.Error())
 	case errors.Is(err, domain.ErrUserAlreadyExists):
 		httpx.Conflict(w, r, codeUserAlreadyExists, domain.ErrUserAlreadyExists.Error())
 	case errors.Is(err, domain.ErrUsernameAlreadyExists):
@@ -156,6 +160,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.Forbidden(w, r, codeBoardIsGlobal, domain.ErrBoardIsGlobal.Error())
 	case errors.Is(err, domain.ErrCompetitionForbidden):
 		httpx.Forbidden(w, r, codeCompetitionForbidden, domain.ErrCompetitionForbidden.Error())
+	case errors.Is(err, domain.ErrBoardManageAdminForbidden):
+		httpx.Forbidden(w, r, codeBoardManageAdminForbidden, domain.ErrBoardManageAdminForbidden.Error())
 
 	// 400 Bad Request
 	case errors.Is(err, domain.ErrInvalidWinnerTeam):

--- a/internal/repositories/competition_repository.go
+++ b/internal/repositories/competition_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/infrastructure/config"
@@ -386,6 +387,43 @@ func (r *CompetitionRepository) DeleteCompetition(
 	}
 
 	return nil
+}
+
+func (r *CompetitionRepository) GetCompetitionByID(
+	ctx context.Context,
+	boardID, competitionID int64,
+) (*domain.Competition, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	competition := &domain.Competition{}
+	var createdBy sql.NullString
+
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, board_id, type, name, created_by, created_at
+		 FROM competitions
+		 WHERE id = $1 AND board_id = $2`,
+		competitionID, boardID,
+	).Scan(
+		&competition.ID,
+		&competition.BoardID,
+		&competition.Type,
+		&competition.Name,
+		&createdBy,
+		&competition.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, domain.ErrCompetitionNotFound
+	}
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetition)
+	}
+
+	if createdBy.Valid {
+		competition.CreatedBy = &createdBy.String
+	}
+
+	return competition, nil
 }
 
 func (r *CompetitionRepository) GetAllPickemIDs(ctx context.Context) ([]int64, error) {

--- a/internal/services/board_member_service.go
+++ b/internal/services/board_member_service.go
@@ -76,6 +76,10 @@ func (s *BoardMemberService) UpdateBoardMemberRole(
 		return err
 	}
 
+	if err := s.assertCanManageTarget(ctx, boardID, userID, role); err != nil {
+		return err
+	}
+
 	return s.boardMemberRepository.UpdateBoardMemberRole(ctx, boardID, userID, payload.Role)
 }
 
@@ -93,7 +97,31 @@ func (s *BoardMemberService) RemoveBoardMember(
 		return err
 	}
 
+	if err := s.assertCanManageTarget(ctx, boardID, userID, role); err != nil {
+		return err
+	}
+
 	return s.boardMemberRepository.RemoveBoardMember(ctx, boardID, userID)
+}
+
+// assertCanManageTarget enforces that only an owner may act on an admin. Admins can manage
+// members only — they cannot change another admin's role or remove them.
+func (s *BoardMemberService) assertCanManageTarget(
+	ctx context.Context,
+	boardID int64,
+	targetUserID string,
+	callerRole domain.BoardMemberRole,
+) error {
+	target, err := s.boardMemberRepository.GetBoardMember(ctx, boardID, targetUserID)
+	if err != nil {
+		return err
+	}
+
+	if target.Role == domain.BoardMemberRoleAdmin && callerRole != domain.BoardMemberRoleOwner {
+		return domain.ErrBoardManageAdminForbidden
+	}
+
+	return nil
 }
 
 func (s *BoardMemberService) LeaveBoard(

--- a/internal/services/board_member_service_test.go
+++ b/internal/services/board_member_service_test.go
@@ -240,6 +240,9 @@ func TestBoardMemberService_UpdateBoardMemberRole(t *testing.T) {
 			},
 		}
 		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleMember}, nil
+			},
 			UpdateBoardMemberRoleFunc: func(ctx context.Context, bid int64, uid string, role domain.BoardMemberRole) error {
 				assert.Equal(t, boardID, bid)
 				assert.Equal(t, userID, uid)
@@ -303,6 +306,9 @@ func TestBoardMemberService_UpdateBoardMemberRole(t *testing.T) {
 			},
 		}
 		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleMember}, nil
+			},
 			UpdateBoardMemberRoleFunc: func(ctx context.Context, bid int64, uid string, role domain.BoardMemberRole) error {
 				return errors.New("database error")
 			},
@@ -314,6 +320,60 @@ func TestBoardMemberService_UpdateBoardMemberRole(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database error")
+	})
+
+	t.Run("forbids an admin from changing another admin's role", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+		payload := dtos.UpdateBoardMemberRoleDto{Role: domain.BoardMemberRoleMember}
+
+		br := &mocks.MockBoardRepository{
+			GetBoardByIDFunc: func(ctx context.Context, bid int64) (*domain.Board, error) {
+				return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
+			},
+		}
+		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleAdmin}, nil
+			},
+			// UpdateBoardMemberRoleFunc intentionally unset — it must not be called.
+		}
+
+		service := newTestBoardMemberService(br, bmr)
+
+		err := service.UpdateBoardMemberRole(context.Background(), boardID, userID, domain.BoardMemberRoleAdmin, payload)
+
+		assert.ErrorIs(t, err, domain.ErrBoardManageAdminForbidden)
+	})
+
+	t.Run("allows an owner to change an admin's role", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+		payload := dtos.UpdateBoardMemberRoleDto{Role: domain.BoardMemberRoleMember}
+
+		br := &mocks.MockBoardRepository{
+			GetBoardByIDFunc: func(ctx context.Context, bid int64) (*domain.Board, error) {
+				return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
+			},
+		}
+		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleAdmin}, nil
+			},
+			UpdateBoardMemberRoleFunc: func(ctx context.Context, bid int64, uid string, role domain.BoardMemberRole) error {
+				return nil
+			},
+		}
+
+		service := newTestBoardMemberService(br, bmr)
+
+		err := service.UpdateBoardMemberRole(context.Background(), boardID, userID, domain.BoardMemberRoleOwner, payload)
+
+		assert.NoError(t, err)
 	})
 }
 
@@ -335,6 +395,9 @@ func TestBoardMemberService_RemoveBoardMember(t *testing.T) {
 			},
 		}
 		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleMember}, nil
+			},
 			RemoveBoardMemberFunc: func(ctx context.Context, bid int64, uid string) error {
 				assert.Equal(t, boardID, bid)
 				assert.Equal(t, userID, uid)
@@ -394,6 +457,9 @@ func TestBoardMemberService_RemoveBoardMember(t *testing.T) {
 			},
 		}
 		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleMember}, nil
+			},
 			RemoveBoardMemberFunc: func(ctx context.Context, bid int64, uid string) error {
 				return errors.New("database error")
 			},
@@ -405,6 +471,58 @@ func TestBoardMemberService_RemoveBoardMember(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database error")
+	})
+
+	t.Run("forbids an admin from removing another admin", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+
+		br := &mocks.MockBoardRepository{
+			GetBoardByIDFunc: func(ctx context.Context, bid int64) (*domain.Board, error) {
+				return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
+			},
+		}
+		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleAdmin}, nil
+			},
+			// RemoveBoardMemberFunc intentionally unset — it must not be called.
+		}
+
+		service := newTestBoardMemberService(br, bmr)
+
+		err := service.RemoveBoardMember(context.Background(), boardID, userID, domain.BoardMemberRoleAdmin)
+
+		assert.ErrorIs(t, err, domain.ErrBoardManageAdminForbidden)
+	})
+
+	t.Run("allows an owner to remove an admin", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+
+		br := &mocks.MockBoardRepository{
+			GetBoardByIDFunc: func(ctx context.Context, bid int64) (*domain.Board, error) {
+				return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
+			},
+		}
+		bmr := &mocks.MockBoardMemberRepository{
+			GetBoardMemberFunc: func(ctx context.Context, bid int64, uid string) (*domain.BoardMember, error) {
+				return &domain.BoardMember{Role: domain.BoardMemberRoleAdmin}, nil
+			},
+			RemoveBoardMemberFunc: func(ctx context.Context, bid int64, uid string) error {
+				return nil
+			},
+		}
+
+		service := newTestBoardMemberService(br, bmr)
+
+		err := service.RemoveBoardMember(context.Background(), boardID, userID, domain.BoardMemberRoleOwner)
+
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/services/board_service.go
+++ b/internal/services/board_service.go
@@ -14,7 +14,7 @@ type BoardServiceInterface interface {
 	CreateBoard(ctx context.Context, payload dtos.CreateBoardDto, userID string) (*domain.Board, error)
 	GetUserBoards(ctx context.Context, userID string) ([]*domain.UserBoardListItem, error)
 	GetBoardByID(ctx context.Context, boardID int64, userID string) (*domain.BoardDetails, error)
-	RegenerateJoinCode(ctx context.Context, boardID int64) (string, error)
+	RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error)
 	UpdateBoard(ctx context.Context, boardID int64, role domain.BoardMemberRole, payload dtos.UpdateBoardDto) error
 	DeleteBoard(ctx context.Context, boardID int64, role domain.BoardMemberRole) error
 }
@@ -111,7 +111,11 @@ func (s *BoardService) GetBoardByID(
 	return s.boardRepository.GetBoardDetails(ctx, boardID, userID)
 }
 
-func (s *BoardService) RegenerateJoinCode(ctx context.Context, boardID int64) (string, error) {
+func (s *BoardService) RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {
+	if !role.CanManage() {
+		return "", domain.ErrForbidden
+	}
+
 	if err := assertNotGlobalBoard(ctx, s.boardRepository, boardID); err != nil {
 		return "", err
 	}

--- a/internal/services/board_service_test.go
+++ b/internal/services/board_service_test.go
@@ -334,7 +334,7 @@ func TestBoardService_RegenerateJoinCode(t *testing.T) {
 
 		service := newTestBoardService(br, nil)
 
-		result, err := service.RegenerateJoinCode(context.Background(), boardID)
+		result, err := service.RegenerateJoinCode(context.Background(), boardID, domain.BoardMemberRoleAdmin)
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, result)
@@ -354,7 +354,7 @@ func TestBoardService_RegenerateJoinCode(t *testing.T) {
 
 		service := newTestBoardService(br, nil)
 
-		result, err := service.RegenerateJoinCode(context.Background(), boardID)
+		result, err := service.RegenerateJoinCode(context.Background(), boardID, domain.BoardMemberRoleAdmin)
 
 		assert.ErrorIs(t, err, domain.ErrBoardIsGlobal)
 		assert.Empty(t, result)
@@ -376,10 +376,24 @@ func TestBoardService_RegenerateJoinCode(t *testing.T) {
 
 		service := newTestBoardService(br, nil)
 
-		result, err := service.RegenerateJoinCode(context.Background(), boardID)
+		result, err := service.RegenerateJoinCode(context.Background(), boardID, domain.BoardMemberRoleAdmin)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "database error")
+		assert.Empty(t, result)
+	})
+
+	t.Run("rejects member without manage permission", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+
+		// Empty repository: a role short-circuit must happen before any repo call.
+		service := newTestBoardService(&mocks.MockBoardRepository{}, nil)
+
+		result, err := service.RegenerateJoinCode(context.Background(), boardID, domain.BoardMemberRoleMember)
+
+		assert.ErrorIs(t, err, domain.ErrForbidden)
 		assert.Empty(t, result)
 	})
 }

--- a/internal/services/competition_service.go
+++ b/internal/services/competition_service.go
@@ -98,5 +98,15 @@ func (s *CompetitionService) DeleteCompetition(
 		return err
 	}
 
+	competition, err := s.competitionRepository.GetCompetitionByID(ctx, boardID, competitionID)
+	if err != nil {
+		return err
+	}
+
+	// The tournament pick'em is the board's anchor competition and must never be removed.
+	if competition.Type == domain.CompetitionTypePickem {
+		return domain.ErrCompetitionPickemNotDeletable
+	}
+
 	return s.competitionRepository.DeleteCompetition(ctx, boardID, competitionID)
 }

--- a/internal/services/competition_service_test.go
+++ b/internal/services/competition_service_test.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestCompetitionService(br *mocks.MockBoardRepository, cr *mocks.MockCompetitionRepository) CompetitionServiceInterface {
+	return NewCompetitionService(br, cr, nil)
+}
+
+func privateBoardRepo() *mocks.MockBoardRepository {
+	return &mocks.MockBoardRepository{
+		GetBoardByIDFunc: func(ctx context.Context, bid int64) (*domain.Board, error) {
+			return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCompetitionService_DeleteCompetition
+// ---------------------------------------------------------------------------
+func TestCompetitionService_DeleteCompetition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects deleting the tournament pick'em competition", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		competitionID := gofakeit.Int64()
+
+		cr := &mocks.MockCompetitionRepository{
+			GetCompetitionByIDFunc: func(ctx context.Context, bid, cid int64) (*domain.Competition, error) {
+				return &domain.Competition{ID: cid, BoardID: bid, Type: domain.CompetitionTypePickem}, nil
+			},
+			// DeleteCompetitionFunc intentionally unset — it must never be called for a pick'em.
+		}
+
+		service := newTestCompetitionService(privateBoardRepo(), cr)
+
+		err := service.DeleteCompetition(context.Background(), boardID, competitionID, domain.BoardMemberRoleAdmin)
+
+		assert.ErrorIs(t, err, domain.ErrCompetitionPickemNotDeletable)
+	})
+
+	t.Run("deletes a match competition", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		competitionID := gofakeit.Int64()
+		deleteCalled := false
+
+		cr := &mocks.MockCompetitionRepository{
+			GetCompetitionByIDFunc: func(ctx context.Context, bid, cid int64) (*domain.Competition, error) {
+				return &domain.Competition{ID: cid, BoardID: bid, Type: domain.CompetitionTypeMatch}, nil
+			},
+			DeleteCompetitionFunc: func(ctx context.Context, bid, cid int64) error {
+				deleteCalled = true
+				assert.Equal(t, boardID, bid)
+				assert.Equal(t, competitionID, cid)
+				return nil
+			},
+		}
+
+		service := newTestCompetitionService(privateBoardRepo(), cr)
+
+		err := service.DeleteCompetition(context.Background(), boardID, competitionID, domain.BoardMemberRoleAdmin)
+
+		assert.NoError(t, err)
+		assert.True(t, deleteCalled)
+	})
+
+	t.Run("rejects a member without manage permission", func(t *testing.T) {
+		t.Parallel()
+
+		// Empty repos: the role check must short-circuit before any repo call.
+		service := newTestCompetitionService(&mocks.MockBoardRepository{}, &mocks.MockCompetitionRepository{})
+
+		err := service.DeleteCompetition(context.Background(), gofakeit.Int64(), gofakeit.Int64(), domain.BoardMemberRoleMember)
+
+		assert.ErrorIs(t, err, domain.ErrCompetitionForbidden)
+	})
+}

--- a/internal/test/mocks/board_service_mock.go
+++ b/internal/test/mocks/board_service_mock.go
@@ -11,7 +11,7 @@ type MockBoardService struct {
 	CreateBoardFunc        func(ctx context.Context, payload dtos.CreateBoardDto, userID string) (*domain.Board, error)
 	GetUserBoardsFunc      func(ctx context.Context, userID string) ([]*domain.UserBoardListItem, error)
 	GetBoardByIDFunc       func(ctx context.Context, boardID int64, userID string) (*domain.BoardDetails, error)
-	RegenerateJoinCodeFunc func(ctx context.Context, boardID int64) (string, error)
+	RegenerateJoinCodeFunc func(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error)
 	UpdateBoardFunc        func(ctx context.Context, boardID int64, role domain.BoardMemberRole, payload dtos.UpdateBoardDto) error
 	DeleteBoardFunc        func(ctx context.Context, boardID int64, role domain.BoardMemberRole) error
 }
@@ -37,9 +37,9 @@ func (m *MockBoardService) GetBoardByID(ctx context.Context, boardID int64, user
 	panic("GetBoardByID called unexpectedly")
 }
 
-func (m *MockBoardService) RegenerateJoinCode(ctx context.Context, boardID int64) (string, error) {
+func (m *MockBoardService) RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {
 	if m.RegenerateJoinCodeFunc != nil {
-		return m.RegenerateJoinCodeFunc(ctx, boardID)
+		return m.RegenerateJoinCodeFunc(ctx, boardID, role)
 	}
 	panic("RegenerateJoinCode called unexpectedly")
 }

--- a/internal/test/mocks/competition_repository_mock.go
+++ b/internal/test/mocks/competition_repository_mock.go
@@ -9,6 +9,7 @@ import (
 type MockCompetitionRepository struct {
 	CreateCompetitionFunc              func(ctx context.Context, competition *domain.Competition) error
 	GetBoardCompetitionsFunc           func(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
+	GetCompetitionByIDFunc             func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error)
 	DeleteCompetitionFunc              func(ctx context.Context, boardID, competitionID int64) error
 	GetAllPickemIDsFunc                func(ctx context.Context) ([]int64, error)
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
@@ -27,6 +28,13 @@ func (m *MockCompetitionRepository) GetBoardCompetitions(ctx context.Context, bo
 		return m.GetBoardCompetitionsFunc(ctx, boardID, viewerUserID)
 	}
 	panic("GetBoardCompetitions called unexpectedly")
+}
+
+func (m *MockCompetitionRepository) GetCompetitionByID(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+	if m.GetCompetitionByIDFunc != nil {
+		return m.GetCompetitionByIDFunc(ctx, boardID, competitionID)
+	}
+	panic("GetCompetitionByID called unexpectedly")
 }
 
 func (m *MockCompetitionRepository) DeleteCompetition(ctx context.Context, boardID, competitionID int64) error {


### PR DESCRIPTION
## Related issue

_No linked issue._

## What changed

- **Competitions:** the tournament pick'em can no longer be deleted (409 `COMPETITION_PICKEM_NOT_DELETABLE`); added `GetCompetitionByID` to back the delete guard.
- **Board members:** only an owner may change or remove an admin — admins can manage members only (403 `BOARD_MANAGE_ADMIN_FORBIDDEN`).
- **Boards:** regenerating a join code now requires a manage role (403 `FORBIDDEN`).

## How to test

- [ ] `DELETE` the board's pick'em competition — expect 409 `COMPETITION_PICKEM_NOT_DELETABLE`; delete a non-pick'em competition — expect success.
- [ ] As an admin, `PATCH`/`DELETE` another admin's membership — expect 403 `BOARD_MANAGE_ADMIN_FORBIDDEN`; do the same as owner — expect success.
- [ ] As a non-manager member, `POST /boards/{id}/regenerate-join-code` — expect 403 `FORBIDDEN`.