### PR TITLE
feat: remap player IDs to a uniform JS-safe range

### DIFF
--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
@@ -1,5 +1,3 @@
--- Drops the provider_id column. The uniform sequential id renumbering is not
--- reversible (the original random placeholder IDs were meaningless and are not
--- reconstructable), and the new IDs are perfectly valid, so player.id values are
--- intentionally left in place.
+-- The id renumbering is irreversible (original placeholder IDs were meaningless);
+-- only the provider_id column is dropped.
 ALTER TABLE players DROP COLUMN IF EXISTS provider_id;

--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
@@ -1,0 +1,5 @@
+-- Drops the provider_id column. The uniform sequential id renumbering is not
+-- reversible (the original random placeholder IDs were meaningless and are not
+-- reconstructable), and the new IDs are perfectly valid, so player.id values are
+-- intentionally left in place.
+ALTER TABLE players DROP COLUMN IF EXISTS provider_id;

--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
@@ -1,0 +1,44 @@
+-- Give every player a single, consistent, JS-safe primary key.
+--
+-- Players were seeded from two sources: ~879 with their real API-Football IDs
+-- (small, e.g. Messi = 45843) and ~471 with random 18-19 digit int64 placeholder
+-- IDs. The placeholders exceed JavaScript's Number.MAX_SAFE_INTEGER
+-- (9007199254740991, ~2^53), so the web client silently rounds them on
+-- JSON.parse and sends a corrupted player_id back, breaking award picks
+-- (PUT /api/awards -> 404). The two ID spaces are also just inconsistent.
+--
+-- players.id is a purely internal surrogate key (nothing syncs players from
+-- API-Football by it), so we renumber ALL players into one uniform sequential
+-- range and move the real API-Football ID to a separate provider_id column
+-- (NULL for the placeholders). This fixes the bug, makes IDs consistent, and
+-- preserves the real provider IDs for future use (e.g. resolving award winners
+-- from API-Football player stats).
+
+ALTER TABLE players ADD COLUMN provider_id BIGINT;
+
+-- Preserve the real API-Football IDs (the small ones); the random placeholders
+-- carry no meaning and become NULL.
+UPDATE players SET provider_id = id WHERE id <= 9007199254740991;
+
+-- Uniform sequential PKs for everyone, ordered deterministically so the result
+-- is identical on every database (fresh dev, test, and prod).
+CREATE TEMP TABLE id_remap ON COMMIT DROP AS
+  SELECT id AS old_id,
+         row_number() OVER (ORDER BY team_fifa_code, name, id) AS new_id
+  FROM players;
+
+-- Updating a referenced primary key requires dropping the FK constraints, since
+-- they are not ON UPDATE CASCADE. Drop, remap parent + children, then re-add.
+ALTER TABLE user_award_picks DROP CONSTRAINT user_award_picks_player_id_fkey;
+ALTER TABLE award_winners    DROP CONSTRAINT award_winners_player_id_fkey;
+
+UPDATE players p          SET id        = r.new_id FROM id_remap r WHERE p.id = r.old_id;
+UPDATE user_award_picks u SET player_id = r.new_id FROM id_remap r WHERE u.player_id = r.old_id;
+UPDATE award_winners a    SET player_id = r.new_id FROM id_remap r WHERE a.player_id = r.old_id;
+
+ALTER TABLE user_award_picks
+  ADD CONSTRAINT user_award_picks_player_id_fkey
+  FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE;
+ALTER TABLE award_winners
+  ADD CONSTRAINT award_winners_player_id_fkey
+  FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE RESTRICT;

--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
@@ -1,34 +1,19 @@
--- Give every player a single, consistent, JS-safe primary key.
---
--- Players were seeded from two sources: ~879 with their real API-Football IDs
--- (small, e.g. Messi = 45843) and ~471 with random 18-19 digit int64 placeholder
--- IDs. The placeholders exceed JavaScript's Number.MAX_SAFE_INTEGER
--- (9007199254740991, ~2^53), so the web client silently rounds them on
--- JSON.parse and sends a corrupted player_id back, breaking award picks
--- (PUT /api/awards -> 404). The two ID spaces are also just inconsistent.
---
--- players.id is a purely internal surrogate key (nothing syncs players from
--- API-Football by it), so we renumber ALL players into one uniform sequential
--- range and move the real API-Football ID to a separate provider_id column
--- (NULL for the placeholders). This fixes the bug, makes IDs consistent, and
--- preserves the real provider IDs for future use (e.g. resolving award winners
--- from API-Football player stats).
+-- ~471 players were seeded with random 18-19 digit placeholder IDs that exceed
+-- Number.MAX_SAFE_INTEGER, so the web client rounds them on JSON.parse and breaks
+-- award picks. players.id is a purely internal surrogate key, so renumber every
+-- player into one uniform sequential range and keep the real API-Football ID
+-- (where known) in a separate provider_id column.
 
 ALTER TABLE players ADD COLUMN provider_id BIGINT;
-
--- Preserve the real API-Football IDs (the small ones); the random placeholders
--- carry no meaning and become NULL.
 UPDATE players SET provider_id = id WHERE id <= 9007199254740991;
 
--- Uniform sequential PKs for everyone, ordered deterministically so the result
--- is identical on every database (fresh dev, test, and prod).
+-- Ordered deterministically so the result is identical on every database.
 CREATE TEMP TABLE id_remap ON COMMIT DROP AS
   SELECT id AS old_id,
          row_number() OVER (ORDER BY team_fifa_code, name, id) AS new_id
   FROM players;
 
--- Updating a referenced primary key requires dropping the FK constraints, since
--- they are not ON UPDATE CASCADE. Drop, remap parent + children, then re-add.
+-- The FKs aren't ON UPDATE CASCADE, so drop them to remap the PK, then re-add.
 ALTER TABLE user_award_picks DROP CONSTRAINT user_award_picks_player_id_fkey;
 ALTER TABLE award_winners    DROP CONSTRAINT award_winners_player_id_fkey;
 


### PR DESCRIPTION
## Related issue

Closes #81

## What changed

- Add `provider_id` column to `players`, backfilling it with the real API-Football IDs (the small ones) and leaving placeholders NULL.
- Renumber all players into one uniform sequential PK range so no `players.id` exceeds JS `Number.MAX_SAFE_INTEGER` — fixes the web client rounding large IDs and corrupting award picks (`PUT /api/awards` → 404).
- Drop/remap/re-add the `user_award_picks` and `award_winners` FKs (not `ON UPDATE CASCADE`) so child rows follow the new IDs.
- Down migration drops `provider_id`; the renumbering is intentionally not reversed (placeholders aren't reconstructable, new IDs are valid).

## How to test

- [ ] `make db-migrate-up` then `make db-test-migrate-up` — both apply cleanly.
- [ ] `SELECT max(id) FROM players;` — well under 9007199254740991, IDs contiguous from 1.
- [ ] `SELECT count(*) FROM players WHERE provider_id IS NOT NULL;` — ~879 (real API-Football IDs preserved).
- [ ] `PUT /api/awards` with a previously-failing large-ID player pick now returns 200.
- [ ] `make db-migrate-down` drops `provider_id` without error.