### PR TITLE
chore: release v1.1.0

### DIFF
--- a/internal/app/routes_boards.go
+++ b/internal/app/routes_boards.go
@@ -7,40 +7,45 @@ import (
 
 func boardsRoutes(c *Container) chi.Router {
 	r := chi.NewRouter()
-	r.Use(middlewares.Auth(c.Authenticator, c.UserService, c.Logger))
 
-	r.Get("/", c.BoardHandler.GetUserBoards)
-	r.Post("/", c.BoardHandler.CreateBoard)
-	r.Post("/join", c.BoardHandler.JoinBoard)
+	r.Get("/preview", c.BoardHandler.GetBoardPreview)
 
-	r.Route("/{boardId}", func(r chi.Router) {
-		r.Use(middlewares.RequireBoardMembership(c.BoardMemberService))
+	r.Group(func(r chi.Router) {
+		r.Use(middlewares.Auth(c.Authenticator, c.UserService, c.Logger))
 
-		r.Get("/", c.BoardHandler.GetBoardByID)
-		r.Patch("/", c.BoardHandler.UpdateBoard)
-		r.Delete("/", c.BoardHandler.DeleteBoard)
-		r.Delete("/leave", c.BoardHandler.LeaveBoard)
-		r.Post("/regenerate-join-code", c.BoardHandler.RegenerateJoinCode)
+		r.Get("/", c.BoardHandler.GetUserBoards)
+		r.Post("/", c.BoardHandler.CreateBoard)
+		r.Post("/join", c.BoardHandler.JoinBoard)
 
-		r.Route("/members", func(r chi.Router) {
-			r.Get("/", c.BoardHandler.GetBoardMembers)
+		r.Route("/{boardId}", func(r chi.Router) {
+			r.Use(middlewares.RequireBoardMembership(c.BoardMemberService))
 
-			r.Route("/{userId}", func(r chi.Router) {
-				r.Use(middlewares.ParseUserID)
-				r.Patch("/role", c.BoardHandler.UpdateBoardMemberRole)
-				r.Delete("/", c.BoardHandler.RemoveBoardMember)
-				r.Post("/transfer-ownership", c.BoardHandler.TransferOwnership)
+			r.Get("/", c.BoardHandler.GetBoardByID)
+			r.Patch("/", c.BoardHandler.UpdateBoard)
+			r.Delete("/", c.BoardHandler.DeleteBoard)
+			r.Delete("/leave", c.BoardHandler.LeaveBoard)
+			r.Post("/regenerate-join-code", c.BoardHandler.RegenerateJoinCode)
+
+			r.Route("/members", func(r chi.Router) {
+				r.Get("/", c.BoardHandler.GetBoardMembers)
+
+				r.Route("/{userId}", func(r chi.Router) {
+					r.Use(middlewares.ParseUserID)
+					r.Patch("/role", c.BoardHandler.UpdateBoardMemberRole)
+					r.Delete("/", c.BoardHandler.RemoveBoardMember)
+					r.Post("/transfer-ownership", c.BoardHandler.TransferOwnership)
+				})
 			})
-		})
 
-		r.Route("/competitions", func(r chi.Router) {
-			r.Get("/", c.CompetitionHandler.GetBoardCompetitions)
-			r.Post("/", c.CompetitionHandler.CreateCompetition)
+			r.Route("/competitions", func(r chi.Router) {
+				r.Get("/", c.CompetitionHandler.GetBoardCompetitions)
+				r.Post("/", c.CompetitionHandler.CreateCompetition)
 
-			r.Route("/{competitionId}", func(r chi.Router) {
-				r.Use(middlewares.ParseCompetitionID)
-				r.Delete("/", c.CompetitionHandler.DeleteCompetition)
-				r.Get("/leaderboard", c.CompetitionHandler.GetLeaderboard)
+				r.Route("/{competitionId}", func(r chi.Router) {
+					r.Use(middlewares.ParseCompetitionID)
+					r.Delete("/", c.CompetitionHandler.DeleteCompetition)
+					r.Get("/leaderboard", c.CompetitionHandler.GetLeaderboard)
+				})
 			})
 		})
 	})

--- a/internal/domain/board.go
+++ b/internal/domain/board.go
@@ -44,6 +44,20 @@ type BoardMembersPage struct {
 	Pagination Pagination
 }
 
+type BoardPreview struct {
+	Name        string                `json:"name" example:"My Board"`
+	Privacy     BoardPrivacy          `json:"privacy" example:"private"`
+	MemberCount int                   `json:"member_count" example:"12"`
+	Members     []*BoardPreviewMember `json:"members"`
+}
+
+type BoardPreviewMember struct {
+	UserID    string `json:"user_id" example:"123e4567-e89b-12d3-a456-426614174000"`
+	UserName  string `json:"username" example:"johndoe"`
+	FirstName string `json:"first_name" example:"John"`
+	LastName  string `json:"last_name" example:"Doe"`
+}
+
 type BoardMembersFilters struct {
 	Search string
 }
@@ -62,6 +76,7 @@ type BoardRepository interface {
 	GetUserBoards(ctx context.Context, userID string) ([]*UserBoardListItem, error)
 	GetBoardByID(ctx context.Context, boardID int64) (*Board, error)
 	GetBoardDetails(ctx context.Context, boardID int64, userID string) (*BoardDetails, error)
+	GetBoardPreview(ctx context.Context, joinCode string, sampleSize int) (*BoardPreview, error)
 	GetBoardMembers(ctx context.Context, boardID int64, filters BoardMembersFilters, page, limit int) (*BoardMembersPage, error)
 	UpdateJoinCode(ctx context.Context, boardID int64, joinCode string) error
 	UpdateBoard(ctx context.Context, boardID int64, board *Board) error

--- a/internal/handlers/board_handler.go
+++ b/internal/handlers/board_handler.go
@@ -129,6 +129,29 @@ func (h *BoardHandler) JoinBoard(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// GetBoardPreview godoc
+//
+//	@Summary		Preview a board by join code
+//	@Description	Returns a public, non-sensitive summary of the board behind a join code (name, privacy, member count, and a small sample of members) for an invite landing page. No authentication required.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			code	query		string				true	"Board join code"
+//	@Success		200		{object}	httpx.Response		"Board preview retrieved successfully"
+//	@Failure		404		{object}	httpx.ErrorResponse	"No board matches the join code"
+//	@Failure		500		{object}	httpx.ErrorResponse	"Internal server error"
+//	@Router			/boards/preview [get]
+func (h *BoardHandler) GetBoardPreview(w http.ResponseWriter, r *http.Request) {
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+
+	preview, err := h.boardService.GetBoardPreview(r.Context(), code)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, preview)
+}
+
 // GetBoardByID godoc
 //
 //	@Summary		Get board details

--- a/internal/handlers/board_handler_test.go
+++ b/internal/handlers/board_handler_test.go
@@ -1177,3 +1177,64 @@ func TestBoardHandler_TransferOwnership(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
+
+// ---------------------------------------------------------------------------
+// TestBoardHandler_GetBoardPreview
+// ---------------------------------------------------------------------------
+func TestBoardHandler_GetBoardPreview(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 200 with preview data", func(t *testing.T) {
+		t.Parallel()
+
+		bs := &mocks.MockBoardService{
+			GetBoardPreviewFunc: func(ctx context.Context, joinCode string) (*domain.BoardPreview, error) {
+				assert.Equal(t, "SJKVOH7Y", joinCode)
+				return &domain.BoardPreview{
+					Name:        "Los Liberos",
+					Privacy:     domain.BoardPrivacyPrivate,
+					MemberCount: 18,
+					Members: []*domain.BoardPreviewMember{
+						{UserID: gofakeit.UUID(), UserName: "dmorales", FirstName: "Daniel", LastName: "Morales"},
+					},
+				}, nil
+			},
+		}
+
+		h := newTestBoardHandler(bs, nil)
+		req := testutils.MakeJSONRequest(t, http.MethodGet, "/boards/preview?code=SJKVOH7Y", nil)
+		w := httptest.NewRecorder()
+
+		h.GetBoardPreview(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data domain.BoardPreview `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "Los Liberos", resp.Data.Name)
+		assert.Equal(t, domain.BoardPrivacyPrivate, resp.Data.Privacy)
+		assert.Equal(t, 18, resp.Data.MemberCount)
+		assert.Len(t, resp.Data.Members, 1)
+		assert.Equal(t, "dmorales", resp.Data.Members[0].UserName)
+	})
+
+	t.Run("returns 404 when the code matches no board", func(t *testing.T) {
+		t.Parallel()
+
+		bs := &mocks.MockBoardService{
+			GetBoardPreviewFunc: func(ctx context.Context, joinCode string) (*domain.BoardPreview, error) {
+				return nil, domain.ErrBoardNotFound
+			},
+		}
+
+		h := newTestBoardHandler(bs, nil)
+		req := testutils.MakeJSONRequest(t, http.MethodGet, "/boards/preview?code=NOPE", nil)
+		w := httptest.NewRecorder()
+
+		h.GetBoardPreview(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/internal/repositories/board_repository.go
+++ b/internal/repositories/board_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -251,6 +252,65 @@ func (r *BoardRepository) GetBoardMembers(
 	membersPage.Pagination.HasMore = page*limit < membersPage.Pagination.Total
 
 	return membersPage, nil
+}
+
+func (r *BoardRepository) GetBoardPreview(
+	ctx context.Context,
+	joinCode string,
+	sampleSize int,
+) (*domain.BoardPreview, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	var preview domain.BoardPreview
+	var boardID int64
+
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			b.id,
+			b.name,
+			b.privacy,
+			(SELECT COUNT(*) FROM board_members WHERE board_id = b.id) AS member_count
+		FROM boards b
+		WHERE b.join_code = $1`,
+		joinCode,
+	).Scan(&boardID, &preview.Name, &preview.Privacy, &preview.MemberCount)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domain.ErrBoardNotFound
+		}
+		return nil, handleDBError(err, resourceBoard)
+	}
+
+	preview.Members = []*domain.BoardPreviewMember{}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT bm.user_id, u.username, u.first_name, u.last_name
+		FROM board_members bm
+		INNER JOIN users u ON u.id = bm.user_id
+		WHERE bm.board_id = $1
+		ORDER BY (bm.role = 'owner') DESC, bm.created_at ASC, bm.user_id ASC
+		LIMIT $2`,
+		boardID, sampleSize,
+	)
+	if err != nil {
+		return nil, handleDBError(err, resourceBoard)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var member domain.BoardPreviewMember
+		if err := rows.Scan(&member.UserID, &member.UserName, &member.FirstName, &member.LastName); err != nil {
+			return nil, handleDBError(err, resourceBoard)
+		}
+		preview.Members = append(preview.Members, &member)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, handleDBError(err, resourceBoard)
+	}
+
+	return &preview, nil
 }
 
 func (r *BoardRepository) GetBoardByID(ctx context.Context, boardID int64) (*domain.Board, error) {

--- a/internal/services/board_service.go
+++ b/internal/services/board_service.go
@@ -5,15 +5,19 @@ import (
 	"crypto/rand"
 	"errors"
 	"math/big"
+	"strings"
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/dtos"
 )
 
+const boardPreviewMemberSampleSize = 8
+
 type BoardServiceInterface interface {
 	CreateBoard(ctx context.Context, payload dtos.CreateBoardDto, userID string) (*domain.Board, error)
 	GetUserBoards(ctx context.Context, userID string) ([]*domain.UserBoardListItem, error)
 	GetBoardByID(ctx context.Context, boardID int64, userID string) (*domain.BoardDetails, error)
+	GetBoardPreview(ctx context.Context, joinCode string) (*domain.BoardPreview, error)
 	RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error)
 	UpdateBoard(ctx context.Context, boardID int64, role domain.BoardMemberRole, payload dtos.UpdateBoardDto) error
 	DeleteBoard(ctx context.Context, boardID int64, role domain.BoardMemberRole) error
@@ -109,6 +113,16 @@ func (s *BoardService) GetBoardByID(
 	userID string,
 ) (*domain.BoardDetails, error) {
 	return s.boardRepository.GetBoardDetails(ctx, boardID, userID)
+}
+
+func (s *BoardService) GetBoardPreview(ctx context.Context, joinCode string) (*domain.BoardPreview, error) {
+	// Join codes are uppercase; normalize so a stray-cased or padded link still resolves.
+	code := strings.ToUpper(strings.TrimSpace(joinCode))
+	if code == "" {
+		return nil, domain.ErrBoardNotFound
+	}
+
+	return s.boardRepository.GetBoardPreview(ctx, code, boardPreviewMemberSampleSize)
 }
 
 func (s *BoardService) RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {

--- a/internal/services/board_service_test.go
+++ b/internal/services/board_service_test.go
@@ -602,3 +602,69 @@ func TestBoardService_generateJoinCode(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// TestBoardService_GetBoardPreview
+// ---------------------------------------------------------------------------
+func TestBoardService_GetBoardPreview(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns preview and normalizes the code", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedCode string
+		var capturedSample int
+
+		br := &mocks.MockBoardRepository{
+			GetBoardPreviewFunc: func(ctx context.Context, joinCode string, sampleSize int) (*domain.BoardPreview, error) {
+				capturedCode = joinCode
+				capturedSample = sampleSize
+				return &domain.BoardPreview{
+					Name:        "Los Liberos",
+					Privacy:     domain.BoardPrivacyPrivate,
+					MemberCount: 18,
+					Members:     []*domain.BoardPreviewMember{{UserID: gofakeit.UUID(), UserName: "dmorales"}},
+				}, nil
+			},
+		}
+
+		service := newTestBoardService(br, nil)
+
+		result, err := service.GetBoardPreview(context.Background(), "  sjkvoh7y ")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "SJKVOH7Y", capturedCode)
+		assert.Equal(t, boardPreviewMemberSampleSize, capturedSample)
+		assert.Equal(t, "Los Liberos", result.Name)
+		assert.Equal(t, 18, result.MemberCount)
+		assert.Len(t, result.Members, 1)
+	})
+
+	t.Run("returns ErrBoardNotFound for a blank code without hitting the repo", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestBoardService(&mocks.MockBoardRepository{}, nil)
+
+		result, err := service.GetBoardPreview(context.Background(), "   ")
+
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, domain.ErrBoardNotFound)
+	})
+
+	t.Run("propagates repository ErrBoardNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		br := &mocks.MockBoardRepository{
+			GetBoardPreviewFunc: func(ctx context.Context, joinCode string, sampleSize int) (*domain.BoardPreview, error) {
+				return nil, domain.ErrBoardNotFound
+			},
+		}
+
+		service := newTestBoardService(br, nil)
+
+		result, err := service.GetBoardPreview(context.Background(), "BADCODE1")
+
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, domain.ErrBoardNotFound)
+	})
+}

--- a/internal/test/mocks/board_repository_mock.go
+++ b/internal/test/mocks/board_repository_mock.go
@@ -11,6 +11,7 @@ type MockBoardRepository struct {
 	GetUserBoardsFunc   func(ctx context.Context, userID string) ([]*domain.UserBoardListItem, error)
 	GetBoardByIDFunc    func(ctx context.Context, boardID int64) (*domain.Board, error)
 	GetBoardDetailsFunc func(ctx context.Context, boardID int64, userID string) (*domain.BoardDetails, error)
+	GetBoardPreviewFunc func(ctx context.Context, joinCode string, sampleSize int) (*domain.BoardPreview, error)
 	GetBoardMembersFunc func(ctx context.Context, boardID int64, filters domain.BoardMembersFilters, page, limit int) (*domain.BoardMembersPage, error)
 	UpdateJoinCodeFunc  func(ctx context.Context, boardID int64, joinCode string) error
 	UpdateBoardFunc     func(ctx context.Context, boardID int64, board *domain.Board) error
@@ -43,6 +44,13 @@ func (m *MockBoardRepository) GetBoardDetails(ctx context.Context, boardID int64
 		return m.GetBoardDetailsFunc(ctx, boardID, userID)
 	}
 	panic("GetBoardDetails called unexpectedly")
+}
+
+func (m *MockBoardRepository) GetBoardPreview(ctx context.Context, joinCode string, sampleSize int) (*domain.BoardPreview, error) {
+	if m.GetBoardPreviewFunc != nil {
+		return m.GetBoardPreviewFunc(ctx, joinCode, sampleSize)
+	}
+	panic("GetBoardPreview called unexpectedly")
 }
 
 func (m *MockBoardRepository) GetBoardMembers(ctx context.Context, boardID int64, filters domain.BoardMembersFilters, page, limit int) (*domain.BoardMembersPage, error) {

--- a/internal/test/mocks/board_service_mock.go
+++ b/internal/test/mocks/board_service_mock.go
@@ -11,6 +11,7 @@ type MockBoardService struct {
 	CreateBoardFunc        func(ctx context.Context, payload dtos.CreateBoardDto, userID string) (*domain.Board, error)
 	GetUserBoardsFunc      func(ctx context.Context, userID string) ([]*domain.UserBoardListItem, error)
 	GetBoardByIDFunc       func(ctx context.Context, boardID int64, userID string) (*domain.BoardDetails, error)
+	GetBoardPreviewFunc    func(ctx context.Context, joinCode string) (*domain.BoardPreview, error)
 	RegenerateJoinCodeFunc func(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error)
 	UpdateBoardFunc        func(ctx context.Context, boardID int64, role domain.BoardMemberRole, payload dtos.UpdateBoardDto) error
 	DeleteBoardFunc        func(ctx context.Context, boardID int64, role domain.BoardMemberRole) error
@@ -35,6 +36,13 @@ func (m *MockBoardService) GetBoardByID(ctx context.Context, boardID int64, user
 		return m.GetBoardByIDFunc(ctx, boardID, userID)
 	}
 	panic("GetBoardByID called unexpectedly")
+}
+
+func (m *MockBoardService) GetBoardPreview(ctx context.Context, joinCode string) (*domain.BoardPreview, error) {
+	if m.GetBoardPreviewFunc != nil {
+		return m.GetBoardPreviewFunc(ctx, joinCode)
+	}
+	panic("GetBoardPreview called unexpectedly")
 }
 
 func (m *MockBoardService) RegenerateJoinCode(ctx context.Context, boardID int64, role domain.BoardMemberRole) (string, error) {


### PR DESCRIPTION
## Release v1.1.0

Adds a public board preview for invite links.

### Highlights
- New public board preview endpoint, letting invitees see a board's basics from an invite link before joining (no auth required).