### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: release
+description: Cut a release in one command — open the develop→main PR and queue it to auto-merge as a merge commit. A maintainer's approval then triggers merge → tag → draft release automatically. Never squash develop→main.
+---
+
+# Release
+
+Promote `develop` to `main` and ship it in **one command**. You open the release PR; once a
+maintainer approves, the rest is automatic:
+
+```
+/release → PR opened + auto-merge queued → (maintainer approves)
+        → GitHub merges as a MERGE COMMIT → release.yml tags vX.Y.Z + drafts the release
+        → you publish the draft → prod deploy
+```
+
+## The one rule
+
+> **`develop → main` must merge as a MERGE COMMIT — never squash or rebase.**
+
+Squashing gives `main` a commit that doesn't have develop's tip as an ancestor, so the next
+release PR shows every develop commit and hits phantom conflicts. A merge commit keeps history
+shared. (Squashing `feat/* → develop` is fine — those branches are short-lived; see `open-pr`.)
+The `--auto --merge` in step 6 enforces this.
+
+## How it's wired
+
+- **Auto-merge** merges the PR as a merge commit the instant its required review lands.
+- **`.github/workflows/release.yml`** runs on the merged PR, reads the version from the title
+  (`chore: release vX.Y.Z`), tags main's merge commit, and drafts the release. You publish the
+  draft to deploy.
+
+**Prerequisites** (already configured — check these if a release misbehaves):
+
+- `main` protection: "Require linear history" **off**; requires **1 non-author review**.
+- Repo: "Allow auto-merge" and "Allow merge commits" **on**.
+- `release.yml` triggers on `pull_request: [closed]` → `main`.
+
+## Steps
+
+1. `git fetch origin --tags --prune`. If `git log origin/main..origin/develop --no-merges --oneline`
+   is empty → stop: "Nothing to release."
+2. If a `develop→main` PR is already open (`gh pr list --base main --head develop --state open`),
+   report its status and stop — don't open another.
+3. **Pre-flight.** `main` has no required checks, so confirm develop is green:
+   `gh run list --branch develop -L 1 --json conclusion,status`. If the latest run isn't
+   `success`, warn and ask before continuing.
+4. **Version.** Propose the next semver and have the user confirm — never guess silently:
+   - Last tag: `git tag -l 'v*.*.*' --sort=-v:refname | head -1` (baseline `v0.0.1`).
+   - Bump from the commits since that tag: `BREAKING CHANGE`/`type!:` → **major**; else `feat:` →
+     **minor**; else → **patch**.
+5. **Open the PR.** Title MUST be exactly `chore: release vX.Y.Z` — `release.yml` parses the
+   version from it. Body: terse grouped highlights (~150 words, same density as `open-pr`) derived
+   from real commits; skip migration files, go.sum bumps, mock regens.
+   ```bash
+   gh pr create --base main --head develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF'
+   ## Release vX.Y.Z
+
+   <one-line summary>
+
+   ### Highlights
+   - <feat bullet>
+
+   ### Fixes
+   - <fix bullet, if notable>
+   EOF
+   )"
+   ```
+6. **Queue auto-merge as a merge commit:** `gh pr merge <num> --auto --merge`. If rejected with
+   "merge method merge commits are not allowed", a prerequisite drifted — fix it and re-queue.
+   Never fall back to squash or rebase.
+7. **Report and stop** — don't tag, merge, or publish; those are the automation's and the user's
+   jobs:
+   > Release PR #<num> (`vX.Y.Z`) is queued to auto-merge as a merge commit. It needs **one
+   > maintainer approval** (not the author). On approval it merges, then `release.yml` tags it and
+   > drafts the release — **publish the draft** to deploy.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,117 @@
 name: release
 
