### PR TITLE
chore: add release skill for develop→main releases

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,78 +1,59 @@
 ---
 name: release
-description: Cut a release in one command — open the develop→main PR and queue it to auto-merge as a merge commit. Once a maintainer approves, GitHub merges it and the release workflow tags + drafts the release automatically. Never squashes develop→main.
+description: Cut a release in one command — open the develop→main PR and queue it to auto-merge as a merge commit. A maintainer's approval then triggers merge → tag → draft release automatically. Never squash develop→main.
 ---
 
 # Release
 
-## Goal
-
-Promote `develop` to `main` and ship it — in a **single command**. You open the release PR;
-everything after a maintainer approves it happens automatically:
+Promote `develop` to `main` and ship it in **one command**. You open the release PR; once a
+maintainer approves, the rest is automatic:
 
 ```
-/release  ──>  PR opened + auto-merge queued
-                     │  (a maintainer approves)
-                     ▼
-          GitHub auto-merges it as a MERGE COMMIT
-                     │  (release.yml fires on the merge)
-                     ▼
-          tag vX.Y.Z pushed  +  DRAFT GitHub Release created
-                     │  (you edit + publish the draft)
-                     ▼
-                prod deploy
+/release → PR opened + auto-merge queued → (maintainer approves)
+        → GitHub merges as a MERGE COMMIT → release.yml tags vX.Y.Z + drafts the release
+        → you publish the draft → prod deploy
 ```
 
-The single rule everything protects:
+## The one rule
 
-> **`develop → main` is merged with a MERGE COMMIT, never squashed or rebased.**
+> **`develop → main` must merge as a MERGE COMMIT — never squash or rebase.**
 
-Squashing severs shared history — `main` gets a new commit that doesn't have develop's tip as an
-ancestor, so the next release PR shows *all* of develop's commits and reports phantom conflicts.
-A merge commit keeps history shared. (Feature branches `feat/* → develop` *are* squashed — that's
-fine, they're short-lived; see the `open-pr` skill. The rule only bites between two long-lived
-branches.)
+Squashing gives `main` a commit that doesn't have develop's tip as an ancestor, so the next
+release PR shows every develop commit and hits phantom conflicts. A merge commit keeps history
+shared. (Squashing `feat/* → develop` is fine — those branches are short-lived; see `open-pr`.)
+The `--auto --merge` in step 6 enforces this.
 
-## How the automation is wired
+## How it's wired
 
-- **Auto-merge** (GitHub) merges the release PR the instant its required review lands — as a
-  merge commit, so it can't be accidentally squashed.
-- **`.github/workflows/release.yml`** runs on the merged `develop→main` PR: it reads the version
-  from the PR title (`chore: release vX.Y.Z`), tags main's merge commit, and creates a **draft**
-  GitHub Release. (The same workflow also handles a manual `vX.Y.Z` tag push for emergencies.)
-  You publish the draft to deploy.
+- **Auto-merge** merges the PR as a merge commit the instant its required review lands.
+- **`.github/workflows/release.yml`** runs on the merged PR, reads the version from the title
+  (`chore: release vX.Y.Z`), tags main's merge commit, and drafts the release. You publish the
+  draft to deploy.
 
-So this skill does **one thing**: open the PR with the right title and queue auto-merge.
+**Prerequisites** (already configured — check these if a release misbehaves):
 
-### Repo prerequisites (one-time, already configured)
+- `main` protection: "Require linear history" **off**; requires **1 non-author review**.
+- Repo: "Allow auto-merge" and "Allow merge commits" **on**.
+- `release.yml` triggers on `pull_request: [closed]` → `main`.
 
-Verify these if a release ever misbehaves:
+## Steps
 
-- `main` protection: **"Require linear history" OFF** —
-  `gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_linear_history.enabled'` → `false`.
-- Repo: **"Allow auto-merge" ON** and **"Allow merge commits" ON** —
-  `gh api repos/<owner>/<repo> --jq '{allow_auto_merge, allow_merge_commit}'` → both `true`.
-- `main` requires **1 approving review** from a non-author (a maintainer).
-- `release.yml` triggers on `pull_request: [closed]` to `main` (the auto path).
-
-## The command
-
-1. `git fetch origin --tags --prune`. Confirm there's something to ship:
-   `git log origin/main..origin/develop --no-merges --oneline`. If empty → stop: "Nothing to release."
-2. **Already in flight?** If a `develop→main` PR is open
-   (`gh pr list --base main --head develop --state open`), don't open another — report its status
-   (approved? merged yet?) and stop.
-3. **Pre-flight — is `develop` green?** `main` has no required status checks, so a red develop
-   could ship. Check `gh run list --branch develop -L 1 --json conclusion,status,workflowName`.
-   If the latest run isn't `success`, **warn and ask** before continuing.
-4. **Suggest the version** (semver, `vMAJOR.MINOR.PATCH`):
+1. `git fetch origin --tags --prune`. If `git log origin/main..origin/develop --no-merges --oneline`
+   is empty → stop: "Nothing to release."
+2. If a `develop→main` PR is already open (`gh pr list --base main --head develop --state open`),
+   report its status and stop — don't open another.
+3. **Pre-flight.** `main` has no required checks, so confirm develop is green:
+   `gh run list --branch develop -L 1 --json conclusion,status`. If the latest run isn't
+   `success`, warn and ask before continuing.
+4. **Version.** Propose the next semver and have the user confirm — never guess silently:
    - Last tag: `git tag -l 'v*.*.*' --sort=-v:refname | head -1` (baseline `v0.0.1`).
