### PR TITLE
ci: deploy to Railway production on release publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: deploy
+
+# Deploys the released version to Railway production when a GitHub Release is
+# published. Publishing the draft release (created by release.yml) is the
+# deliberate go-live gate.
+#
+# Prerequisite: Railway's "Auto deploys when pushed to GitHub" must be DISABLED
+# on the api service, so a main merge doesn't also deploy — this workflow is the
+# single production-deploy path. The repo stays connected for build settings and
+# the pre-deploy migration command; only the auto-deploy trigger is off.
+on:
+  release:
+    types: [published]
+
+# Never run two production deploys at once; don't cancel one in flight.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    environment: production
+    steps:
+      # Check out the exact released tag so we deploy that version's code.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install Railway CLI
+        run: npm i -g @railway/cli
+
+      # RAILWAY_TOKEN is a project token scoped to the production environment, so
+      # the environment is implied. --ci streams build logs and exits on completion.
+      - name: Deploy to Railway (production)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: railway up --ci --service api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,13 @@
 name: deploy
 
-# Deploys the released version to Railway production when a GitHub Release is
-# published. Publishing the draft release (created by release.yml) is the
-# deliberate go-live gate.
-#
-# Prerequisite: Railway's "Auto deploys when pushed to GitHub" must be DISABLED
-# on the api service, so a main merge doesn't also deploy — this workflow is the
-# single production-deploy path. The repo stays connected for build settings and
-# the pre-deploy migration command; only the auto-deploy trigger is off.
+# Deploys the released version to Railway production when a GitHub Release is published
+# (the go-live gate). Railway's "Auto deploys when pushed to GitHub" must be DISABLED on
+# the api service so a main merge doesn't also deploy — this is the single production path;
+# the repo stays connected only for build settings and the pre-deploy migration command.
 on:
   release:
     types: [published]
 
-# Never run two production deploys at once; don't cancel one in flight.
 concurrency:
   group: deploy-production
   cancel-in-progress: false
@@ -23,7 +18,6 @@ jobs:
     timeout-minutes: 20
     environment: production
     steps:
-      # Check out the exact released tag so we deploy that version's code.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
@@ -31,8 +25,8 @@ jobs:
       - name: Install Railway CLI
         run: npm i -g @railway/cli
 
-      # RAILWAY_TOKEN is a project token scoped to the production environment, so
-      # the environment is implied. --ci streams build logs and exits on completion.
+      # RAILWAY_TOKEN is a project token scoped to production, so the environment is
+      # implied; --ci streams build logs and exits when the build completes.
       - name: Deploy to Railway (production)
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## What changed

Adds `deploy.yml` — deploys the released version to Railway **production** when a GitHub **Release is published**.

- Trigger: `release: [published]` (publishing the draft = the go-live gate).
- Checks out the released **tag**, installs the Railway CLI, runs `railway up --ci --service api`.
- `concurrency` prevents overlapping prod deploys.
- Uses a GitHub `production` environment for deployment tracking.

## Required setup before this works (manual, one-time)

1. **Railway project token** scoped to the **production** environment → store as the GitHub secret **`RAILWAY_TOKEN`**.
2. **Disable** "Auto deploys when pushed to GitHub" on the Railway `api` service (keep the repo connected — only the auto-deploy trigger is turned off), so a `main` merge doesn't also deploy.
3. Confirm the Railway service name is `api` (matches `--service`).

## How to test

- [ ] Publish a release → Actions runs `deploy`, `railway up` builds + deploys, migrations run via the existing pre-deploy command.