### PR TITLE
fix: sliding sessions + refresh rotation races + diagnostics

### DIFF
--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -6,14 +6,13 @@ import (
 )
 
 type RefreshToken struct {
-	ID               string     `json:"id"`
-	UserID           string     `json:"user_id"`
-	SessionID        string     `json:"session_id"`
-	TokenHash        string     `json:"token_hash"`
-	ExpiresAt        time.Time  `json:"expires_at"`
-	RotatedAt        *time.Time `json:"rotated_at"`
-	CreatedAt        time.Time  `json:"created_at"`
-	SessionExpiresAt time.Time  `json:"session_expires_at"`
+	ID        string     `json:"id"`
+	UserID    string     `json:"user_id"`
+	SessionID string     `json:"session_id"`
+	TokenHash string     `json:"token_hash"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	RotatedAt *time.Time `json:"rotated_at"`
+	CreatedAt time.Time  `json:"created_at"`
 }
 
 type RefreshTokenRepository interface {

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -20,7 +20,7 @@ type Session struct {
 type SessionRepository interface {
 	CreateSession(ctx context.Context, session *Session) error
 	GetSessions(ctx context.Context, refreshTokenHash string) ([]Session, error)
-	UpdateLastUsedAt(ctx context.Context, id string) error
+	UpdateLastUsedAt(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error)
 	DeleteSession(ctx context.Context, refreshTokenHash string) error
 	DeleteAllSessions(ctx context.Context, refreshTokenHash string) error
 	DeleteSessionById(ctx context.Context, sessionID string, userID string) error

--- a/internal/handlers/auth_handler.go
+++ b/internal/handlers/auth_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/fifawcp/api/internal/dtos"
@@ -11,6 +12,7 @@ import (
 	"github.com/fifawcp/api/internal/infrastructure/validator"
 	"github.com/fifawcp/api/internal/services"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 type AuthHandler struct {
@@ -156,7 +158,12 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authResponse, err := h.authService.RefreshToken(r.Context(), refreshToken)
+	ctx := context.WithValue(r.Context(), httpctx.RefreshDiagnosticsContextKey, &httpctx.RefreshDiagnostics{
+		RequestID: middleware.GetReqID(r.Context()),
+		Source:    r.Header.Get("X-Refresh-Source"),
+	})
+
+	authResponse, err := h.authService.RefreshToken(ctx, refreshToken)
 	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return

--- a/internal/httpctx/context.go
+++ b/internal/httpctx/context.go
@@ -10,22 +10,36 @@ import (
 type ContextKey string
 
 const (
-	RequestInfoContextKey       ContextKey = "request_info"
-	AuthenticatedUserContextKey ContextKey = "authenticated_user"
-	BoardIDContextKey           ContextKey = "board_id"
-	BoardMemberRoleContextKey   ContextKey = "board_member_role"
-	UserIDContextKey            ContextKey = "user_id"
-	MatchIDContextKey           ContextKey = "match_id"
-	CompetitionIDContextKey     ContextKey = "competition_id"
-	ReturnToContextKey          ContextKey = "return_to"
-	OAuthStateContextKey        ContextKey = "oauth_state"
-	OAuthCodeContextKey         ContextKey = "oauth_code"
-	ResponseErrorContextKey     ContextKey = "response_error"
+	RequestInfoContextKey        ContextKey = "request_info"
+	AuthenticatedUserContextKey  ContextKey = "authenticated_user"
+	BoardIDContextKey            ContextKey = "board_id"
+	BoardMemberRoleContextKey    ContextKey = "board_member_role"
+	UserIDContextKey             ContextKey = "user_id"
+	MatchIDContextKey            ContextKey = "match_id"
+	CompetitionIDContextKey      ContextKey = "competition_id"
+	ReturnToContextKey           ContextKey = "return_to"
+	OAuthStateContextKey         ContextKey = "oauth_state"
+	OAuthCodeContextKey          ContextKey = "oauth_code"
+	ResponseErrorContextKey      ContextKey = "response_error"
+	RefreshDiagnosticsContextKey ContextKey = "refresh_diagnostics"
 )
 
 type ResponseError struct {
 	Code    string
 	Message string
+}
+
+type RefreshDiagnostics struct {
+	RequestID string
+	Source    string
+}
+
+func GetRefreshDiagnostics(ctx context.Context) *RefreshDiagnostics {
+	diagnostics, ok := ctx.Value(RefreshDiagnosticsContextKey).(*RefreshDiagnostics)
+	if !ok {
+		return nil
+	}
+	return diagnostics
 }
 
 func GetResponseError(ctx context.Context) *ResponseError {

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -79,11 +79,12 @@ type JWTConfig struct {
 }
 
 type AuthConfig struct {
-	SessionTTL     time.Duration
-	OTPTTL         time.Duration
-	MaxOTPAttempts int
-	OTPCooldown    time.Duration
-	GoogleOAuth    OAuthConfig
+	SessionTTL         time.Duration
+	SessionMaxLifetime time.Duration
+	OTPTTL             time.Duration
+	MaxOTPAttempts     int
+	OTPCooldown        time.Duration
+	GoogleOAuth        OAuthConfig
 }
 
 type OAuthConfig struct {
@@ -159,13 +160,14 @@ func NewConfig() *Config {
 			Issuer:             env.GetString("JWT_ISSUER", "fifa-wcp"),
 			AccessTokenExpiry:  env.GetDuration("JWT_ACCESS_TOKEN_EXPIRY", 15*time.Minute),
 			RefreshTokenExpiry: env.GetDuration("JWT_REFRESH_TOKEN_EXPIRY", 7*24*time.Hour),
-			RefreshGraceWindow: env.GetDuration("JWT_REFRESH_GRACE_WINDOW", 10*time.Second),
+			RefreshGraceWindow: env.GetDuration("JWT_REFRESH_GRACE_WINDOW", 20*time.Second),
 		},
 		Auth: AuthConfig{
-			SessionTTL:     env.GetDuration("AUTH_SESSION_TTL", 7*24*time.Hour),
-			OTPTTL:         env.GetDuration("AUTH_OTP_TTL", 10*time.Minute),
-			MaxOTPAttempts: env.GetInt("AUTH_MAX_OTP_ATTEMPTS", 3),
-			OTPCooldown:    env.GetDuration("AUTH_OTP_COOLDOWN", 30*time.Second),
+			SessionTTL:         env.GetDuration("AUTH_SESSION_TTL", 7*24*time.Hour),
+			SessionMaxLifetime: env.GetDuration("AUTH_SESSION_MAX_LIFETIME", 30*24*time.Hour),
+			OTPTTL:             env.GetDuration("AUTH_OTP_TTL", 10*time.Minute),
+			MaxOTPAttempts:     env.GetInt("AUTH_MAX_OTP_ATTEMPTS", 3),
+			OTPCooldown:        env.GetDuration("AUTH_OTP_COOLDOWN", 30*time.Second),
 			GoogleOAuth: OAuthConfig{
 				ClientID:          env.GetString("GOOGLE_OAUTH_CLIENT_ID", ""),
 				ClientSecret:      env.GetString("GOOGLE_OAUTH_CLIENT_SECRET", ""),

--- a/internal/infrastructure/logging/fields.go
+++ b/internal/infrastructure/logging/fields.go
@@ -12,6 +12,16 @@ const (
 	Outcome    = "outcome"     // "success" | "user_error" | "server_error"
 )
 
+const (
+	SessionID        = "session_id"
+	RefreshOutcome   = "refresh_outcome" // success | rotated_past_grace | not_found_or_expired
+	RefreshSource    = "refresh_source"  // client | middleware
+	RotatedAgeMS     = "rotated_age_ms"  // small == concurrent race
+	GraceWindowMS    = "grace_window_ms"
+	TokenAgeMS       = "token_age_ms"
+	TokenFingerprint = "token_fp"
+)
+
 // Audit-specific fields
 const (
 	LogName    = "log_name"    // always "audit" — filters audit vs operational logs

--- a/internal/repositories/refresh_token_repository.go
+++ b/internal/repositories/refresh_token_repository.go
@@ -61,10 +61,8 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	// Join sessions so we can enforce session expiry at lookup time and carry
-	// session.expires_at to the service for capping the rotated token's TTL.
-	// rotated_at is carried too: a rotated-but-unexpired row is still returned so
-	// the service can grant it the grace window (or reject it as stale reuse).
+	// Join sessions to enforce session expiry at lookup time. rotated_at is carried so
+	// the service can grant the grace window (or reject the token as stale reuse).
 	query := `SELECT
 		rt.id,
 		rt.user_id,
@@ -72,8 +70,7 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 		rt.token_hash,
 		rt.expires_at,
 		rt.rotated_at,
-		rt.created_at,
-		s.expires_at AS session_expires_at
+		rt.created_at
 	FROM refresh_tokens rt
 	JOIN sessions s ON s.id = rt.session_id
 	WHERE rt.token_hash = $1
@@ -90,7 +87,6 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 		&refreshToken.ExpiresAt,
 		&refreshToken.RotatedAt,
 		&refreshToken.CreatedAt,
-		&refreshToken.SessionExpiresAt,
 	)
 
 	if err != nil {
@@ -100,17 +96,11 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 	return &refreshToken, nil
 }
 
