### PR TITLE
chore: release v1.0.1

### DIFF
--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.down.sql
@@ -1,0 +1,3 @@
+-- The id renumbering is irreversible (original placeholder IDs were meaningless);
+-- only the provider_id column is dropped.
+ALTER TABLE players DROP COLUMN IF EXISTS provider_id;

--- a/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
+++ b/cmd/db/migrations/000015_remap_unsafe_player_ids.up.sql
@@ -1,0 +1,29 @@
+-- ~471 players were seeded with random 18-19 digit placeholder IDs that exceed
+-- Number.MAX_SAFE_INTEGER, so the web client rounds them on JSON.parse and breaks
+-- award picks. players.id is a purely internal surrogate key, so renumber every
+-- player into one uniform sequential range and keep the real API-Football ID
+-- (where known) in a separate provider_id column.
+
+ALTER TABLE players ADD COLUMN provider_id BIGINT;
+UPDATE players SET provider_id = id WHERE id <= 9007199254740991;
+
+-- Ordered deterministically so the result is identical on every database.
+CREATE TEMP TABLE id_remap ON COMMIT DROP AS
+  SELECT id AS old_id,
+         row_number() OVER (ORDER BY team_fifa_code, name, id) AS new_id
+  FROM players;
+
+-- The FKs aren't ON UPDATE CASCADE, so drop them to remap the PK, then re-add.
+ALTER TABLE user_award_picks DROP CONSTRAINT user_award_picks_player_id_fkey;
+ALTER TABLE award_winners    DROP CONSTRAINT award_winners_player_id_fkey;
+
+UPDATE players p          SET id        = r.new_id FROM id_remap r WHERE p.id = r.old_id;
+UPDATE user_award_picks u SET player_id = r.new_id FROM id_remap r WHERE u.player_id = r.old_id;
+UPDATE award_winners a    SET player_id = r.new_id FROM id_remap r WHERE a.player_id = r.old_id;
+
+ALTER TABLE user_award_picks
+  ADD CONSTRAINT user_award_picks_player_id_fkey
+  FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE;
+ALTER TABLE award_winners
+  ADD CONSTRAINT award_winners_player_id_fkey
+  FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE RESTRICT;


### PR DESCRIPTION
## Release v1.0.1

Fixes award picks breaking for players whose IDs exceeded JavaScript's safe integer range.

### Fixes
- Remap all player IDs into a uniform, JS-safe sequential range so the web client no longer rounds large IDs and corrupts award picks (`PUT /api/awards` → 404).
- Preserve real API-Football IDs in a new `provider_id` column for future use.