### PR TITLE
chore: dedupe CI on release PRs and categorize release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,18 @@
 name: ci
 
-# Runs on pushes to main/develop and on PRs targeting develop.
-# PRs targeting main (i.e. develop→main release PRs) deliberately have NO
-# pull_request run — their head is develop, which already ran push CI on the
-# same commit, so a pull_request run would just duplicate it.
-# All three jobs (lint, build, test) run in parallel for faster feedback.
+# pull_request runs only on develop: a develop→main release PR's head is develop,
+# which already ran push CI on the same commit, so a pull_request run would duplicate it.
 on:
   push:
     branches: [main, develop]
   pull_request:
     branches: [develop]
 
-# Cancel any in-progress run on the same branch when a new push arrives,
-# avoiding wasted CI minutes on outdated commits.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Lint
-  # Static analysis: dependency hygiene, go vet, and staticcheck.
   lint:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -32,40 +25,31 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod  # pins the exact Go version from go.mod
-          cache: true              # caches the module download cache between runs
+          go-version-file: go.mod
+          cache: true
 
-      # swag generates the docs package required by cmd/api imports.
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest
 
-      # Generate docs so the local docs package exists before any Go tooling runs.
       - name: Generate docs
         run: make swagger-inner
 
-      # Ensures all module checksums match what is recorded in go.sum.
       - name: Verify dependencies
         run: go mod verify
 
-      # Runs go mod tidy and fails if it produces any changes, meaning the
-      # committed go.mod/go.sum are not in sync with the source code.
       - name: Check go mod tidy
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-      # Built-in Go static analyser — catches common mistakes at the AST level.
       - name: go vet
         run: go vet ./...
 
-      # Stricter static analysis beyond go vet (unused code, deprecated APIs, etc.).
       - name: staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...
 
-  # Build
-  # Generates Swagger docs and verifies the project compiles cleanly.
   build:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -77,20 +61,15 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # swag is not a project dependency, install it as a CI tool.
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest
 
-      # Regenerates the OpenAPI spec under ./docs from handler annotations.
       - name: Generate docs
         run: make swagger-inner
 
-      # Full compilation check — catches missing symbols, type errors, etc.
       - name: Build
         run: go build -v ./...
 
-  # Test
-  # Runs all unit tests with the race detector enabled.
   test:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -102,6 +81,5 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # -race detects data races; -count=1 disables the test result cache.
       - name: Run unit tests
         run: make test-unit-inner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,15 @@
 name: ci
 
-# Runs on every push and PR targeting main or develop.
+# Runs on pushes to main/develop and on PRs targeting develop.
+# PRs targeting main (i.e. develop→main release PRs) deliberately have NO
+# pull_request run — their head is develop, which already ran push CI on the
+# same commit, so a pull_request run would just duplicate it.
 # All three jobs (lint, build, test) run in parallel for faster feedback.
 on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
 
 # Cancel any in-progress run on the same branch when a new push arrives,
 # avoiding wasted CI minutes on outdated commits.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,97 +83,50 @@ jobs:
 
       # Build a raw commit log since the previous tag as a changelog starting
       # point. Edit and clean this up before publishing the draft.
-      - name: Generate commit log since last tag
-        id: log
+      # Build a clean, categorized changelog from conventional-commit subjects
+      # since the previous tag, written to NOTES.md. Empty sections are omitted.
+      # Edit the draft in the GitHub UI before publishing if you want a summary.
+      - name: Generate release notes
         env:
           VERSION: ${{ steps.ver.outputs.version }}
+          REPO: ${{ github.repository }}
         run: |
           PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$VERSION" | head -1)