-// RotateRefreshToken supersedes the presented token and issues the new one in a
-// single statement:
-//  1. mark the old token rotated (idempotent — a concurrent caller may have
-//     already marked it; we still issue the new token so the race loser keeps a
-//     working session),
-//  2. prune the session's *previous* grace token (any rotated row other than the
-//     one we just superseded), bounding an active session to ≤2 rows,
-//  3. insert the new token.
-//
-// The caller is responsible for validating the old token (existence, expiry,
-// grace window) before calling this.
+// RotateRefreshToken marks the presented token rotated and issues a new one in one
+// statement. The prune drops the session's spent tokens but keeps any still inside the
+// grace window, so concurrent refreshes (middleware + client) don't delete a token
+// another in-flight request is about to redeem. The presented token is never pruned;
+// the caller validates it first.
 func (r *RefreshTokenRepository) RotateRefreshToken(
 	ctx context.Context,
 	oldTokenHash string,
@@ -127,7 +117,10 @@ func (r *RefreshTokenRepository) RotateRefreshToken(
 	),
 	pruned AS (
 		DELETE FROM refresh_tokens
-		WHERE session_id = $3 AND rotated_at IS NOT NULL AND token_hash <> $1
+		WHERE session_id = $3
+		  AND token_hash <> $1
+		  AND created_at < NOW() - make_interval(secs => $6)
+		  AND (rotated_at IS NULL OR rotated_at < NOW() - make_interval(secs => $6))
 		RETURNING id
 	)
 	INSERT INTO refresh_tokens (
@@ -147,6 +140,7 @@ func (r *RefreshTokenRepository) RotateRefreshToken(
 		newToken.SessionID,
 		newToken.TokenHash,
 		newToken.ExpiresAt,
+		r.cfg.JWT.RefreshGraceWindow.Seconds(),
 	).Scan(&newToken.ID)
 
 	if err != nil {

--- a/internal/repositories/session_repository.go
+++ b/internal/repositories/session_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/infrastructure/config"
@@ -114,29 +115,37 @@ func (r *SessionRepository) GetSessions(
 	return sessions, nil
 }
 
+// UpdateLastUsedAt touches the session and slides its expiry to slideTo, capped at
+// created_at + maxLifetime. expires_at only ever grows. It returns the resulting
+// expiry so the caller can cap the rotated refresh token to it.
 func (r *SessionRepository) UpdateLastUsedAt(
 	ctx context.Context,
 	id string,
-) error {
+	slideTo time.Time,
+	maxLifetime time.Duration,
+) (time.Time, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	query := `UPDATE sessions SET last_used_at = NOW() WHERE id = $1 AND expires_at > NOW()`
-	result, err := r.db.ExecContext(ctx, query, id)
+	query := `UPDATE sessions
+		SET last_used_at = NOW(),
+			expires_at = GREATEST(
+				expires_at,
+				LEAST($2::timestamptz, created_at + make_interval(secs => $3))
+			)
+		WHERE id = $1 AND expires_at > NOW()
+		RETURNING expires_at`
+
+	var expiresAt time.Time
+	err := r.db.QueryRowContext(ctx, query, id, slideTo, maxLifetime.Seconds()).Scan(&expiresAt)
 	if err != nil {
-		return handleDBError(err, resourceSession)
+		if err == sql.ErrNoRows {
+			return time.Time{}, domain.ErrRefreshTokenInvalidOrExpired
+		}
+		return time.Time{}, handleDBError(err, resourceSession)
 	}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return handleDBError(err, resourceSession)
-	}
-
-	if rowsAffected == 0 {
-		return domain.ErrRefreshTokenInvalidOrExpired
-	}
-
-	return nil
+	return expiresAt, nil
 }
 
 func (r *SessionRepository) DeleteSession(

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/httpctx"
 	"github.com/fifawcp/api/internal/infrastructure/auth"
 	"github.com/fifawcp/api/internal/infrastructure/config"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
@@ -189,21 +190,21 @@ func (s *AuthService) RefreshToken(
 	ctx context.Context,
 	refreshTokenString string,
 ) (*dtos.AuthData, error) {
-	// Validate refresh token
-	refreshToken, err := s.refreshTokenRepository.GetRefreshTokenByTokenHash(ctx, hashToken(refreshTokenString))
+	tokenHash := hashToken(refreshTokenString)
+	refreshToken, err := s.refreshTokenRepository.GetRefreshTokenByTokenHash(ctx, tokenHash)
 	if err != nil {
 		if errors.Is(err, domain.ErrRefreshTokenNotFound) {
+			s.logRefreshOutcome(ctx, "not_found_or_expired", tokenHash, nil)
 			return nil, domain.ErrRefreshTokenInvalidOrExpired
 		}
 
 		return nil, err
 	}
 
-	// A token already superseded by rotation is honored only inside the grace
-	// window — this lets concurrent refreshes (e.g. the web middleware and client
-	// racing on the same cookie) both succeed instead of logging the user out.
-	// Reuse past the window is treated as invalid.
+	// A rotated token is still honored inside the grace window so concurrent refreshes
+	// don't log the user out; past the window it's invalid.
 	if refreshToken.RotatedAt != nil && time.Since(*refreshToken.RotatedAt) > s.cfg.JWT.RefreshGraceWindow {
+		s.logRefreshOutcome(ctx, "rotated_past_grace", tokenHash, refreshToken)
 		return nil, domain.ErrRefreshTokenInvalidOrExpired
 	}
 
@@ -219,9 +220,22 @@ func (s *AuthService) RefreshToken(
 		return nil, err
 	}
 
+	// Slide the session expiry forward (bounded by SessionMaxLifetime) before rotating,
+	// so the new refresh token can be capped to the post-slide expiry rather than the
+	// stale pre-slide one — otherwise an active session's token would be clamped short.
+	sessionExpiresAt, err := s.sessionRepository.UpdateLastUsedAt(
+		ctx,
+		refreshToken.SessionID,
+		time.Now().Add(s.cfg.Auth.SessionTTL),
+		s.cfg.Auth.SessionMaxLifetime,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	refreshTokenExpiresAt := refreshTokenResult.ExpiresAt
-	if refreshTokenExpiresAt.After(refreshToken.SessionExpiresAt) {
-		refreshTokenExpiresAt = refreshToken.SessionExpiresAt
+	if refreshTokenExpiresAt.After(sessionExpiresAt) {
+		refreshTokenExpiresAt = sessionExpiresAt
 	}
 
 	// Rotate refresh token
@@ -234,16 +248,50 @@ func (s *AuthService) RefreshToken(
 		return nil, err
 	}
 
-	// Update session last_used_at
-	if err := s.sessionRepository.UpdateLastUsedAt(ctx, refreshToken.SessionID); err != nil {
-		return nil, err
-	}
+	s.logRefreshOutcome(ctx, "success", tokenHash, refreshToken)
 
 	return &dtos.AuthData{
 		AccessToken:  accessTokenResult.Token,
 		RefreshToken: refreshTokenResult.Token,
 		ExpiresAt:    refreshTokenResult.ExpiresAt,
 	}, nil
+}
+
+// logRefreshOutcome emits one structured line per refresh attempt. rt is nil when no
+// live row was found. Only a hash fingerprint is logged, never the raw token.
+func (s *AuthService) logRefreshOutcome(ctx context.Context, outcome, tokenHash string, rt *domain.RefreshToken) {
+	fields := []any{
+		logging.RefreshOutcome, outcome,
+		logging.TokenFingerprint, tokenHash[:8],
+		logging.GraceWindowMS, s.cfg.JWT.RefreshGraceWindow.Milliseconds(),
+	}
+
+	if rt != nil {
+		fields = append(fields, logging.UserID, rt.UserID, logging.SessionID, rt.SessionID)
+		if !rt.CreatedAt.IsZero() {
+			fields = append(fields, logging.TokenAgeMS, time.Since(rt.CreatedAt).Milliseconds())
+		}
+		if rt.RotatedAt != nil {
+			fields = append(fields, logging.RotatedAgeMS, time.Since(*rt.RotatedAt).Milliseconds())
+		}
+	}
+
+	if diagnostics := httpctx.GetRefreshDiagnostics(ctx); diagnostics != nil {
+		if diagnostics.RequestID != "" {
+			fields = append(fields, logging.RequestID, diagnostics.RequestID)
+		}
+		if diagnostics.Source != "" {
+			fields = append(fields, logging.RefreshSource, diagnostics.Source)
+		}
+	}
+
+	// rotated_past_grace is the real anomaly (race lost past the window / reuse);
+	// success and the benign not_found_or_expired stay at info to avoid warn noise.
+	if outcome == "rotated_past_grace" {
+		s.logger.Warn("refresh outcome", fields...)
+	} else {
+		s.logger.Info("refresh outcome", fields...)
+	}
 }
 
 func (s *AuthService) Logout(ctx context.Context, refreshToken string) error {

--- a/internal/services/auth_service_test.go
+++ b/internal/services/auth_service_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/infrastructure/auth"
 	"github.com/fifawcp/api/internal/infrastructure/config"
-	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/fifawcp/api/internal/infrastructure/totp"
+	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,9 +34,10 @@ func newTestAuthService(
 			RefreshGraceWindow: 10 * time.Second,
 		},
 		Auth: config.AuthConfig{
-			OTPCooldown:    30 * time.Second,
-			MaxOTPAttempts: 3,
-			SessionTTL:     24 * time.Hour,
+			OTPCooldown:        30 * time.Second,
+			MaxOTPAttempts:     3,
+			SessionTTL:         24 * time.Hour,
+			SessionMaxLifetime: 72 * time.Hour,
 		},
 	}
 
@@ -1114,9 +1115,12 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
 				assert.Equal(t, sessionID, id)
-				return nil
+				// expiry slides to now + SessionTTL, bounded by SessionMaxLifetime
+				assert.WithinDuration(t, time.Now().Add(24*time.Hour), slideTo, time.Minute)
+				assert.Equal(t, 72*time.Hour, maxLifetime)
+				return slideTo, nil
 			},
 		}
 
@@ -1158,7 +1162,9 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error { return nil },
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
 		}
 
 		authenticator := &mocks.MockAuthenticator{
@@ -1252,8 +1258,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return errors.New("database error")
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return time.Time{}, errors.New("database error")
 			},
 		}
 
@@ -1288,8 +1294,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return nil
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
 			},
 		}
 
