### PR TITLE
chore: remove all comments from workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ci
 
-# pull_request runs only on develop: a develop→main release PR's head is develop,
-# which already ran push CI on the same commit, so a pull_request run would duplicate it.
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,5 @@
 name: deploy
 
-# Deploys the released version to Railway production when a GitHub Release is published
-# (the go-live gate). Railway's "Auto deploys when pushed to GitHub" must be DISABLED on
-# the api service so a main merge doesn't also deploy — this is the single production path;
-# the repo stays connected only for build settings and the pre-deploy migration command.
 on:
   release:
     types: [published]
@@ -25,8 +21,6 @@ jobs:
       - name: Install Railway CLI
         run: npm i -g @railway/cli
 
-      # RAILWAY_TOKEN is a project token scoped to production, so the environment is
-      # implied; --ci streams build logs and exits when the build completes.
       - name: Deploy to Railway (production)
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,5 @@
 name: release
 
-# Creates a DRAFT GitHub Release (edit + publish it; publishing triggers deploy-prod).
-# Two paths, one job:
-#   1. AUTO — a develop→main release PR merges; the version is read from its title
-#      (`chore: release vX.Y.Z`), this job tags main's merge commit, then drafts.
-#   2. MANUAL — a `vX.Y.Z` tag is pushed by hand; tagging is skipped, just drafts.
-# The AUTO tag push uses GITHUB_TOKEN, which can't trigger another workflow run, so this
-# same job drafts the release directly rather than relying on the tag trigger.
 on:
   push:
     tags:
@@ -30,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Full history/tags to diff against the previous tag and reach main's merge commit.
           fetch-depth: 0
           ref: main
 
@@ -77,7 +69,6 @@ jobs:
           if [ -n "$PREV" ]; then RANGE="${PREV}..${VERSION}"; else RANGE="$VERSION"; fi
 
           ALL=$(git log "$RANGE" --no-merges --pretty='%s' | grep -vE '^chore: release ')
-          # Strip the conventional-commit prefix (type, optional scope, optional !).
           strip='s/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
 
           FEATS=$(printf '%s\n' "$ALL" | grep -E '^feat'      | sed -E "$strip" | sed 's/^/- /')


### PR DESCRIPTION
Strips every comment from `ci.yml`, `release.yml`, and `deploy.yml`. Rationale lives in the release skill doc and PR history. Generated release-note output (the `echo "##"`/`"###"` lines) is preserved; all three validated as YAML.