-   - Scan `git log <last-tag>..origin/develop --no-merges`:
-     - any `BREAKING CHANGE` / `type!:` → **major**; else any `feat:` → **minor**; else → **patch**.
-   - **Show the proposed version and ask the user to confirm or override.** Never guess silently.
-   - The chosen `vX.Y.Z` MUST go in the PR title verbatim — `release.yml` parses it from there.
-5. **Draft the PR body** — terse, grouped, ~150 words max (same density as `open-pr`):
-   ```md
+   - Bump from the commits since that tag: `BREAKING CHANGE`/`type!:` → **major**; else `feat:` →
+     **minor**; else → **patch**.
+5. **Open the PR.** Title MUST be exactly `chore: release vX.Y.Z` — `release.yml` parses the
+   version from it. Body: terse grouped highlights (~150 words, same density as `open-pr`) derived
+   from real commits; skip migration files, go.sum bumps, mock regens.
+   ```bash
+   gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
    ## Release vX.Y.Z
 
    <one-line summary>
@@ -82,36 +63,14 @@ Verify these if a release ever misbehaves:
 
    ### Fixes
    - <fix bullet, if notable>
-   ```
-   Derive bullets from real commits since the last tag. Don't invent; skip migration files,
-   go.sum bumps, mock regens.
-6. **Open the PR** — the title carries the version, which is how the workflow learns it:
-   ```bash
-   gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
-   <body>
    EOF
    )"
    ```
-7. **Queue auto-merge as a merge commit** — never leave the merge button to chance:
-   ```bash
-   gh pr merge <num> --auto --merge
-   ```
-   If rejected with "merge method merge commits are not allowed", a prerequisite drifted (linear
-   history re-enabled / merge commits disabled) — fix it, then re-queue. **Never** fall back to
-   squash or rebase.
-8. **Report and stop.** Tell the user, plainly:
-   > Release PR #<num> (`vX.Y.Z`) is queued to **auto-merge as a merge commit**.
-   > It needs **one maintainer approval** (not the author) — ping a reviewer.
-   > On approval it merges, then `release.yml` tags `vX.Y.Z` and creates a **draft** release.
-   > **Publish the draft** to deploy to production.
-
-   The skill is done here — it does NOT tag, merge, or publish. Those are the automation's and
-   the user's jobs.
-
-## Rules
-
-- **NEVER** squash or rebase `develop → main`. Merge commit only (enforced via `--auto --merge`).
-- The PR title MUST be exactly `chore: release vX.Y.Z` — the workflow parses the version from it.
-- **NEVER** push a tag by hand as part of this flow — `release.yml` owns tagging on the auto path.
-  (A manual tag is only for emergencies and triggers the same workflow's manual path.)
-- Confirm the version with the user; derive notes from real commits; keep output terse.
+6. **Queue auto-merge as a merge commit:** `gh pr merge <num> --auto --merge`. If rejected with
+   "merge method merge commits are not allowed", a prerequisite drifted — fix it and re-queue.
+   Never fall back to squash or rebase.
+7. **Report and stop** — don't tag, merge, or publish; those are the automation's and the user's
+   jobs:
+   > Release PR #<num> (`vX.Y.Z`) is queued to auto-merge as a merge commit. It needs **one
+   > maintainer approval** (not the author). On approval it merges, then `release.yml` tags it and
+   > drafts the release — **publish the draft** to deploy.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,140 +1,117 @@
 ---
 name: release
-description: Cut a release by merging develop into main and tagging it. Two-phase and gated — Phase 1 opens the develop→main PR and queues it to auto-merge as a merge commit once reviewed; Phase 2 tags main vX.Y.Z to fire the release draft. Never squashes develop→main.
+description: Cut a release in one command — open the develop→main PR and queue it to auto-merge as a merge commit. Once a maintainer approves, GitHub merges it and the release workflow tags + drafts the release automatically. Never squashes develop→main.
 ---
 
 # Release
 
 ## Goal
 
-Promote `develop` to `main` and tag it for deployment, while keeping `main` and `develop`
-history **shared**. The single rule that everything else protects:
+Promote `develop` to `main` and ship it — in a **single command**. You open the release PR;
+everything after a maintainer approves it happens automatically:
+
+```
+/release  ──>  PR opened + auto-merge queued
+                     │  (a maintainer approves)
+                     ▼
+          GitHub auto-merges it as a MERGE COMMIT
+                     │  (release.yml fires on the merge)
+                     ▼
+          tag vX.Y.Z pushed  +  DRAFT GitHub Release created
+                     │  (you edit + publish the draft)
+                     ▼
+                prod deploy
+```
+
+The single rule everything protects:
 
 > **`develop → main` is merged with a MERGE COMMIT, never squashed or rebased.**
 
-Squashing severs shared history: `main` gets a brand-new commit that doesn't have develop's
-tip as an ancestor, so the next `develop → main` PR shows *all* of develop's commits as
-"missing from main" and reports phantom add/add conflicts. A merge commit keeps develop's tip
-as an ancestor of main, so future releases show only genuinely new commits.
+Squashing severs shared history — `main` gets a new commit that doesn't have develop's tip as an
+ancestor, so the next release PR shows *all* of develop's commits and reports phantom conflicts.
+A merge commit keeps history shared. (Feature branches `feat/* → develop` *are* squashed — that's
+fine, they're short-lived; see the `open-pr` skill. The rule only bites between two long-lived
+branches.)
 
-(For contrast, `feat/* → develop` *is* squash-merged — see the `open-pr` skill — and that's
-fine, because feature branches are short-lived and deleted. The rule only bites between two
-long-lived branches.)
+## How the automation is wired
+
+- **Auto-merge** (GitHub) merges the release PR the instant its required review lands — as a
+  merge commit, so it can't be accidentally squashed.
+- **`.github/workflows/release.yml`** runs on the merged `develop→main` PR: it reads the version
+  from the PR title (`chore: release vX.Y.Z`), tags main's merge commit, and creates a **draft**
+  GitHub Release. (The same workflow also handles a manual `vX.Y.Z` tag push for emergencies.)
+  You publish the draft to deploy.
+
+So this skill does **one thing**: open the PR with the right title and queue auto-merge.
 
 ### Repo prerequisites (one-time, already configured)
 
-These make merge-commit releases possible — verify if a release ever misbehaves:
+Verify these if a release ever misbehaves:
 
-- `main` branch protection has **"Require linear history" OFF** (linear history forbids merge
-  commits). Check: `gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_linear_history.enabled'` → must be `false`.
-- Repo setting **"Allow auto-merge" ON** and **"Allow merge commits" ON**. Check:
+- `main` protection: **"Require linear history" OFF** —
+  `gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_linear_history.enabled'` → `false`.
+- Repo: **"Allow auto-merge" ON** and **"Allow merge commits" ON** —
   `gh api repos/<owner>/<repo> --jq '{allow_auto_merge, allow_merge_commit}'` → both `true`.
-- `main` requires **1 approving review** from someone other than the author (e.g. a maintainer),
-  so a release PR always needs a teammate's approval before it merges.
+- `main` requires **1 approving review** from a non-author (a maintainer).
+- `release.yml` triggers on `pull_request: [closed]` to `main` (the auto path).
 
-## Detect the phase
-
-Always start with `git fetch origin --tags --prune`, then pick the phase:
-
-- **Nothing to do** — `git rev-list --count origin/main..origin/develop` is `0` and `origin/main`
-  is already tagged. Say so and stop.
-- **Phase 2 (tag)** — `origin/main` carries the release merge but has no tag yet (main is ahead
-  of the latest `v*` tag), or a `develop→main` PR was just merged. Tag it.
-- **Between phases** — an OPEN PR with base `main`, head `develop` already exists. If it's queued
-  to auto-merge it just needs its review; point the user there (Phase 1 step 7). Do not open another.
-- **Phase 1 (open PR)** — develop is ahead of main and no open release PR exists. Open it.
-
-## Phase 1 — open the release PR
+## The command
 
 1. `git fetch origin --tags --prune`. Confirm there's something to ship:
    `git log origin/main..origin/develop --no-merges --oneline`. If empty → stop: "Nothing to release."
-2. Bail if a release PR is already open:
-   `gh pr list --base main --head develop --state open`. If one exists, point to it and stop.
-3. **Pre-flight: is `develop` green?** `main` has no required status checks, so a broken `develop`
-   could ship. Check the latest CI run on develop:
-   `gh run list --branch develop -L 1 --json conclusion,status,workflowName`.
-   If the latest run isn't `success` (failing, or still in progress), **warn and ask** before
-   continuing — don't release a red branch.
+2. **Already in flight?** If a `develop→main` PR is open
+   (`gh pr list --base main --head develop --state open`), don't open another — report its status
+   (approved? merged yet?) and stop.
+3. **Pre-flight — is `develop` green?** `main` has no required status checks, so a red develop
+   could ship. Check `gh run list --branch develop -L 1 --json conclusion,status,workflowName`.
+   If the latest run isn't `success`, **warn and ask** before continuing.
 4. **Suggest the version** (semver, `vMAJOR.MINOR.PATCH`):
-   - Last tag: `git describe --tags --abbrev=0 origin/main 2>/dev/null` (repo's first real
-     release baseline is `v0.0.1`).
+   - Last tag: `git tag -l 'v*.*.*' --sort=-v:refname | head -1` (baseline `v0.0.1`).
    - Scan `git log <last-tag>..origin/develop --no-merges`:
-     - any `BREAKING CHANGE` or `type!:` → bump **major**
-     - else any `feat:` → bump **minor**
-     - else (`fix:`/`chore:`/`refactor:`/…) → bump **patch**
-   - If no tag exists at all → propose `v0.1.0`.
-   - **Show the proposed version and ask the user to confirm or override.** Never tag from a guess.
-5. **Draft the PR body** — terse, grouped, ~150 words max (same density rules as `open-pr`):
+     - any `BREAKING CHANGE` / `type!:` → **major**; else any `feat:` → **minor**; else → **patch**.
+   - **Show the proposed version and ask the user to confirm or override.** Never guess silently.
+   - The chosen `vX.Y.Z` MUST go in the PR title verbatim — `release.yml` parses it from there.
+5. **Draft the PR body** — terse, grouped, ~150 words max (same density as `open-pr`):
    ```md
    ## Release vX.Y.Z
 
-   <one-line summary of the release>
+   <one-line summary>
 
    ### Highlights
    - <feat bullet>
-   - <feat bullet>
 
    ### Fixes
-   - <fix bullet, only if notable>
+   - <fix bullet, if notable>
    ```
-   Derive bullets from the actual commits since the last tag. Don't invent; don't list migration
-   files, go.sum bumps, or mock regenerations.
-6. Open the PR:
+   Derive bullets from real commits since the last tag. Don't invent; skip migration files,
+   go.sum bumps, mock regens.
+6. **Open the PR** — the title carries the version, which is how the workflow learns it:
    ```bash
    gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
    <body>
    EOF
    )"
    ```
-7. **Queue auto-merge as a merge commit — do NOT leave the merge button to chance.** This is the
-   whole point of the skill: GitHub merges the PR *as a merge commit* the moment its required
-   review lands, so nobody can accidentally squash it.
+7. **Queue auto-merge as a merge commit** — never leave the merge button to chance:
    ```bash
    gh pr merge <num> --auto --merge
    ```
-   Then tell the user, plainly:
-   > Release PR #<num> is queued to **auto-merge as a merge commit** once approved.
-   > It needs **one approval from a maintainer** (not the author). Ping a reviewer.
-   > After it merges, re-run `/release` to tag and ship.
+   If rejected with "merge method merge commits are not allowed", a prerequisite drifted (linear
+   history re-enabled / merge commits disabled) — fix it, then re-queue. **Never** fall back to
+   squash or rebase.
+8. **Report and stop.** Tell the user, plainly:
+   > Release PR #<num> (`vX.Y.Z`) is queued to **auto-merge as a merge commit**.
+   > It needs **one maintainer approval** (not the author) — ping a reviewer.
+   > On approval it merges, then `release.yml` tags `vX.Y.Z` and creates a **draft** release.
+   > **Publish the draft** to deploy to production.
 
-   If `--auto --merge` is rejected with "merge method merge commits are not allowed", the repo
-   prerequisites above have drifted (linear history got re-enabled, or merge commits disabled) —
-   fix those first, then re-queue. Never fall back to a squash or rebase merge.
-
-## Phase 2 — tag the release
-
-1. `git fetch origin --tags --prune`. Identify the merged release (most recently merged
-   `develop→main` PR, or `origin/main` ahead of the latest `v*` tag).
-2. **Safety check — did the merge keep shared history?**
-   ```bash
-   git merge-base --is-ancestor origin/develop origin/main && echo OK || echo BROKEN
-   ```
-   - If **BROKEN**, the release PR was squashed or rebased. **STOP and warn loudly:** shared
-     history is severed and the next release will hit phantom conflicts. Offer the repair before
-     tagging — open a fresh `develop→main` PR and merge it as a **merge commit**
-     (`gh pr merge <num> --merge`); its content diff is empty but it re-links ancestry. Only tag
-     once the check prints `OK`.
-3. **Determine the version** — read it back from the merged release PR title
-   (`chore: release vX.Y.Z`). Confirm with the user.
-4. **Tag-existence guard.** Make sure the tag isn't already used:
-   `git ls-remote --tags origin "refs/tags/vX.Y.Z"` (and `git tag -l vX.Y.Z` locally).
-   If it already exists, **stop** — pick a new version or investigate; never move an existing tag.
-5. ⚠️ **Warn before tagging — this is the production gate.** Pushing the tag triggers
-   `.github/workflows/release.yml`, which creates a **draft** GitHub Release. Publishing that
-   draft triggers the prod deploy. State that plainly and get explicit confirmation.
-6. Tag main's merge commit and push the tag:
-   ```bash
-   git fetch origin
-   git tag -a vX.Y.Z origin/main -m "Release vX.Y.Z"
-   git push origin vX.Y.Z
-   ```
-7. Tell the user: a **draft** release now exists (Releases page / Actions → release workflow).
-   Edit the notes and **publish** it to deploy. The skill stops here — it never publishes.
+   The skill is done here — it does NOT tag, merge, or publish. Those are the automation's and
+   the user's jobs.
 
 ## Rules
 
-- **NEVER** squash or rebase `develop → main`. Merge commit only.
-- **NEVER** push a version tag without explicit confirmation — it leads to a prod deploy.
-- Version tags are `vMAJOR.MINOR.PATCH` — leading `v`, no suffixes, no omissions.
-- Derive release notes from real commits since the last tag; never invent them.
-- Keep output terse and skimmable, matching the `open-pr` skill.
+- **NEVER** squash or rebase `develop → main`. Merge commit only (enforced via `--auto --merge`).
+- The PR title MUST be exactly `chore: release vX.Y.Z` — the workflow parses the version from it.
+- **NEVER** push a tag by hand as part of this flow — `release.yml` owns tagging on the auto path.
+  (A manual tag is only for emergencies and triggers the same workflow's manual path.)
+- Confirm the version with the user; derive notes from real commits; keep output terse.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut a release by merging develop into main and tagging it. Two-phase and gated — Phase 1 opens the develop→main PR with a merge-commit reminder; Phase 2 (after you merge) tags main vX.Y.Z to fire the release draft. Never squashes develop→main.
+description: Cut a release by merging develop into main and tagging it. Two-phase and gated — Phase 1 opens the develop→main PR and queues it to auto-merge as a merge commit once reviewed; Phase 2 tags main vX.Y.Z to fire the release draft. Never squashes develop→main.
 ---
 
 # Release
@@ -21,6 +21,17 @@ as an ancestor of main, so future releases show only genuinely new commits.
 fine, because feature branches are short-lived and deleted. The rule only bites between two
 long-lived branches.)
 
+### Repo prerequisites (one-time, already configured)
+
+These make merge-commit releases possible — verify if a release ever misbehaves:
+
+- `main` branch protection has **"Require linear history" OFF** (linear history forbids merge
+  commits). Check: `gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_linear_history.enabled'` → must be `false`.
+- Repo setting **"Allow auto-merge" ON** and **"Allow merge commits" ON**. Check:
+  `gh api repos/<owner>/<repo> --jq '{allow_auto_merge, allow_merge_commit}'` → both `true`.
+- `main` requires **1 approving review** from someone other than the author (e.g. a maintainer),
+  so a release PR always needs a teammate's approval before it merges.
+
 ## Detect the phase
 
 Always start with `git fetch origin --tags --prune`, then pick the phase:
@@ -29,8 +40,8 @@ Always start with `git fetch origin --tags --prune`, then pick the phase:
   is already tagged. Say so and stop.
 - **Phase 2 (tag)** — `origin/main` carries the release merge but has no tag yet (main is ahead
   of the latest `v*` tag), or a `develop→main` PR was just merged. Tag it.
-- **Between phases** — an OPEN PR with base `main`, head `develop` already exists. Point the user
-  to it and the merge instruction (Phase 1 step 6); do not open another.
+- **Between phases** — an OPEN PR with base `main`, head `develop` already exists. If it's queued
+  to auto-merge it just needs its review; point the user there (Phase 1 step 7). Do not open another.
 - **Phase 1 (open PR)** — develop is ahead of main and no open release PR exists. Open it.
 
 ## Phase 1 — open the release PR
@@ -39,7 +50,12 @@ Always start with `git fetch origin --tags --prune`, then pick the phase:
    `git log origin/main..origin/develop --no-merges --oneline`. If empty → stop: "Nothing to release."
 2. Bail if a release PR is already open:
    `gh pr list --base main --head develop --state open`. If one exists, point to it and stop.
-3. **Suggest the version** (semver, `vMAJOR.MINOR.PATCH`):
+3. **Pre-flight: is `develop` green?** `main` has no required status checks, so a broken `develop`
+   could ship. Check the latest CI run on develop:
+   `gh run list --branch develop -L 1 --json conclusion,status,workflowName`.
+   If the latest run isn't `success` (failing, or still in progress), **warn and ask** before
+   continuing — don't release a red branch.
+4. **Suggest the version** (semver, `vMAJOR.MINOR.PATCH`):
    - Last tag: `git describe --tags --abbrev=0 origin/main 2>/dev/null` (repo's first real
      release baseline is `v0.0.1`).
    - Scan `git log <last-tag>..origin/develop --no-merges`:
@@ -48,7 +64,7 @@ Always start with `git fetch origin --tags --prune`, then pick the phase:
      - else (`fix:`/`chore:`/`refactor:`/…) → bump **patch**
    - If no tag exists at all → propose `v0.1.0`.
    - **Show the proposed version and ask the user to confirm or override.** Never tag from a guess.
-4. **Draft the PR body** — terse, grouped, ~150 words max (same density rules as `open-pr`):
+5. **Draft the PR body** — terse, grouped, ~150 words max (same density rules as `open-pr`):
    ```md
    ## Release vX.Y.Z
 
@@ -63,19 +79,27 @@ Always start with `git fetch origin --tags --prune`, then pick the phase:
    ```
    Derive bullets from the actual commits since the last tag. Don't invent; don't list migration
    files, go.sum bumps, or mock regenerations.
-5. Open the PR:
+6. Open the PR:
    ```bash
    gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
    <body>
    EOF
    )"
    ```
-6. **Print this prominently — it is the whole point of the skill:**
+7. **Queue auto-merge as a merge commit — do NOT leave the merge button to chance.** This is the
+   whole point of the skill: GitHub merges the PR *as a merge commit* the moment its required
+   review lands, so nobody can accidentally squash it.
+   ```bash
+   gh pr merge <num> --auto --merge
+   ```
+   Then tell the user, plainly:
+   > Release PR #<num> is queued to **auto-merge as a merge commit** once approved.
+   > It needs **one approval from a maintainer** (not the author). Ping a reviewer.
+   > After it merges, re-run `/release` to tag and ship.
 
-   > ⚠️ **Merge this PR with "Create a merge commit" — NOT "Squash and merge".**
-   > Squashing severs shared history and breaks every future release.
-   > Foolproof from the CLI: `gh pr merge <num> --merge`
-   > Then re-run `/release` to tag and ship.
+   If `--auto --merge` is rejected with "merge method merge commits are not allowed", the repo
+   prerequisites above have drifted (linear history got re-enabled, or merge commits disabled) —
+   fix those first, then re-queue. Never fall back to a squash or rebase merge.
 
 ## Phase 2 — tag the release
 
@@ -92,16 +116,19 @@ Always start with `git fetch origin --tags --prune`, then pick the phase:
      once the check prints `OK`.
 3. **Determine the version** — read it back from the merged release PR title
    (`chore: release vX.Y.Z`). Confirm with the user.
-4. ⚠️ **Warn before tagging — this is the production gate.** Pushing the tag triggers
+4. **Tag-existence guard.** Make sure the tag isn't already used:
+   `git ls-remote --tags origin "refs/tags/vX.Y.Z"` (and `git tag -l vX.Y.Z` locally).
+   If it already exists, **stop** — pick a new version or investigate; never move an existing tag.
+5. ⚠️ **Warn before tagging — this is the production gate.** Pushing the tag triggers
    `.github/workflows/release.yml`, which creates a **draft** GitHub Release. Publishing that
    draft triggers the prod deploy. State that plainly and get explicit confirmation.
-5. Tag main's merge commit and push the tag:
+6. Tag main's merge commit and push the tag:
    ```bash
    git fetch origin
    git tag -a vX.Y.Z origin/main -m "Release vX.Y.Z"
    git push origin vX.Y.Z
    ```
-6. Tell the user: a **draft** release now exists (Releases page / Actions → release workflow).
+7. Tell the user: a **draft** release now exists (Releases page / Actions → release workflow).
    Edit the notes and **publish** it to deploy. The skill stops here — it never publishes.
 
 ## Rules

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: release
+description: Cut a release by merging develop into main and tagging it. Two-phase and gated — Phase 1 opens the develop→main PR with a merge-commit reminder; Phase 2 (after you merge) tags main vX.Y.Z to fire the release draft. Never squashes develop→main.
+---
+
+# Release
+
+## Goal
+
+Promote `develop` to `main` and tag it for deployment, while keeping `main` and `develop`
+history **shared**. The single rule that everything else protects:
+
+> **`develop → main` is merged with a MERGE COMMIT, never squashed or rebased.**
+
+Squashing severs shared history: `main` gets a brand-new commit that doesn't have develop's
+tip as an ancestor, so the next `develop → main` PR shows *all* of develop's commits as
+"missing from main" and reports phantom add/add conflicts. A merge commit keeps develop's tip
+as an ancestor of main, so future releases show only genuinely new commits.
+
+(For contrast, `feat/* → develop` *is* squash-merged — see the `open-pr` skill — and that's
+fine, because feature branches are short-lived and deleted. The rule only bites between two
+long-lived branches.)
+
+## Detect the phase
+
+Always start with `git fetch origin --tags --prune`, then pick the phase:
+
+- **Nothing to do** — `git rev-list --count origin/main..origin/develop` is `0` and `origin/main`
+  is already tagged. Say so and stop.
+- **Phase 2 (tag)** — `origin/main` carries the release merge but has no tag yet (main is ahead
+  of the latest `v*` tag), or a `develop→main` PR was just merged. Tag it.
+- **Between phases** — an OPEN PR with base `main`, head `develop` already exists. Point the user
+  to it and the merge instruction (Phase 1 step 6); do not open another.
+- **Phase 1 (open PR)** — develop is ahead of main and no open release PR exists. Open it.
+
+## Phase 1 — open the release PR
+
+1. `git fetch origin --tags --prune`. Confirm there's something to ship:
+   `git log origin/main..origin/develop --no-merges --oneline`. If empty → stop: "Nothing to release."
+2. Bail if a release PR is already open:
+   `gh pr list --base main --head develop --state open`. If one exists, point to it and stop.
+3. **Suggest the version** (semver, `vMAJOR.MINOR.PATCH`):
+   - Last tag: `git describe --tags --abbrev=0 origin/main 2>/dev/null` (repo's first real
+     release baseline is `v0.0.1`).
+   - Scan `git log <last-tag>..origin/develop --no-merges`:
+     - any `BREAKING CHANGE` or `type!:` → bump **major**
+     - else any `feat:` → bump **minor**
+     - else (`fix:`/`chore:`/`refactor:`/…) → bump **patch**
+   - If no tag exists at all → propose `v0.1.0`.
+   - **Show the proposed version and ask the user to confirm or override.** Never tag from a guess.
+4. **Draft the PR body** — terse, grouped, ~150 words max (same density rules as `open-pr`):
+   ```md
+   ## Release vX.Y.Z
+
+   <one-line summary of the release>
+
+   ### Highlights
+   - <feat bullet>
+   - <feat bullet>
+
+   ### Fixes
+   - <fix bullet, only if notable>
+   ```
+   Derive bullets from the actual commits since the last tag. Don't invent; don't list migration
+   files, go.sum bumps, or mock regenerations.
+5. Open the PR:
+   ```bash
+   gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+6. **Print this prominently — it is the whole point of the skill:**
+
+   > ⚠️ **Merge this PR with "Create a merge commit" — NOT "Squash and merge".**
+   > Squashing severs shared history and breaks every future release.
+   > Foolproof from the CLI: `gh pr merge <num> --merge`
+   > Then re-run `/release` to tag and ship.
+
+## Phase 2 — tag the release
+
+1. `git fetch origin --tags --prune`. Identify the merged release (most recently merged
+   `develop→main` PR, or `origin/main` ahead of the latest `v*` tag).
+2. **Safety check — did the merge keep shared history?**
+   ```bash
+   git merge-base --is-ancestor origin/develop origin/main && echo OK || echo BROKEN
+   ```
+   - If **BROKEN**, the release PR was squashed or rebased. **STOP and warn loudly:** shared
+     history is severed and the next release will hit phantom conflicts. Offer the repair before
+     tagging — open a fresh `develop→main` PR and merge it as a **merge commit**
+     (`gh pr merge <num> --merge`); its content diff is empty but it re-links ancestry. Only tag
+     once the check prints `OK`.
+3. **Determine the version** — read it back from the merged release PR title
+   (`chore: release vX.Y.Z`). Confirm with the user.
+4. ⚠️ **Warn before tagging — this is the production gate.** Pushing the tag triggers
+   `.github/workflows/release.yml`, which creates a **draft** GitHub Release. Publishing that
+   draft triggers the prod deploy. State that plainly and get explicit confirmation.
+5. Tag main's merge commit and push the tag:
+   ```bash
+   git fetch origin
+   git tag -a vX.Y.Z origin/main -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+6. Tell the user: a **draft** release now exists (Releases page / Actions → release workflow).
+   Edit the notes and **publish** it to deploy. The skill stops here — it never publishes.
+
+## Rules
+
+- **NEVER** squash or rebase `develop → main`. Merge commit only.
+- **NEVER** push a version tag without explicit confirmation — it leads to a prod deploy.
+- Version tags are `vMAJOR.MINOR.PATCH` — leading `v`, no suffixes, no omissions.
+- Derive release notes from real commits since the last tag; never invent them.
+- Keep output terse and skimmable, matching the `open-pr` skill.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,117 @@
 name: release
 
-# Triggers when a version tag (e.g. v1.2.3) is pushed to any branch.
-# Creates a DRAFT GitHub Release pre-populated with commits since the
-# last tag. You then edit the draft and publish it manually.
-# Publishing the release triggers deploy-prod.yml.
+# Creates a DRAFT GitHub Release (you edit + publish it; publishing triggers
+# deploy-prod). Runs on two paths, sharing one job:
+#
+#   1. AUTO (normal path) — a `develop → main` release PR is MERGED. The version
+#      is read from the PR title (`chore: release vX.Y.Z`); this workflow tags
+#      main's merge commit, then drafts the release. Used by the `release` skill:
+#      open the PR + queue auto-merge, and the rest happens here, server-side.
+#
+#   2. MANUAL (emergency path) — someone pushes a `vX.Y.Z` tag by hand. The tag
+#      already exists, so we skip tagging and just draft the release.
+#
+# Note on path 1: the tag is pushed with GITHUB_TOKEN, which by design does NOT
+# start another workflow run — so the push-tag trigger below won't double-fire.
+# That's why this same job drafts the release directly after tagging.
 on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
-  # Create release draft
   create-release:
+    # Run on a manual tag push, OR on a merged develop→main release PR.
+    if: >
+      github.event_name == 'push' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'develop' &&
+       startsWith(github.event.pull_request.title, 'chore: release v'))
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
-    # Needs write access to create GitHub Releases.
+    # Needs write access to push the tag and create the GitHub Release.
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
         with:
-          # Fetch full history so we can diff against the previous tag.
+          # Full history + all tags so we can diff against the previous tag and
+          # reach main's merge commit.
           fetch-depth: 0
+          ref: main
 
-      # Build a raw commit log since the previous tag as a starting point
-      # for the changelog. Edit and clean this up before publishing.
+      # Resolve the version: from the tag (manual) or the PR title (auto).
+      - name: Determine version
+        id: ver
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "$EVENT" = "push" ]; then
+            VERSION="$REF_NAME"
+          else
+            VERSION=$(printf '%s' "$TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          fi
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Could not resolve a vX.Y.Z version (event=$EVENT, title=$TITLE, ref=$REF_NAME)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION"
+
+      # AUTO path only: tag main's merge commit and push it.
+      - name: Tag the merge commit
+        if: github.event_name == 'pull_request'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists — refusing to move it."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" "$SHA" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      # Build a raw commit log since the previous tag as a changelog starting
+      # point. Edit and clean this up before publishing the draft.
       - name: Generate commit log since last tag
         id: log
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$VERSION" | head -1)
           if [ -n "$PREV" ]; then
             echo "Commits since ${PREV}:"
-            LOG=$(git log ${PREV}..HEAD --oneline --no-merges)
+            LOG=$(git log "${PREV}..${VERSION}" --oneline --no-merges)
           else
             echo "First release — no previous tag found."
-            LOG=$(git log --oneline --no-merges)
+            LOG=$(git log "${VERSION}" --oneline --no-merges)
+            PREV="$VERSION"
           fi
-          # Write to output using multiline syntax.
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
           {
             echo "log<<EOF"
             echo "$LOG"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # Creates the draft release. Edit the body in GitHub UI before publishing.
+      # Creates the draft release. Edit the body in the GitHub UI before publishing.
       # Publishing the release will trigger deploy-prod.yml.
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: ${{ steps.ver.outputs.version }}
           body: |
             <!-- Raw commit log since previous tag - replace with clean changelog below -->
             ${{ steps.log.outputs.log }}
@@ -60,7 +120,7 @@ jobs:
             <!-- Release Notes Template - Fill in the sections below -->
             <!-- ============================================================ -->
 
-            # Release ${{ github.ref_name }}
+            # Release ${{ steps.ver.outputs.version }}
 
             Brief summary of the release.
 
@@ -116,4 +176,4 @@ jobs:
 
             ## Full diff
 
-            https://github.com/${{ github.repository }}/compare/PREV...${{ github.ref_name }}
+            https://github.com/${{ github.repository }}/compare/${{ steps.log.outputs.prev }}...${{ steps.ver.outputs.version }}


### PR DESCRIPTION
## What changed

- Adds `.claude/skills/release/SKILL.md` — a two-phase, gated release helper.
- **Phase 1** opens the `develop → main` PR with auto-suggested semver and a loud merge-commit reminder.
- **Phase 2** (after merge) tags `main vX.Y.Z`, which fires `release.yml`'s draft release.
- Enforces **merge commit, never squash** on `develop → main` so the two branches keep shared history — and a Phase 2 safety check (`git merge-base --is-ancestor`) detects and warns if a release was squashed.

## How to test

- [ ] Run `/release` with `develop` ahead of `main` → it suggests a version and drafts the PR body.
- [ ] Confirm it refuses to tag (Phase 2) when `merge-base --is-ancestor origin/develop origin/main` is false.
- [ ] Confirm it never pushes a tag without explicit confirmation.