@@ -1328,8 +1334,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return nil
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
 			},
 		}
 
@@ -1367,13 +1373,19 @@ func TestAuthService_RefreshToken(t *testing.T) {
 			},
 		}
 
+		sr := &mocks.MockSessionRepository{
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
+		}
+
 		authenticator := &mocks.MockAuthenticator{
 			GenerateTokenFunc: func(uid string, tokenType auth.TokenType) (*auth.TokenResult, error) {
 				return &auth.TokenResult{Token: "access-token", ExpiresAt: time.Now().Add(time.Hour)}, nil
 			},
 		}
 
-		service := newTestAuthService(nil, nil, rtr, nil, &mocks.MockLogger{}, authenticator, nil)
+		service := newTestAuthService(nil, sr, rtr, nil, &mocks.MockLogger{}, authenticator, nil)
 
 		result, err := service.RefreshToken(context.Background(), "token")
 

--- a/internal/test/mocks/session_repository_mock.go
+++ b/internal/test/mocks/session_repository_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"github.com/fifawcp/api/internal/domain"
 )
@@ -9,7 +10,7 @@ import (
 type MockSessionRepository struct {
 	CreateSessionFunc         func(ctx context.Context, session *domain.Session) error
 	GetSessionsFunc           func(ctx context.Context, refreshTokenHash string) ([]domain.Session, error)
-	UpdateLastUsedAtFunc      func(ctx context.Context, id string) error
+	UpdateLastUsedAtFunc      func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error)
 	DeleteSessionFunc         func(ctx context.Context, refreshTokenHash string) error
 	DeleteAllSessionsFunc     func(ctx context.Context, refreshTokenHash string) error
 	DeleteSessionByIdFunc     func(ctx context.Context, sessionID string, userID string) error
@@ -30,9 +31,9 @@ func (m *MockSessionRepository) GetSessions(ctx context.Context, refreshTokenHas
 	panic("GetSessions called unexpectedly")
 }
 
-func (m *MockSessionRepository) UpdateLastUsedAt(ctx context.Context, id string) error {
+func (m *MockSessionRepository) UpdateLastUsedAt(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
 	if m.UpdateLastUsedAtFunc != nil {
-		return m.UpdateLastUsedAtFunc(ctx, id)
+		return m.UpdateLastUsedAtFunc(ctx, id, slideTo, maxLifetime)
 	}
 	panic("UpdateLastUsedAt called unexpectedly")
 }


### PR DESCRIPTION
## Related issue

None.

## What changed

- Sessions now slide their expiry forward on each refresh (capped at a new 30-day `AUTH_SESSION_MAX_LIFETIME`) instead of a fixed 7-day cap, so active users stay logged in.
- Refresh-token rotation prune keeps tokens still inside the grace window, fixing the concurrent middleware+client `REFRESH_TOKEN_INVALID_OR_EXPIRED` storms; still reaps orphaned rows.
- Grace window default 10s → 20s (`JWT_REFRESH_GRACE_WINDOW`, env-overridable).
- Added structured `refresh outcome` logging (user/session, outcome, token ages, source) to diagnose refresh failures.

## How to test

- [ ] Log in, then fire 3 concurrent `POST /api/auth/token/refresh` with the same cookie → all 200 (no 401 storm).
- [ ] Replay a just-rotated token within the grace window → 200; after it → 401 `rotated_past_grace`.
- [ ] Refresh repeatedly; `SELECT expires_at FROM sessions WHERE id='…'` slides forward, plateauing at `created_at + 30d`.
- [ ] Send a garbage `refresh_token` cookie → 401, logged as `refresh_outcome=not_found_or_expired`.
- [ ] Tail server logs for `refresh outcome` lines (`refresh_outcome`, `session_id`, `refresh_source`).