-# Triggers when a version tag (e.g. v1.2.3) is pushed to any branch.
-# Creates a DRAFT GitHub Release pre-populated with commits since the
-# last tag. You then edit the draft and publish it manually.
-# Publishing the release triggers deploy-prod.yml.
+# Creates a DRAFT GitHub Release (you edit + publish it; publishing triggers
+# deploy-prod). Runs on two paths, sharing one job:
+#
+#   1. AUTO (normal path) — a `develop → main` release PR is MERGED. The version
+#      is read from the PR title (`chore: release vX.Y.Z`); this workflow tags
+#      main's merge commit, then drafts the release. Used by the `release` skill:
+#      open the PR + queue auto-merge, and the rest happens here, server-side.
+#
+#   2. MANUAL (emergency path) — someone pushes a `vX.Y.Z` tag by hand. The tag
+#      already exists, so we skip tagging and just draft the release.
+#
+# Note on path 1: the tag is pushed with GITHUB_TOKEN, which by design does NOT
+# start another workflow run — so the push-tag trigger below won't double-fire.
+# That's why this same job drafts the release directly after tagging.
 on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
-  # Create release draft
   create-release:
+    # Run on a manual tag push, OR on a merged develop→main release PR.
+    if: >
+      github.event_name == 'push' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'develop' &&
+       startsWith(github.event.pull_request.title, 'chore: release v'))
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
-    # Needs write access to create GitHub Releases.
+    # Needs write access to push the tag and create the GitHub Release.
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
         with:
-          # Fetch full history so we can diff against the previous tag.
+          # Full history + all tags so we can diff against the previous tag and
+          # reach main's merge commit.
           fetch-depth: 0
+          ref: main
 
-      # Build a raw commit log since the previous tag as a starting point
-      # for the changelog. Edit and clean this up before publishing.
+      # Resolve the version: from the tag (manual) or the PR title (auto).
+      - name: Determine version
+        id: ver
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "$EVENT" = "push" ]; then
+            VERSION="$REF_NAME"
+          else
+            VERSION=$(printf '%s' "$TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          fi
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Could not resolve a vX.Y.Z version (event=$EVENT, title=$TITLE, ref=$REF_NAME)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION"
+
+      # AUTO path only: tag main's merge commit and push it.
+      - name: Tag the merge commit
+        if: github.event_name == 'pull_request'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists — refusing to move it."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" "$SHA" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      # Build a raw commit log since the previous tag as a changelog starting
+      # point. Edit and clean this up before publishing the draft.
       - name: Generate commit log since last tag
         id: log
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$VERSION" | head -1)
           if [ -n "$PREV" ]; then
             echo "Commits since ${PREV}:"
-            LOG=$(git log ${PREV}..HEAD --oneline --no-merges)
+            LOG=$(git log "${PREV}..${VERSION}" --oneline --no-merges)
           else
             echo "First release — no previous tag found."
-            LOG=$(git log --oneline --no-merges)
+            LOG=$(git log "${VERSION}" --oneline --no-merges)
+            PREV="$VERSION"
           fi
-          # Write to output using multiline syntax.
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
           {
             echo "log<<EOF"
             echo "$LOG"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # Creates the draft release. Edit the body in GitHub UI before publishing.
+      # Creates the draft release. Edit the body in the GitHub UI before publishing.
       # Publishing the release will trigger deploy-prod.yml.
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: ${{ steps.ver.outputs.version }}
           body: |
             <!-- Raw commit log since previous tag - replace with clean changelog below -->
             ${{ steps.log.outputs.log }}
@@ -60,7 +120,7 @@ jobs:
             <!-- Release Notes Template - Fill in the sections below -->
             <!-- ============================================================ -->
 
-            # Release ${{ github.ref_name }}
+            # Release ${{ steps.ver.outputs.version }}
 
             Brief summary of the release.
 
@@ -116,4 +176,4 @@ jobs:
 
             ## Full diff
 
-            https://github.com/${{ github.repository }}/compare/PREV...${{ github.ref_name }}
+            https://github.com/${{ github.repository }}/compare/${{ steps.log.outputs.prev }}...${{ steps.ver.outputs.version }}


### PR DESCRIPTION
## Release v0.1.0

First release through the automated `/release` flow. Promotes the release tooling itself to `main`.

### Highlights
- `release` skill: one-command `develop → main` releases (open PR + queue auto-merge as a merge commit).
- `release.yml` now also tags + drafts the release automatically when the release PR merges (auto path), keeping the manual tag-push path for emergencies.

### Notes
- This is the release that lands the new `release.yml` on `main`, enabling the fully-automatic tag/draft on subsequent releases.