-          if [ -n "$PREV" ]; then
-            echo "Commits since ${PREV}:"
-            LOG=$(git log "${PREV}..${VERSION}" --oneline --no-merges)
-          else
-            echo "First release — no previous tag found."
-            LOG=$(git log "${VERSION}" --oneline --no-merges)
-            PREV="$VERSION"
-          fi
-          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
-          {
-            echo "log<<EOF"
-            echo "$LOG"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          if [ -n "$PREV" ]; then RANGE="${PREV}..${VERSION}"; else RANGE="$VERSION"; fi
 
-      # Creates the draft release. Edit the body in the GitHub UI before publishing.
-      # Publishing the release will trigger deploy-prod.yml.
+          # All non-merge subjects in range, minus the release-merge noise.
+          ALL=$(git log "$RANGE" --no-merges --pretty='%s' | grep -vE '^chore: release ')
+          # Strip the conventional-commit prefix (type, optional scope, optional !).
+          strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
+
+          FEATS=$(printf '%s\n' "$ALL" | grep -E '^feat'      | sed -E "$strip" | sed 's/^/- /')
+          FIXES=$(printf '%s\n' "$ALL" | grep -E '^fix'       | sed -E "$strip" | sed 's/^/- /')
+          OTHER=$(printf '%s\n' "$ALL" | grep -vE '^(feat|fix)' | sed -E "$strip" | sed 's/^/- /')
+          BREAKING=$(printf '%s\n' "$ALL" | grep -E '^[a-z]+(\([^)]*\))?!:' | sed -E "$strip" | sed 's/^/- /')
+
+          {
+            echo "<!-- Optional: add a one-line summary above What's changed, then publish. -->"
+            echo ""
+            echo "## What's changed"
+            echo ""
+            [ -n "$BREAKING" ] && { echo "### Breaking changes"; echo "$BREAKING"; echo ""; }
+            [ -n "$FEATS" ]    && { echo "### Features";         echo "$FEATS";    echo ""; }
+            [ -n "$FIXES" ]    && { echo "### Fixes";            echo "$FIXES";    echo ""; }
+            [ -n "$OTHER" ]    && { echo "### Other";            echo "$OTHER";    echo ""; }
+            if [ -n "$PREV" ]; then
+              echo "**Full changelog**: https://github.com/${REPO}/compare/${PREV}...${VERSION}"
+            fi
+          } > NOTES.md
+
+          echo "::group::Generated NOTES.md"
+          cat NOTES.md
+          echo "::endgroup::"
+
+      # Creates the draft release from NOTES.md. Edit + publish to deploy.
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           tag_name: ${{ steps.ver.outputs.version }}
           name: ${{ steps.ver.outputs.version }}
-          body: |
-            <!-- Raw commit log since previous tag - replace with clean changelog below -->
-            ${{ steps.log.outputs.log }}
-
-            <!-- ============================================================ -->
-            <!-- Release Notes Template - Fill in the sections below -->
-            <!-- ============================================================ -->
-
-            # Release ${{ steps.ver.outputs.version }}
-
-            Brief summary of the release.
-
-            ## Highlights
-
-            - Highlight 1
-            - Highlight 2
-            - Highlight 3
-
-            ## What's changed
-
-            ### Features
-            - Added ...
-
-            ### Improvements
-            - Improved ...
-
-            ### Bug fixes
-            - Fixed ...
-
-            ### Testing
-            - Added/updated ...
-
-            ### Developer experience
-            - Added/updated ...
-
-            ### Internal
-            - Refactored ...
-            - Updated dependencies ...
-
-            ## Breaking changes
-
-            None.
-
-            ## Migration notes
-
-            - Run ...
-            - Update ...
-            - Verify ...
-
-            ## Deployment notes
-
-            - Required environment variables:
-              - `VAR_NAME`
-            - Infra notes:
-              - ...
-            - Operational notes:
-              - ...
-
-            ## Contributors
-
-            - @username
-
-            ## Full diff
-
-            https://github.com/${{ github.repository }}/compare/${{ steps.log.outputs.prev }}...${{ steps.ver.outputs.version }}
+          body_path: NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,12 @@
 name: release
 
-# Creates a DRAFT GitHub Release (you edit + publish it; publishing triggers
-# deploy-prod). Runs on two paths, sharing one job:
-#
-#   1. AUTO (normal path) — a `develop → main` release PR is MERGED. The version
-#      is read from the PR title (`chore: release vX.Y.Z`); this workflow tags
-#      main's merge commit, then drafts the release. Used by the `release` skill:
-#      open the PR + queue auto-merge, and the rest happens here, server-side.
-#
-#   2. MANUAL (emergency path) — someone pushes a `vX.Y.Z` tag by hand. The tag
-#      already exists, so we skip tagging and just draft the release.
-#
-# Note on path 1: the tag is pushed with GITHUB_TOKEN, which by design does NOT
-# start another workflow run — so the push-tag trigger below won't double-fire.
-# That's why this same job drafts the release directly after tagging.
+# Creates a DRAFT GitHub Release (edit + publish it; publishing triggers deploy-prod).
+# Two paths, one job:
+#   1. AUTO — a develop→main release PR merges; the version is read from its title
+#      (`chore: release vX.Y.Z`), this job tags main's merge commit, then drafts.
+#   2. MANUAL — a `vX.Y.Z` tag is pushed by hand; tagging is skipped, just drafts.
+# The AUTO tag push uses GITHUB_TOKEN, which can't trigger another workflow run, so this
+# same job drafts the release directly rather than relying on the tag trigger.
 on:
   push:
     tags:
@@ -24,7 +17,6 @@ on:
 
 jobs:
   create-release:
-    # Run on a manual tag push, OR on a merged develop→main release PR.
     if: >
       github.event_name == 'push' ||
       (github.event.pull_request.merged == true &&
@@ -32,20 +24,16 @@ jobs:
        startsWith(github.event.pull_request.title, 'chore: release v'))
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-
-    # Needs write access to push the tag and create the GitHub Release.
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
         with:
-          # Full history + all tags so we can diff against the previous tag and
-          # reach main's merge commit.
+          # Full history/tags to diff against the previous tag and reach main's merge commit.
           fetch-depth: 0
           ref: main
 
-      # Resolve the version: from the tag (manual) or the PR title (auto).
       - name: Determine version
         id: ver
         env:
@@ -65,7 +53,6 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing $VERSION"
 
-      # AUTO path only: tag main's merge commit and push it.
       - name: Tag the merge commit
         if: github.event_name == 'pull_request'
         env:
@@ -81,11 +68,6 @@ jobs:
           git tag -a "$VERSION" "$SHA" -m "Release $VERSION"
           git push origin "$VERSION"
 
-      # Build a raw commit log since the previous tag as a changelog starting
-      # point. Edit and clean this up before publishing the draft.
-      # Build a clean, categorized changelog from conventional-commit subjects
-      # since the previous tag, written to NOTES.md. Empty sections are omitted.
-      # Edit the draft in the GitHub UI before publishing if you want a summary.
       - name: Generate release notes
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -94,7 +76,6 @@ jobs:
           PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$VERSION" | head -1)
           if [ -n "$PREV" ]; then RANGE="${PREV}..${VERSION}"; else RANGE="$VERSION"; fi
 
-          # All non-merge subjects in range, minus the release-merge noise.
           ALL=$(git log "$RANGE" --no-merges --pretty='%s' | grep -vE '^chore: release ')
           # Strip the conventional-commit prefix (type, optional scope, optional !).
           strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
@@ -122,7 +103,6 @@ jobs:
           cat NOTES.md
           echo "::endgroup::"
 
-      # Creates the draft release from NOTES.md. Edit + publish to deploy.
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## What changed

- **CI dedup (`ci.yml`):** `pull_request` now triggers only on base `develop`. Release PRs (`develop → main`) no longer show duplicated `(push)` + `(pull_request)` check runs — they reuse develop's push CI on the same commit. Push CI on `main`/`develop` is unchanged.
- **Release notes (`release.yml`):** the draft body is now a categorized changelog (Features / Fixes / Other, with breaking changes surfaced) built from conventional-commit subjects since the previous tag, instead of a raw commit dump + placeholder template.

## How to test

- [ ] Open a feature PR to `develop` → only 3 checks (no `(push)` duplicates).
- [ ] Next release draft shows a clean categorized "What's changed" list with a Full changelog compare link.