### PR TITLE
feat: add pool competition type for single-match leaderboards

### DIFF
--- a/cmd/db/migrations/000016_create_competition_pool.down.sql
+++ b/cmd/db/migrations/000016_create_competition_pool.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_competitions_one_pool_per_match;
+ALTER TABLE competitions DROP CONSTRAINT IF EXISTS chk_competition_pool_match;
+ALTER TABLE competitions DROP CONSTRAINT IF EXISTS chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match'));
+ALTER TABLE competitions DROP COLUMN IF EXISTS match_id;

--- a/cmd/db/migrations/000016_create_competition_pool.up.sql
+++ b/cmd/db/migrations/000016_create_competition_pool.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE competitions ADD COLUMN match_id BIGINT REFERENCES matches(id) ON DELETE CASCADE;
+
+-- Postgres cannot edit a CHECK in place; drop and re-add to allow the new type.
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pool'));
+
+-- match_id is present iff the competition is a pool.
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_pool_match
+    CHECK ((type = 'pool') = (match_id IS NOT NULL));
+
+-- At most one pool per match per board.
+CREATE UNIQUE INDEX idx_competitions_one_pool_per_match
+    ON competitions(board_id, match_id) WHERE type = 'pool';

--- a/internal/domain/competition.go
+++ b/internal/domain/competition.go
@@ -10,16 +10,18 @@ type CompetitionType string
 const (
 	CompetitionTypePickem CompetitionType = "pickem"
 	CompetitionTypeMatch  CompetitionType = "match"
+	CompetitionTypePool   CompetitionType = "pool"
 )
 
 type Competition struct {
-	ID        int64             `json:"id" example:"1"`
-	BoardID   int64             `json:"board_id" example:"1"`
-	Type      CompetitionType   `json:"type" example:"pickem"`
-	Name      string            `json:"name" example:"Pick'em"`
-	CreatedBy *string           `json:"-"`
-	CreatedAt time.Time         `json:"created_at" example:"2026-01-15T10:30:00Z"`
-	Scope     *CompetitionScope `json:"scope,omitempty"`
+	ID          int64             `json:"id" example:"1"`
+	BoardID     int64             `json:"board_id" example:"1"`
+	Type        CompetitionType   `json:"type" example:"pickem"`
+	Name        string            `json:"name" example:"Pick'em"`
+	CreatedBy   *string           `json:"-"`
+	CreatedAt   time.Time         `json:"created_at" example:"2026-01-15T10:30:00Z"`
+	Scope       *CompetitionScope `json:"scope,omitempty"`
+	PoolMatchID *int64            `json:"pool_match_id,omitempty" example:"42"`
 }
 
 // CompetitionScope is only populated for match competitions

--- a/internal/domain/competition_score.go
+++ b/internal/domain/competition_score.go
@@ -17,7 +17,9 @@ type CompetitionUserStats struct {
 
 type CompetitionScoreRepository interface {
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
 	BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error
 	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*CompetitionLeaderboardPage, error)
 	GetUserPickemStats(ctx context.Context, competitionID int64, userID string) (CompetitionUserStats, error)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -110,6 +110,7 @@ var ErrCompetitionForbidden = errors.New("only board owner or admins can manage 
 var ErrCompetitionPickemAlreadyExists = errors.New("a tournament pick'em competition already exists on this board")
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
 var ErrCompetitionPickemNotDeletable = errors.New("the tournament pick'em competition cannot be deleted")
+var ErrDuplicatePoolForMatch = errors.New("a pool for this match already exists on this board")
 
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")

--- a/internal/dtos/competition_dto.go
+++ b/internal/dtos/competition_dto.go
@@ -8,7 +8,8 @@ type CreateCompetitionScopeDto struct {
 }
 
 type CreateCompetitionDto struct {
-	Type  domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match" example:"pickem"`
-	Name  string                     `json:"name" validate:"required,max=20" example:"Pick'em"`
-	Scope *CreateCompetitionScopeDto `json:"scope,omitempty"`
+	Type    domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match pool" example:"pickem"`
+	Name    string                     `json:"name" validate:"required,max=20" example:"Pick'em"`
+	Scope   *CreateCompetitionScopeDto `json:"scope,omitempty"`
+	MatchID *int64                     `json:"match_id,omitempty" example:"42"`
 }

--- a/internal/handlers/award_handler.go
+++ b/internal/handlers/award_handler.go
@@ -75,7 +75,7 @@ func (h *AwardHandler) GetUserAwards(w http.ResponseWriter, r *http.Request) {
 //	@Description	Returns the most-picked players per award (across all users), ranked desc by pick count then alphabetically. Eligibility is enforced per award: Golden Glove restricts to goalkeepers; Young Player restricts to players within the age cap (unknown ages are treated as eligible). Boot and Ball draw from the full catalog. Useful for the awards picker UI's "top choices" section.
 //	@Tags			awards
 //	@Produce		json
-//	@Param			limit	query		int	false	"Top-N per award (1-50)"	default(10)
+//	@Param			limit	query		int							false	"Top-N per award (1-50)"	default(10)
 //	@Success		200		{object}	domain.PopularPicksByAward	"Top picks grouped by award type"
 //	@Failure		400		{object}	httpx.ErrorResponse			"Invalid limit"
 //	@Failure		401		{object}	httpx.ErrorResponse			"Missing or invalid Bearer token"

--- a/internal/handlers/competition_handler_test.go
+++ b/internal/handlers/competition_handler_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/httpx"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCompetitionHandler(cs *mocks.MockCompetitionService) *CompetitionHandler {
+	return NewCompetitionHandler(cs, testutils.NewTestConfig(), validator.NewValidator(), &mocks.MockLogger{})
+}
+
+func makeCreatePoolReq(t *testing.T, body any) *http.Request {
+	return testutils.MakeJSONRequest(
+		t, http.MethodPost, "/boards/1/competitions", body,
+		testutils.WithAuthUser(testutils.CreateTestUser()),
+		testutils.WithBoardID(1),
+		testutils.WithBoardMemberRole(domain.BoardMemberRoleAdmin),
+	)
+}
+
+func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
+	t.Parallel()
+
+	matchID := int64(42)
+
+	t.Run("returns 201 on success", func(t *testing.T) {
+		t.Parallel()
+
+		cs := &mocks.MockCompetitionService{
+			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+				return &domain.CompetitionListItem{
+					Competition: domain.Competition{ID: 9, BoardID: boardID, Type: domain.CompetitionTypePool, Name: payload.Name, PoolMatchID: payload.MatchID},
+				}, nil
+			},
+		}
+		h := newTestCompetitionHandler(cs)
+
+		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		w := httptest.NewRecorder()
+
+		h.CreateCompetition(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code)
+		var resp struct {
+			Data domain.CompetitionListItem `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, domain.CompetitionTypePool, resp.Data.Type)
+		require.NotNil(t, resp.Data.PoolMatchID)
+		assert.Equal(t, matchID, *resp.Data.PoolMatchID)
+	})
+
+	t.Run("returns 409 when a pool already exists for the match", func(t *testing.T) {
+		t.Parallel()
+
+		cs := &mocks.MockCompetitionService{
+			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+				return nil, domain.ErrDuplicatePoolForMatch
+			},
+		}
+		h := newTestCompetitionHandler(cs)
+
+		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		w := httptest.NewRecorder()
+
+		h.CreateCompetition(w, req)
+
+		require.Equal(t, http.StatusConflict, w.Code)
+		var resp httpx.ErrorResponse
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "DUPLICATE_POOL_FOR_MATCH", resp.Error.Code)
+	})
+}

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -31,6 +31,7 @@ const (
 	codeCompetitionPickemAlreadyExists = "COMPETITION_PICKEM_ALREADY_EXISTS"
 	codeCompetitionNameAlreadyExists   = "COMPETITION_NAME_ALREADY_EXISTS"
 	codeCompetitionPickemNotDeletable  = "COMPETITION_PICKEM_NOT_DELETABLE"
+	codeDuplicatePoolForMatch          = "DUPLICATE_POOL_FOR_MATCH"
 
 	// 401 Unauthorized
 	codeOTPInvalidOrExpired          = "OTP_INVALID_OR_EXPIRED"
@@ -233,6 +234,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.BadRequest(w, r, codeCannotTransferToSelf, domain.ErrCannotTransferOwnershipToSelf.Error())
 	case errors.Is(err, domain.ErrCompetitionNameAlreadyExists):
 		httpx.Conflict(w, r, codeCompetitionNameAlreadyExists, domain.ErrCompetitionNameAlreadyExists.Error())
+	case errors.Is(err, domain.ErrDuplicatePoolForMatch):
+		httpx.Conflict(w, r, codeDuplicatePoolForMatch, domain.ErrDuplicatePoolForMatch.Error())
 
 	// 502 Bad Gateway
 	case errors.Is(err, domain.ErrMissingIDToken):

--- a/internal/handlers/player_handler.go
+++ b/internal/handlers/player_handler.go
@@ -31,14 +31,14 @@ func NewPlayerHandler(playerService services.PlayerServiceInterface, logger logg
 //	@Description	Search the tournament player catalog. All filters are optional and combine with AND. `q` is a case-insensitive substring match across name, first name and last name. `team_fifa_codes` and `positions` accept comma-separated values (or the param repeated) and match if the player's value is in the supplied set. Results are paginated.
 //	@Tags			players
 //	@Produce		json
-//	@Param			q					query		string				false	"Case-insensitive substring match across name, first_name and last_name"
-//	@Param			team_fifa_codes		query		[]string			false	"Filter by team FIFA codes (e.g. MEX,COL). Comma-separated or repeated."	collectionFormat(csv)
-//	@Param			positions			query		[]string			false	"Filter by positions. Comma-separated or repeated."	collectionFormat(csv)	Enums(goalkeeper,defender,midfielder,attacker)
-//	@Param			page				query		int					false	"Page number (1-based)"	default(1)
-//	@Param			limit				query		int					false	"Page size (max 100)"	default(20)
-//	@Success		200					{object}	httpx.Response		"Paginated list of players"
-//	@Failure		400					{object}	httpx.ErrorResponse	"Invalid query parameters"
-//	@Failure		401					{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Param			q				query		string				false	"Case-insensitive substring match across name, first_name and last_name"
+//	@Param			team_fifa_codes	query		[]string			false	"Filter by team FIFA codes (e.g. MEX,COL). Comma-separated or repeated."	collectionFormat(csv)
+//	@Param			positions		query		[]string			false	"Filter by positions. Comma-separated or repeated."							collectionFormat(csv)	Enums(goalkeeper,defender,midfielder,attacker)
+//	@Param			page			query		int					false	"Page number (1-based)"														default(1)
+//	@Param			limit			query		int					false	"Page size (max 100)"														default(20)
+//	@Success		200				{object}	httpx.Response		"Paginated list of players"
+//	@Failure		400				{object}	httpx.ErrorResponse	"Invalid query parameters"
+//	@Failure		401				{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
 //	@Security		BearerAuth
 //	@Router			/players [get]
 func (h *PlayerHandler) SearchPlayers(w http.ResponseWriter, r *http.Request) {

--- a/internal/infrastructure/validator/validator.go
+++ b/internal/infrastructure/validator/validator.go
@@ -178,6 +178,13 @@ func validateCreateCompetition(sl validator.StructLevel) {
 		if input.Scope == nil || len(input.Scope.Stages) == 0 {
 			sl.ReportError(input.Scope, "scope", "Scope", "scope_required", "")
 		}
+	case domain.CompetitionTypePool:
+		if input.Scope != nil {
+			sl.ReportError(input.Scope, "scope", "Scope", "scope_forbidden", "")
+		}
+		if input.MatchID == nil {
+			sl.ReportError(input.MatchID, "match_id", "MatchID", "required", "")
+		}
 	}
 }
 

--- a/internal/infrastructure/validator/validator_test.go
+++ b/internal/infrastructure/validator/validator_test.go
@@ -346,3 +346,45 @@ func TestValidateStruct_UpdateMatchResult_RejectsTiedPenalties(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "PENALTY_TIED", awayField.Code)
 }
+
+func TestValidateStruct_CreateCompetition_ValidPool(t *testing.T) {
+	matchID := int64(42)
+
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type:    domain.CompetitionTypePool,
+		Name:    "CvP",
+		MatchID: &matchID,
+	})
+
+	assert.Nil(t, result)
+}
+
+func TestValidateStruct_CreateCompetition_PoolRequiresMatchID(t *testing.T) {
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type: domain.CompetitionTypePool,
+		Name: "CvP",
+	})
+
+	require.NotNil(t, result)
+	field, ok := result["match_id"]
+	require.True(t, ok)
+	assert.Equal(t, "REQUIRED", field.Code)
+}
+
+func TestValidateStruct_CreateCompetition_PoolForbidsScope(t *testing.T) {
+	matchID := int64(42)
+
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type:    domain.CompetitionTypePool,
+		Name:    "CvP",
+		MatchID: &matchID,
+		Scope: &dtos.CreateCompetitionScopeDto{
+			Stages: []domain.MatchStageCode{domain.MatchStageCodeGroupStage},
+		},
+	})
+
+	require.NotNil(t, result)
+	field, ok := result["scope"]
+	require.True(t, ok)
+	assert.Equal(t, "SCOPE_FORBIDDEN", field.Code)
+}

--- a/internal/repositories/competition_repository.go
+++ b/internal/repositories/competition_repository.go
@@ -33,13 +33,14 @@ func (r *CompetitionRepository) CreateCompetition(
 	defer tx.Rollback()
 
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO competitions (board_id, type, name, created_by)
-		 VALUES ($1, $2, $3, $4)
+		`INSERT INTO competitions (board_id, type, name, created_by, match_id)
+		 VALUES ($1, $2, $3, $4, $5)
 		 RETURNING id, created_at`,
 		competition.BoardID,
 		competition.Type,
 		competition.Name,
 		competition.CreatedBy,
+		competition.PoolMatchID,
 	).Scan(&competition.ID, &competition.CreatedAt)
 	if err != nil {
 		return handleDBError(err, resourceCompetition)
@@ -178,6 +179,44 @@ func (r *CompetitionRepository) seedScoresFromEvents(
 		if err != nil {
 			return handleDBError(err, resourceCompetition)
 		}
+
+	case domain.CompetitionTypePool:
+		_, err := tx.ExecContext(ctx, `
+			WITH user_agg AS (
+				SELECT
+					se.user_id,
+					SUM(se.points)                                          AS match_score_points,
+					COUNT(*) FILTER (WHERE se.points >= $4)                 AS exact_hits_count,
+					COUNT(*) FILTER (WHERE se.points > 0 AND se.points < $4) AS correct_outcomes_count
+				FROM score_events se
+				WHERE se.source_type = 'match_score_pick'
+				  AND se.source_ref::bigint = $3
+				GROUP BY se.user_id
+			)
+			INSERT INTO competition_match_scores (
+				competition_id,
+				user_id,
+				total_points,
+				exact_hits,
+				correct_outcomes
+			)
+			SELECT
+				$1,
+				bm.user_id,
+				COALESCE(agg.match_score_points, 0),
+				COALESCE(agg.exact_hits_count, 0),
+				COALESCE(agg.correct_outcomes_count, 0)
+			FROM board_members bm
+			LEFT JOIN user_agg agg ON agg.user_id = bm.user_id
+			WHERE bm.board_id = $2`,
+			competition.ID,
+			competition.BoardID,
+			competition.PoolMatchID,
+			r.cfg.Scoring.MatchScoreExact,
+		)
+		if err != nil {
+			return handleDBError(err, resourceCompetition)
+		}
 	}
 
 	return nil
@@ -193,7 +232,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 
 	query := `
 		WITH board_competitions AS (
-			SELECT id, board_id, type, name, created_by, created_at
+			SELECT id, board_id, type, name, created_by, created_at, match_id
 			FROM competitions
 			WHERE board_id = $1
 		),
@@ -241,7 +280,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			SELECT competition_id, user_id, total_points, rank FROM match_ranked
 		)
 		SELECT
-			bc.id, bc.board_id, bc.type, bc.name, bc.created_by, bc.created_at,
+			bc.id, bc.board_id, bc.type, bc.name, bc.created_by, bc.created_at, bc.match_id,
 			COALESCE(vr.rank, 0)   AS viewer_rank,
 			COALESCE(vr.total_points, 0) AS viewer_total_points
 		FROM board_competitions bc
@@ -260,6 +299,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 	for rows.Next() {
 		competition := &domain.CompetitionListItem{}
 		var createdBy sql.NullString
+		var matchID sql.NullInt64
 
 		if err := rows.Scan(
 			&competition.ID,
@@ -268,6 +308,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			&competition.Name,
 			&createdBy,
 			&competition.CreatedAt,
+			&matchID,
 			&competition.Viewer.Rank,
 			&competition.Viewer.TotalPoints,
 		); err != nil {
@@ -276,6 +317,10 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 
 		if createdBy.Valid {
 			competition.CreatedBy = &createdBy.String
+		}
+
+		if matchID.Valid {
+			competition.PoolMatchID = &matchID.Int64
 		}
 
 		competitions = append(competitions, competition)
@@ -398,9 +443,10 @@ func (r *CompetitionRepository) GetCompetitionByID(
 
 	competition := &domain.Competition{}
 	var createdBy sql.NullString
+	var matchID sql.NullInt64
 
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, board_id, type, name, created_by, created_at
+		`SELECT id, board_id, type, name, created_by, created_at, match_id
 		 FROM competitions
 		 WHERE id = $1 AND board_id = $2`,
 		competitionID, boardID,
@@ -411,6 +457,7 @@ func (r *CompetitionRepository) GetCompetitionByID(
 		&competition.Name,
 		&createdBy,
 		&competition.CreatedAt,
+		&matchID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, domain.ErrCompetitionNotFound
@@ -421,6 +468,10 @@ func (r *CompetitionRepository) GetCompetitionByID(
 
 	if createdBy.Valid {
 		competition.CreatedBy = &createdBy.String
+	}
+
+	if matchID.Valid {
+		competition.PoolMatchID = &matchID.Int64
 	}
 
 	return competition, nil

--- a/internal/repositories/competition_score_repository.go
+++ b/internal/repositories/competition_score_repository.go
@@ -63,6 +63,41 @@ func (r *CompetitionScoreRepository) FindMatchCompetitionsByMatches(
 	return ids, rows.Err()
 }
 
+func (r *CompetitionScoreRepository) FindPoolCompetitionsByMatches(
+	ctx context.Context,
+	matchIDs []int64,
+) ([]int64, error) {
+	if len(matchIDs) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		SELECT id
+		FROM competitions
+		WHERE type = 'pool' AND match_id = ANY($1::bigint[])
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(matchIDs))
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, rows.Err()
+}
+
 func (r *CompetitionScoreRepository) BatchUpsertMatchScores(
 	ctx context.Context,
 	competitionID int64,
@@ -89,6 +124,61 @@ func (r *CompetitionScoreRepository) BatchUpsertMatchScores(
 					  AND cst.team_fifa_code IN (m.home_team_fifa_code, m.away_team_fifa_code)
 				)
 			)
+		),
+		computed AS (
+			SELECT
+				se.user_id,
+				COALESCE(SUM(se.points), 0)                                   AS match_score_points,
+				COUNT(*) FILTER (WHERE se.points >= $3)                       AS exact_hits_count,
+				COUNT(*) FILTER (WHERE se.points > 0 AND se.points < $3)      AS correct_outcomes_count
+			FROM score_events se
+			INNER JOIN scope_matches sm ON sm.id = se.source_ref::bigint
+			WHERE se.user_id = ANY($2::uuid[])
+			  AND se.source_type = 'match_score_pick'
+			GROUP BY se.user_id
+		)
+		INSERT INTO competition_match_scores (
+			competition_id, user_id, total_points,
+			exact_hits, correct_outcomes, updated_at
+		)
+		SELECT $1, c.user_id, c.match_score_points, c.exact_hits_count, c.correct_outcomes_count, NOW()
+		FROM computed c
+		WHERE EXISTS (
+			SELECT 1 FROM competitions co
+			INNER JOIN board_members bm ON bm.board_id = co.board_id AND bm.user_id = c.user_id
+			WHERE co.id = $1
+		)
+		ON CONFLICT (competition_id, user_id) DO UPDATE SET
+			total_points     = EXCLUDED.total_points,
+			exact_hits       = EXCLUDED.exact_hits,
+			correct_outcomes = EXCLUDED.correct_outcomes,
+			updated_at       = EXCLUDED.updated_at
+	`
+
+	_, err := r.db.ExecContext(ctx, query, competitionID, pq.Array(userIDs), exactScorePts)
+	if err != nil {
+		return handleDBError(err, resourceCompetitionScore)
+	}
+
+	return nil
+}
+
+func (r *CompetitionScoreRepository) BatchUpsertPoolScores(
+	ctx context.Context,
+	competitionID int64,
+	userIDs []string,
+	exactScorePts int,
+) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		WITH scope_matches AS (
+			SELECT match_id AS id FROM competitions WHERE id = $1
 		),
 		computed AS (
 			SELECT
@@ -218,7 +308,7 @@ func (r *CompetitionScoreRepository) GetLeaderboard(
 	switch competitionType {
 	case domain.CompetitionTypePickem:
 		return r.getPickemLeaderboard(ctx, competitionID, page, limit, q)
-	case domain.CompetitionTypeMatch:
+	case domain.CompetitionTypeMatch, domain.CompetitionTypePool:
 		return r.getMatchLeaderboard(ctx, competitionID, page, limit, q)
 	default:
 		return nil, domain.ErrCompetitionNotFound

--- a/internal/repositories/errors.go
+++ b/internal/repositories/errors.go
@@ -98,6 +98,8 @@ func translateForeignKeyViolation(pqErr *pq.Error) error {
 		"board_members_board_id_fkey",
 		"board_members_user_id_fkey":
 		return domain.ErrUserNotFound
+	case "competitions_match_id_fkey":
+		return domain.ErrMatchNotFound
 	default:
 		return buildErrorFromPQError(pqErr)
 	}
@@ -115,6 +117,8 @@ func translateUniqueViolation(pqErr *pq.Error) error {
 		return domain.ErrBoardMemberAlreadyInBoard
 	case "idx_competitions_one_pickem_per_board":
 		return domain.ErrCompetitionPickemAlreadyExists
+	case "idx_competitions_one_pool_per_match":
+		return domain.ErrDuplicatePoolForMatch
 	case "competitions_board_id_name_key":
 		return domain.ErrCompetitionNameAlreadyExists
 	default:

--- a/internal/services/competition_scoring_service.go
+++ b/internal/services/competition_scoring_service.go
@@ -66,6 +66,30 @@ func (s *CompetitionScoringService) RecomputeForMatches(ctx context.Context, res
 		}
 	}
 
+	// Pool competitions (single-match pools share the match-score cache)
+	if len(result.ScoredMatchIDs) > 0 {
+		poolIDs, err := s.competitionScoreRepository.FindPoolCompetitionsByMatches(ctx, result.ScoredMatchIDs)
+		if err != nil {
+			s.logger.Error("failed to find pool competitions",
+				logging.Error, err.Error(),
+				"match_ids", result.ScoredMatchIDs,
+			)
+			return err
+		}
+
+		for _, competitionID := range poolIDs {
+			if err := s.competitionScoreRepository.BatchUpsertPoolScores(
+				ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
+			); err != nil {
+				s.logger.Error("failed to upsert pool scores",
+					logging.Error, err.Error(),
+					"competition_id", competitionID,
+				)
+				return err
+			}
+		}
+	}
+
 	// Pickem competitions
 	if result.PickemAffected {
 		if err := s.recomputeAllPickems(ctx, result.AffectedUserIDs); err != nil {

--- a/internal/services/competition_scoring_service_test.go
+++ b/internal/services/competition_scoring_service_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompetitionScoringService_RecomputeForMatches_Pools(t *testing.T) {
+	t.Parallel()
+
+	matchIDs := []int64{42}
+	userIDs := []string{"user-1", "user-2"}
+	poolID := int64(7)
+
+	var upsertedPoolID int64
+	var upsertedPts int
+	var upsertedUsers []string
+
+	scoreRepo := &mocks.MockCompetitionScoreRepository{
+		FindMatchCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
+			return nil, nil
+		},
+		FindPoolCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
+			assert.Equal(t, matchIDs, ids)
+			return []int64{poolID}, nil
+		},
+		BatchUpsertPoolScoresFunc: func(ctx context.Context, competitionID int64, users []string, exactScorePts int) error {
+			upsertedPoolID = competitionID
+			upsertedUsers = users
+			upsertedPts = exactScorePts
+			return nil
+		},
+	}
+
+	cfg := &config.Config{Scoring: config.ScoringConfig{MatchScoreExact: 5}}
+	service := NewCompetitionScoringService(&mocks.MockCompetitionRepository{}, scoreRepo, cfg, &mocks.MockLogger{})
+
+	err := service.RecomputeForMatches(context.Background(), &domain.ScoreMatchesResult{
+		AffectedUserIDs: userIDs,
+		ScoredMatchIDs:  matchIDs,
+		PickemAffected:  false,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, poolID, upsertedPoolID)
+	assert.Equal(t, userIDs, upsertedUsers)
+	assert.Equal(t, 5, upsertedPts)
+}

--- a/internal/services/competition_service.go
+++ b/internal/services/competition_service.go
@@ -48,10 +48,11 @@ func (s *CompetitionService) CreateCompetition(
 	}
 
 	competition := &domain.Competition{
-		BoardID:   boardID,
-		Type:      payload.Type,
-		Name:      payload.Name,
-		CreatedBy: &userID,
+		BoardID:     boardID,
+		Type:        payload.Type,
+		Name:        payload.Name,
+		CreatedBy:   &userID,
+		PoolMatchID: payload.MatchID,
 	}
 
 	if payload.Scope != nil {

--- a/internal/services/competition_service_test.go
+++ b/internal/services/competition_service_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestCompetitionService(br *mocks.MockBoardRepository, cr *mocks.MockCompetitionRepository) CompetitionServiceInterface {
@@ -20,6 +22,57 @@ func privateBoardRepo() *mocks.MockBoardRepository {
 			return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
 		},
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCompetitionService_CreateCompetition
+// ---------------------------------------------------------------------------
+func TestCompetitionService_CreateCompetition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates a pool competition carrying the match id", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+		matchID := gofakeit.Int64()
+
+		var captured *domain.Competition
+		cr := &mocks.MockCompetitionRepository{
+			CreateCompetitionFunc: func(ctx context.Context, c *domain.Competition) error {
+				captured = c
+				return nil
+			},
+		}
+
+		service := newTestCompetitionService(privateBoardRepo(), cr)
+
+		_, err := service.CreateCompetition(context.Background(), boardID, userID, domain.BoardMemberRoleAdmin, dtos.CreateCompetitionDto{
+			Type:    domain.CompetitionTypePool,
+			Name:    "CvP",
+			MatchID: &matchID,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.PoolMatchID)
+		assert.Equal(t, matchID, *captured.PoolMatchID)
+		assert.Equal(t, domain.CompetitionTypePool, captured.Type)
+	})
+
+	t.Run("rejects a member without manage permission", func(t *testing.T) {
+		t.Parallel()
+
+		// Empty repos: the role check must short-circuit before any repo call.
+		service := newTestCompetitionService(&mocks.MockBoardRepository{}, &mocks.MockCompetitionRepository{})
+
+		_, err := service.CreateCompetition(context.Background(), gofakeit.Int64(), gofakeit.UUID(), domain.BoardMemberRoleMember, dtos.CreateCompetitionDto{
+			Type: domain.CompetitionTypePool,
+			Name: "CvP",
+		})
+
+		assert.ErrorIs(t, err, domain.ErrCompetitionForbidden)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/test/mocks/award_service_mock.go
+++ b/internal/test/mocks/award_service_mock.go
@@ -7,10 +7,10 @@ import (
 )
 
 type MockAwardService struct {
-	GetUserAwardsFunc    func(ctx context.Context, userID string) (*domain.UserAwards, error)
-	SaveAwardPicksFunc   func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
-	GetPopularPicksFunc  func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
-	RecordWinnersFunc    func(ctx context.Context, winners []*domain.AwardWinner) error
+	GetUserAwardsFunc   func(ctx context.Context, userID string) (*domain.UserAwards, error)
+	SaveAwardPicksFunc  func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
+	GetPopularPicksFunc func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
+	RecordWinnersFunc   func(ctx context.Context, winners []*domain.AwardWinner) error
 }
 
 func (m *MockAwardService) GetUserAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {

--- a/internal/test/mocks/competition_score_repository_mock.go
+++ b/internal/test/mocks/competition_score_repository_mock.go
@@ -8,7 +8,9 @@ import (
 
 type MockCompetitionScoreRepository struct {
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPoolCompetitionsByMatchesFunc  func(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScoresFunc         func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	BatchUpsertPoolScoresFunc          func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
 	BatchUpsertPickemScoresFunc        func(ctx context.Context, competitionIDs []int64, userIDs []string) error
 	GetLeaderboardFunc                 func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
 	GetUserPickemStatsFunc             func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error)
@@ -22,11 +24,25 @@ func (m *MockCompetitionScoreRepository) FindMatchCompetitionsByMatches(ctx cont
 	panic("FindMatchCompetitionsByMatches called unexpectedly")
 }
 
+func (m *MockCompetitionScoreRepository) FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error) {
+	if m.FindPoolCompetitionsByMatchesFunc != nil {
+		return m.FindPoolCompetitionsByMatchesFunc(ctx, matchIDs)
+	}
+	panic("FindPoolCompetitionsByMatches called unexpectedly")
+}
+
 func (m *MockCompetitionScoreRepository) BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
 	if m.BatchUpsertMatchScoresFunc != nil {
 		return m.BatchUpsertMatchScoresFunc(ctx, competitionID, userIDs, exactScorePts)
 	}
 	panic("BatchUpsertMatchScores called unexpectedly")
+}
+
+func (m *MockCompetitionScoreRepository) BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
+	if m.BatchUpsertPoolScoresFunc != nil {
+		return m.BatchUpsertPoolScoresFunc(ctx, competitionID, userIDs, exactScorePts)
+	}
+	panic("BatchUpsertPoolScores called unexpectedly")
 }
 
 func (m *MockCompetitionScoreRepository) BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error {

--- a/internal/test/mocks/competition_service_mock.go
+++ b/internal/test/mocks/competition_service_mock.go
@@ -1,0 +1,43 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+)
+
+type MockCompetitionService struct {
+	CreateCompetitionFunc    func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error)
+	GetBoardCompetitionsFunc func(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
+	GetLeaderboardFunc       func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
+	DeleteCompetitionFunc    func(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error
+}
+
+func (m *MockCompetitionService) CreateCompetition(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+	if m.CreateCompetitionFunc != nil {
+		return m.CreateCompetitionFunc(ctx, boardID, userID, role, payload)
+	}
+	panic("CreateCompetition called unexpectedly")
+}
+
+func (m *MockCompetitionService) GetBoardCompetitions(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error) {
+	if m.GetBoardCompetitionsFunc != nil {
+		return m.GetBoardCompetitionsFunc(ctx, boardID, viewerUserID)
+	}
+	panic("GetBoardCompetitions called unexpectedly")
+}
+
+func (m *MockCompetitionService) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+	if m.GetLeaderboardFunc != nil {
+		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q)
+	}
+	panic("GetLeaderboard called unexpectedly")
+}
+
+func (m *MockCompetitionService) DeleteCompetition(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error {
+	if m.DeleteCompetitionFunc != nil {
+		return m.DeleteCompetitionFunc(ctx, boardID, competitionID, role)
+	}
+	panic("DeleteCompetition called unexpectedly")
+}


### PR DESCRIPTION
## Related issue

Closes #88

## What changed

- Add `pool` competition type — a single-match leaderboard tied to one match via `competitions.match_id`, with a CHECK enforcing `match_id` is set iff type is `pool` and a unique index for one pool per match per board (migration 000016).
- Seed and recompute pool scores from existing `match_score_pick` events, reusing the match-score cache and leaderboard rendering.
- Wire pool recompute into `RecomputeForMatches` so scored matches refresh their pools.
- Validate `pool` creation: `match_id` required, `scope` forbidden; map FK/unique violations to `MATCH_NOT_FOUND` / `DUPLICATE_POOL_FOR_MATCH` (409).

## How to test

- [ ] `make db-migrate-up && make db-test-migrate-up`
- [ ] `POST /boards/{id}/competitions` with `{"type":"pool","name":"...","match_id":42}` → 201
- [ ] Same call again for match 42 → 409 `DUPLICATE_POOL_FOR_MATCH`
- [ ] `POST` pool with unknown `match_id` → `MATCH_NOT_FOUND`; with a `scope` → 422
- [ ] Score match 42 (result sync), then `GET .../competitions/{poolId}/leaderboard` reflects updated points
- [ ] `make test-unit`