### PR TITLE
chore: release v1.1.0

### DIFF
--- a/cmd/db/migrations/000016_create_competition_pool.down.sql
+++ b/cmd/db/migrations/000016_create_competition_pool.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_competitions_one_pool_per_match;
+ALTER TABLE competitions DROP CONSTRAINT IF EXISTS chk_competition_pool_match;
+ALTER TABLE competitions DROP CONSTRAINT IF EXISTS chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match'));
+ALTER TABLE competitions DROP COLUMN IF EXISTS match_id;

--- a/cmd/db/migrations/000016_create_competition_pool.up.sql
+++ b/cmd/db/migrations/000016_create_competition_pool.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE competitions ADD COLUMN match_id BIGINT REFERENCES matches(id) ON DELETE CASCADE;
+
+-- Postgres cannot edit a CHECK in place; drop and re-add to allow the new type.
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pool'));
+
+-- match_id is present iff the competition is a pool.
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_pool_match
+    CHECK ((type = 'pool') = (match_id IS NOT NULL));
+
+-- At most one pool per match per board.
+CREATE UNIQUE INDEX idx_competitions_one_pool_per_match
+    ON competitions(board_id, match_id) WHERE type = 'pool';

--- a/internal/domain/competition.go
+++ b/internal/domain/competition.go
@@ -10,16 +10,18 @@ type CompetitionType string
 const (
 	CompetitionTypePickem CompetitionType = "pickem"
 	CompetitionTypeMatch  CompetitionType = "match"
+	CompetitionTypePool   CompetitionType = "pool"
 )
 
 type Competition struct {
-	ID        int64             `json:"id" example:"1"`
-	BoardID   int64             `json:"board_id" example:"1"`
-	Type      CompetitionType   `json:"type" example:"pickem"`
-	Name      string            `json:"name" example:"Pick'em"`
-	CreatedBy *string           `json:"-"`
-	CreatedAt time.Time         `json:"created_at" example:"2026-01-15T10:30:00Z"`
-	Scope     *CompetitionScope `json:"scope,omitempty"`
+	ID          int64             `json:"id" example:"1"`
+	BoardID     int64             `json:"board_id" example:"1"`
+	Type        CompetitionType   `json:"type" example:"pickem"`
+	Name        string            `json:"name" example:"Pick'em"`
+	CreatedBy   *string           `json:"-"`
+	CreatedAt   time.Time         `json:"created_at" example:"2026-01-15T10:30:00Z"`
+	Scope       *CompetitionScope `json:"scope,omitempty"`
+	PoolMatchID *int64            `json:"pool_match_id,omitempty" example:"42"`
 }
 
 // CompetitionScope is only populated for match competitions

--- a/internal/domain/competition_score.go
+++ b/internal/domain/competition_score.go
@@ -17,7 +17,9 @@ type CompetitionUserStats struct {
 
 type CompetitionScoreRepository interface {
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
 	BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error
 	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*CompetitionLeaderboardPage, error)
 	GetUserPickemStats(ctx context.Context, competitionID int64, userID string) (CompetitionUserStats, error)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -110,6 +110,7 @@ var ErrCompetitionForbidden = errors.New("only board owner or admins can manage 
 var ErrCompetitionPickemAlreadyExists = errors.New("a tournament pick'em competition already exists on this board")
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
 var ErrCompetitionPickemNotDeletable = errors.New("the tournament pick'em competition cannot be deleted")
+var ErrDuplicatePoolForMatch = errors.New("a pool for this match already exists on this board")
 
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")

--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -6,14 +6,13 @@ import (
 )
 
 type RefreshToken struct {
-	ID               string     `json:"id"`
-	UserID           string     `json:"user_id"`
-	SessionID        string     `json:"session_id"`
-	TokenHash        string     `json:"token_hash"`
-	ExpiresAt        time.Time  `json:"expires_at"`
-	RotatedAt        *time.Time `json:"rotated_at"`
-	CreatedAt        time.Time  `json:"created_at"`
-	SessionExpiresAt time.Time  `json:"session_expires_at"`
+	ID        string     `json:"id"`
+	UserID    string     `json:"user_id"`
+	SessionID string     `json:"session_id"`
+	TokenHash string     `json:"token_hash"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	RotatedAt *time.Time `json:"rotated_at"`
+	CreatedAt time.Time  `json:"created_at"`
 }
 
 type RefreshTokenRepository interface {

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -20,7 +20,7 @@ type Session struct {
 type SessionRepository interface {
 	CreateSession(ctx context.Context, session *Session) error
 	GetSessions(ctx context.Context, refreshTokenHash string) ([]Session, error)
-	UpdateLastUsedAt(ctx context.Context, id string) error
+	UpdateLastUsedAt(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error)
 	DeleteSession(ctx context.Context, refreshTokenHash string) error
 	DeleteAllSessions(ctx context.Context, refreshTokenHash string) error
 	DeleteSessionById(ctx context.Context, sessionID string, userID string) error

--- a/internal/dtos/competition_dto.go
+++ b/internal/dtos/competition_dto.go
@@ -8,7 +8,8 @@ type CreateCompetitionScopeDto struct {
 }
 
 type CreateCompetitionDto struct {
-	Type  domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match" example:"pickem"`
-	Name  string                     `json:"name" validate:"required,max=20" example:"Pick'em"`
-	Scope *CreateCompetitionScopeDto `json:"scope,omitempty"`
+	Type    domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match pool" example:"pickem"`
+	Name    string                     `json:"name" validate:"required,max=20" example:"Pick'em"`
+	Scope   *CreateCompetitionScopeDto `json:"scope,omitempty"`
+	MatchID *int64                     `json:"match_id,omitempty" example:"42"`
 }

--- a/internal/handlers/auth_handler.go
+++ b/internal/handlers/auth_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/fifawcp/api/internal/dtos"
@@ -11,6 +12,7 @@ import (
 	"github.com/fifawcp/api/internal/infrastructure/validator"
 	"github.com/fifawcp/api/internal/services"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 type AuthHandler struct {
@@ -156,7 +158,12 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authResponse, err := h.authService.RefreshToken(r.Context(), refreshToken)
+	ctx := context.WithValue(r.Context(), httpctx.RefreshDiagnosticsContextKey, &httpctx.RefreshDiagnostics{
+		RequestID: middleware.GetReqID(r.Context()),
+		Source:    r.Header.Get("X-Refresh-Source"),
+	})
+
+	authResponse, err := h.authService.RefreshToken(ctx, refreshToken)
 	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return

--- a/internal/handlers/award_handler.go
+++ b/internal/handlers/award_handler.go
@@ -75,7 +75,7 @@ func (h *AwardHandler) GetUserAwards(w http.ResponseWriter, r *http.Request) {
 //	@Description	Returns the most-picked players per award (across all users), ranked desc by pick count then alphabetically. Eligibility is enforced per award: Golden Glove restricts to goalkeepers; Young Player restricts to players within the age cap (unknown ages are treated as eligible). Boot and Ball draw from the full catalog. Useful for the awards picker UI's "top choices" section.
 //	@Tags			awards
 //	@Produce		json
-//	@Param			limit	query		int	false	"Top-N per award (1-50)"	default(10)
+//	@Param			limit	query		int							false	"Top-N per award (1-50)"	default(10)
 //	@Success		200		{object}	domain.PopularPicksByAward	"Top picks grouped by award type"
 //	@Failure		400		{object}	httpx.ErrorResponse			"Invalid limit"
 //	@Failure		401		{object}	httpx.ErrorResponse			"Missing or invalid Bearer token"

--- a/internal/handlers/competition_handler_test.go
+++ b/internal/handlers/competition_handler_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/httpx"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCompetitionHandler(cs *mocks.MockCompetitionService) *CompetitionHandler {
+	return NewCompetitionHandler(cs, testutils.NewTestConfig(), validator.NewValidator(), &mocks.MockLogger{})
+}
+
+func makeCreatePoolReq(t *testing.T, body any) *http.Request {
+	return testutils.MakeJSONRequest(
+		t, http.MethodPost, "/boards/1/competitions", body,
+		testutils.WithAuthUser(testutils.CreateTestUser()),
+		testutils.WithBoardID(1),
+		testutils.WithBoardMemberRole(domain.BoardMemberRoleAdmin),
+	)
+}
+
+func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
+	t.Parallel()
+
+	matchID := int64(42)
+
+	t.Run("returns 201 on success", func(t *testing.T) {
+		t.Parallel()
+
+		cs := &mocks.MockCompetitionService{
+			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+				return &domain.CompetitionListItem{
+					Competition: domain.Competition{ID: 9, BoardID: boardID, Type: domain.CompetitionTypePool, Name: payload.Name, PoolMatchID: payload.MatchID},
+				}, nil
+			},
+		}
+		h := newTestCompetitionHandler(cs)
+
+		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		w := httptest.NewRecorder()
+
+		h.CreateCompetition(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code)
+		var resp struct {
+			Data domain.CompetitionListItem `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, domain.CompetitionTypePool, resp.Data.Type)
+		require.NotNil(t, resp.Data.PoolMatchID)
+		assert.Equal(t, matchID, *resp.Data.PoolMatchID)
+	})
+
+	t.Run("returns 409 when a pool already exists for the match", func(t *testing.T) {
+		t.Parallel()
+
+		cs := &mocks.MockCompetitionService{
+			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+				return nil, domain.ErrDuplicatePoolForMatch
+			},
+		}
+		h := newTestCompetitionHandler(cs)
+
+		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		w := httptest.NewRecorder()
+
+		h.CreateCompetition(w, req)
+
+		require.Equal(t, http.StatusConflict, w.Code)
+		var resp httpx.ErrorResponse
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "DUPLICATE_POOL_FOR_MATCH", resp.Error.Code)
+	})
+}

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -31,6 +31,7 @@ const (
 	codeCompetitionPickemAlreadyExists = "COMPETITION_PICKEM_ALREADY_EXISTS"
 	codeCompetitionNameAlreadyExists   = "COMPETITION_NAME_ALREADY_EXISTS"
 	codeCompetitionPickemNotDeletable  = "COMPETITION_PICKEM_NOT_DELETABLE"
+	codeDuplicatePoolForMatch          = "DUPLICATE_POOL_FOR_MATCH"
 
 	// 401 Unauthorized
 	codeOTPInvalidOrExpired          = "OTP_INVALID_OR_EXPIRED"
@@ -233,6 +234,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.BadRequest(w, r, codeCannotTransferToSelf, domain.ErrCannotTransferOwnershipToSelf.Error())
 	case errors.Is(err, domain.ErrCompetitionNameAlreadyExists):
 		httpx.Conflict(w, r, codeCompetitionNameAlreadyExists, domain.ErrCompetitionNameAlreadyExists.Error())
+	case errors.Is(err, domain.ErrDuplicatePoolForMatch):
+		httpx.Conflict(w, r, codeDuplicatePoolForMatch, domain.ErrDuplicatePoolForMatch.Error())
 
 	// 502 Bad Gateway
 	case errors.Is(err, domain.ErrMissingIDToken):

--- a/internal/handlers/player_handler.go
+++ b/internal/handlers/player_handler.go
@@ -31,14 +31,14 @@ func NewPlayerHandler(playerService services.PlayerServiceInterface, logger logg
 //	@Description	Search the tournament player catalog. All filters are optional and combine with AND. `q` is a case-insensitive substring match across name, first name and last name. `team_fifa_codes` and `positions` accept comma-separated values (or the param repeated) and match if the player's value is in the supplied set. Results are paginated.
 //	@Tags			players
 //	@Produce		json
-//	@Param			q					query		string				false	"Case-insensitive substring match across name, first_name and last_name"
-//	@Param			team_fifa_codes		query		[]string			false	"Filter by team FIFA codes (e.g. MEX,COL). Comma-separated or repeated."	collectionFormat(csv)
-//	@Param			positions			query		[]string			false	"Filter by positions. Comma-separated or repeated."	collectionFormat(csv)	Enums(goalkeeper,defender,midfielder,attacker)
-//	@Param			page				query		int					false	"Page number (1-based)"	default(1)
-//	@Param			limit				query		int					false	"Page size (max 100)"	default(20)
-//	@Success		200					{object}	httpx.Response		"Paginated list of players"
-//	@Failure		400					{object}	httpx.ErrorResponse	"Invalid query parameters"
-//	@Failure		401					{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Param			q				query		string				false	"Case-insensitive substring match across name, first_name and last_name"
+//	@Param			team_fifa_codes	query		[]string			false	"Filter by team FIFA codes (e.g. MEX,COL). Comma-separated or repeated."	collectionFormat(csv)
+//	@Param			positions		query		[]string			false	"Filter by positions. Comma-separated or repeated."							collectionFormat(csv)	Enums(goalkeeper,defender,midfielder,attacker)
+//	@Param			page			query		int					false	"Page number (1-based)"														default(1)
+//	@Param			limit			query		int					false	"Page size (max 100)"														default(20)
+//	@Success		200				{object}	httpx.Response		"Paginated list of players"
+//	@Failure		400				{object}	httpx.ErrorResponse	"Invalid query parameters"
+//	@Failure		401				{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
 //	@Security		BearerAuth
 //	@Router			/players [get]
 func (h *PlayerHandler) SearchPlayers(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpctx/context.go
+++ b/internal/httpctx/context.go
@@ -10,22 +10,36 @@ import (
 type ContextKey string
 
 const (
-	RequestInfoContextKey       ContextKey = "request_info"
-	AuthenticatedUserContextKey ContextKey = "authenticated_user"
-	BoardIDContextKey           ContextKey = "board_id"
-	BoardMemberRoleContextKey   ContextKey = "board_member_role"
-	UserIDContextKey            ContextKey = "user_id"
-	MatchIDContextKey           ContextKey = "match_id"
-	CompetitionIDContextKey     ContextKey = "competition_id"
-	ReturnToContextKey          ContextKey = "return_to"
-	OAuthStateContextKey        ContextKey = "oauth_state"
-	OAuthCodeContextKey         ContextKey = "oauth_code"
-	ResponseErrorContextKey     ContextKey = "response_error"
+	RequestInfoContextKey        ContextKey = "request_info"
+	AuthenticatedUserContextKey  ContextKey = "authenticated_user"
+	BoardIDContextKey            ContextKey = "board_id"
+	BoardMemberRoleContextKey    ContextKey = "board_member_role"
+	UserIDContextKey             ContextKey = "user_id"
+	MatchIDContextKey            ContextKey = "match_id"
+	CompetitionIDContextKey      ContextKey = "competition_id"
+	ReturnToContextKey           ContextKey = "return_to"
+	OAuthStateContextKey         ContextKey = "oauth_state"
+	OAuthCodeContextKey          ContextKey = "oauth_code"
+	ResponseErrorContextKey      ContextKey = "response_error"
+	RefreshDiagnosticsContextKey ContextKey = "refresh_diagnostics"
 )
 
 type ResponseError struct {
 	Code    string
 	Message string
+}
+
+type RefreshDiagnostics struct {
+	RequestID string
+	Source    string
+}
+
+func GetRefreshDiagnostics(ctx context.Context) *RefreshDiagnostics {
+	diagnostics, ok := ctx.Value(RefreshDiagnosticsContextKey).(*RefreshDiagnostics)
+	if !ok {
+		return nil
+	}
+	return diagnostics
 }
 
 func GetResponseError(ctx context.Context) *ResponseError {

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -79,11 +79,12 @@ type JWTConfig struct {
 }
 
 type AuthConfig struct {
-	SessionTTL     time.Duration
-	OTPTTL         time.Duration
-	MaxOTPAttempts int
-	OTPCooldown    time.Duration
-	GoogleOAuth    OAuthConfig
+	SessionTTL         time.Duration
+	SessionMaxLifetime time.Duration
+	OTPTTL             time.Duration
+	MaxOTPAttempts     int
+	OTPCooldown        time.Duration
+	GoogleOAuth        OAuthConfig
 }
 
 type OAuthConfig struct {
@@ -159,13 +160,14 @@ func NewConfig() *Config {
 			Issuer:             env.GetString("JWT_ISSUER", "fifa-wcp"),
 			AccessTokenExpiry:  env.GetDuration("JWT_ACCESS_TOKEN_EXPIRY", 15*time.Minute),
 			RefreshTokenExpiry: env.GetDuration("JWT_REFRESH_TOKEN_EXPIRY", 7*24*time.Hour),
-			RefreshGraceWindow: env.GetDuration("JWT_REFRESH_GRACE_WINDOW", 10*time.Second),
+			RefreshGraceWindow: env.GetDuration("JWT_REFRESH_GRACE_WINDOW", 20*time.Second),
 		},
 		Auth: AuthConfig{
-			SessionTTL:     env.GetDuration("AUTH_SESSION_TTL", 7*24*time.Hour),
-			OTPTTL:         env.GetDuration("AUTH_OTP_TTL", 10*time.Minute),
-			MaxOTPAttempts: env.GetInt("AUTH_MAX_OTP_ATTEMPTS", 3),
-			OTPCooldown:    env.GetDuration("AUTH_OTP_COOLDOWN", 30*time.Second),
+			SessionTTL:         env.GetDuration("AUTH_SESSION_TTL", 7*24*time.Hour),
+			SessionMaxLifetime: env.GetDuration("AUTH_SESSION_MAX_LIFETIME", 30*24*time.Hour),
+			OTPTTL:             env.GetDuration("AUTH_OTP_TTL", 10*time.Minute),
+			MaxOTPAttempts:     env.GetInt("AUTH_MAX_OTP_ATTEMPTS", 3),
+			OTPCooldown:        env.GetDuration("AUTH_OTP_COOLDOWN", 30*time.Second),
 			GoogleOAuth: OAuthConfig{
 				ClientID:          env.GetString("GOOGLE_OAUTH_CLIENT_ID", ""),
 				ClientSecret:      env.GetString("GOOGLE_OAUTH_CLIENT_SECRET", ""),

--- a/internal/infrastructure/logging/fields.go
+++ b/internal/infrastructure/logging/fields.go
@@ -12,6 +12,16 @@ const (
 	Outcome    = "outcome"     // "success" | "user_error" | "server_error"
 )
 
+const (
+	SessionID        = "session_id"
+	RefreshOutcome   = "refresh_outcome" // success | rotated_past_grace | not_found_or_expired
+	RefreshSource    = "refresh_source"  // client | middleware
+	RotatedAgeMS     = "rotated_age_ms"  // small == concurrent race
+	GraceWindowMS    = "grace_window_ms"
+	TokenAgeMS       = "token_age_ms"
+	TokenFingerprint = "token_fp"
+)
+
 // Audit-specific fields
 const (
 	LogName    = "log_name"    // always "audit" — filters audit vs operational logs

--- a/internal/infrastructure/validator/validator.go
+++ b/internal/infrastructure/validator/validator.go
@@ -178,6 +178,13 @@ func validateCreateCompetition(sl validator.StructLevel) {
 		if input.Scope == nil || len(input.Scope.Stages) == 0 {
 			sl.ReportError(input.Scope, "scope", "Scope", "scope_required", "")
 		}
+	case domain.CompetitionTypePool:
+		if input.Scope != nil {
+			sl.ReportError(input.Scope, "scope", "Scope", "scope_forbidden", "")
+		}
+		if input.MatchID == nil {
+			sl.ReportError(input.MatchID, "match_id", "MatchID", "required", "")
+		}
 	}
 }
 

--- a/internal/infrastructure/validator/validator_test.go
+++ b/internal/infrastructure/validator/validator_test.go
@@ -346,3 +346,45 @@ func TestValidateStruct_UpdateMatchResult_RejectsTiedPenalties(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "PENALTY_TIED", awayField.Code)
 }
+
+func TestValidateStruct_CreateCompetition_ValidPool(t *testing.T) {
+	matchID := int64(42)
+
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type:    domain.CompetitionTypePool,
+		Name:    "CvP",
+		MatchID: &matchID,
+	})
+
+	assert.Nil(t, result)
+}
+
+func TestValidateStruct_CreateCompetition_PoolRequiresMatchID(t *testing.T) {
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type: domain.CompetitionTypePool,
+		Name: "CvP",
+	})
+
+	require.NotNil(t, result)
+	field, ok := result["match_id"]
+	require.True(t, ok)
+	assert.Equal(t, "REQUIRED", field.Code)
+}
+
+func TestValidateStruct_CreateCompetition_PoolForbidsScope(t *testing.T) {
+	matchID := int64(42)
+
+	result := v.ValidateStruct(dtos.CreateCompetitionDto{
+		Type:    domain.CompetitionTypePool,
+		Name:    "CvP",
+		MatchID: &matchID,
+		Scope: &dtos.CreateCompetitionScopeDto{
+			Stages: []domain.MatchStageCode{domain.MatchStageCodeGroupStage},
+		},
+	})
+
+	require.NotNil(t, result)
+	field, ok := result["scope"]
+	require.True(t, ok)
+	assert.Equal(t, "SCOPE_FORBIDDEN", field.Code)
+}

--- a/internal/repositories/board_member_repository.go
+++ b/internal/repositories/board_member_repository.go
@@ -146,6 +146,35 @@ func (r *BoardMemberRepository) initCompetitionScoresForMember(
 		return handleDBError(err, resourceBoardMember)
 	}
 
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO competition_match_scores (
+			competition_id, user_id,
+			total_points, exact_hits, correct_outcomes
+		)
+		SELECT
+			c.id,
+			$2,
+			COALESCE(agg.match_score_points, 0),
+			COALESCE(agg.exact_hits_count, 0),
+			COALESCE(agg.correct_outcomes_count, 0)
+		FROM competitions c
+		LEFT JOIN LATERAL (
+			SELECT
+				SUM(se.points)                                           AS match_score_points,
+				COUNT(*) FILTER (WHERE se.points >= $3)                  AS exact_hits_count,
+				COUNT(*) FILTER (WHERE se.points > 0 AND se.points < $3) AS correct_outcomes_count
+			FROM score_events se
+			WHERE se.user_id = $2
+			  AND se.source_type = 'match_score_pick'
+			  AND se.source_ref::bigint = c.match_id
+		) agg ON TRUE
+		WHERE c.board_id = $1 AND c.type = 'pool'`,
+		boardID, userID,
+		r.cfg.Scoring.MatchScoreExact,
+	); err != nil {
+		return handleDBError(err, resourceBoardMember)
+	}
+
 	return nil
 }
 

--- a/internal/repositories/competition_repository.go
+++ b/internal/repositories/competition_repository.go
@@ -33,13 +33,14 @@ func (r *CompetitionRepository) CreateCompetition(
 	defer tx.Rollback()
 
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO competitions (board_id, type, name, created_by)
-		 VALUES ($1, $2, $3, $4)
+		`INSERT INTO competitions (board_id, type, name, created_by, match_id)
+		 VALUES ($1, $2, $3, $4, $5)
 		 RETURNING id, created_at`,
 		competition.BoardID,
 		competition.Type,
 		competition.Name,
 		competition.CreatedBy,
+		competition.PoolMatchID,
 	).Scan(&competition.ID, &competition.CreatedAt)
 	if err != nil {
 		return handleDBError(err, resourceCompetition)
@@ -178,6 +179,44 @@ func (r *CompetitionRepository) seedScoresFromEvents(
 		if err != nil {
 			return handleDBError(err, resourceCompetition)
 		}
+
+	case domain.CompetitionTypePool:
+		_, err := tx.ExecContext(ctx, `
+			WITH user_agg AS (
+				SELECT
+					se.user_id,
+					SUM(se.points)                                          AS match_score_points,
+					COUNT(*) FILTER (WHERE se.points >= $4)                 AS exact_hits_count,
+					COUNT(*) FILTER (WHERE se.points > 0 AND se.points < $4) AS correct_outcomes_count
+				FROM score_events se
+				WHERE se.source_type = 'match_score_pick'
+				  AND se.source_ref::bigint = $3
+				GROUP BY se.user_id
+			)
+			INSERT INTO competition_match_scores (
+				competition_id,
+				user_id,
+				total_points,
+				exact_hits,
+				correct_outcomes
+			)
+			SELECT
+				$1,
+				bm.user_id,
+				COALESCE(agg.match_score_points, 0),
+				COALESCE(agg.exact_hits_count, 0),
+				COALESCE(agg.correct_outcomes_count, 0)
+			FROM board_members bm
+			LEFT JOIN user_agg agg ON agg.user_id = bm.user_id
+			WHERE bm.board_id = $2`,
+			competition.ID,
+			competition.BoardID,
+			competition.PoolMatchID,
+			r.cfg.Scoring.MatchScoreExact,
+		)
+		if err != nil {
+			return handleDBError(err, resourceCompetition)
+		}
 	}
 
 	return nil
@@ -193,7 +232,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 
 	query := `
 		WITH board_competitions AS (
-			SELECT id, board_id, type, name, created_by, created_at
+			SELECT id, board_id, type, name, created_by, created_at, match_id
 			FROM competitions
 			WHERE board_id = $1
 		),
@@ -241,7 +280,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			SELECT competition_id, user_id, total_points, rank FROM match_ranked
 		)
 		SELECT
-			bc.id, bc.board_id, bc.type, bc.name, bc.created_by, bc.created_at,
+			bc.id, bc.board_id, bc.type, bc.name, bc.created_by, bc.created_at, bc.match_id,
 			COALESCE(vr.rank, 0)   AS viewer_rank,
 			COALESCE(vr.total_points, 0) AS viewer_total_points
 		FROM board_competitions bc
@@ -260,6 +299,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 	for rows.Next() {
 		competition := &domain.CompetitionListItem{}
 		var createdBy sql.NullString
+		var matchID sql.NullInt64
 
 		if err := rows.Scan(
 			&competition.ID,
@@ -268,6 +308,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			&competition.Name,
 			&createdBy,
 			&competition.CreatedAt,
+			&matchID,
 			&competition.Viewer.Rank,
 			&competition.Viewer.TotalPoints,
 		); err != nil {
@@ -276,6 +317,10 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 
 		if createdBy.Valid {
 			competition.CreatedBy = &createdBy.String
+		}
+
+		if matchID.Valid {
+			competition.PoolMatchID = &matchID.Int64
 		}
 
 		competitions = append(competitions, competition)
@@ -398,9 +443,10 @@ func (r *CompetitionRepository) GetCompetitionByID(
 
 	competition := &domain.Competition{}
 	var createdBy sql.NullString
+	var matchID sql.NullInt64
 
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, board_id, type, name, created_by, created_at
+		`SELECT id, board_id, type, name, created_by, created_at, match_id
 		 FROM competitions
 		 WHERE id = $1 AND board_id = $2`,
 		competitionID, boardID,
@@ -411,6 +457,7 @@ func (r *CompetitionRepository) GetCompetitionByID(
 		&competition.Name,
 		&createdBy,
 		&competition.CreatedAt,
+		&matchID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, domain.ErrCompetitionNotFound
@@ -421,6 +468,10 @@ func (r *CompetitionRepository) GetCompetitionByID(
 
 	if createdBy.Valid {
 		competition.CreatedBy = &createdBy.String
+	}
+
+	if matchID.Valid {
+		competition.PoolMatchID = &matchID.Int64
 	}
 
 	return competition, nil

--- a/internal/repositories/competition_score_repository.go
+++ b/internal/repositories/competition_score_repository.go
@@ -63,6 +63,41 @@ func (r *CompetitionScoreRepository) FindMatchCompetitionsByMatches(
 	return ids, rows.Err()
 }
 
+func (r *CompetitionScoreRepository) FindPoolCompetitionsByMatches(
+	ctx context.Context,
+	matchIDs []int64,
+) ([]int64, error) {
+	if len(matchIDs) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		SELECT id
+		FROM competitions
+		WHERE type = 'pool' AND match_id = ANY($1::bigint[])
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(matchIDs))
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, rows.Err()
+}
+
 func (r *CompetitionScoreRepository) BatchUpsertMatchScores(
 	ctx context.Context,
 	competitionID int64,
@@ -89,6 +124,61 @@ func (r *CompetitionScoreRepository) BatchUpsertMatchScores(
 					  AND cst.team_fifa_code IN (m.home_team_fifa_code, m.away_team_fifa_code)
 				)
 			)
+		),
+		computed AS (
+			SELECT
+				se.user_id,
+				COALESCE(SUM(se.points), 0)                                   AS match_score_points,
+				COUNT(*) FILTER (WHERE se.points >= $3)                       AS exact_hits_count,
+				COUNT(*) FILTER (WHERE se.points > 0 AND se.points < $3)      AS correct_outcomes_count
+			FROM score_events se
+			INNER JOIN scope_matches sm ON sm.id = se.source_ref::bigint
+			WHERE se.user_id = ANY($2::uuid[])
+			  AND se.source_type = 'match_score_pick'
+			GROUP BY se.user_id
+		)
+		INSERT INTO competition_match_scores (
+			competition_id, user_id, total_points,
+			exact_hits, correct_outcomes, updated_at
+		)
+		SELECT $1, c.user_id, c.match_score_points, c.exact_hits_count, c.correct_outcomes_count, NOW()
+		FROM computed c
+		WHERE EXISTS (
+			SELECT 1 FROM competitions co
+			INNER JOIN board_members bm ON bm.board_id = co.board_id AND bm.user_id = c.user_id
+			WHERE co.id = $1
+		)
+		ON CONFLICT (competition_id, user_id) DO UPDATE SET
+			total_points     = EXCLUDED.total_points,
+			exact_hits       = EXCLUDED.exact_hits,
+			correct_outcomes = EXCLUDED.correct_outcomes,
+			updated_at       = EXCLUDED.updated_at
+	`
+
+	_, err := r.db.ExecContext(ctx, query, competitionID, pq.Array(userIDs), exactScorePts)
+	if err != nil {
+		return handleDBError(err, resourceCompetitionScore)
+	}
+
+	return nil
+}
+
+func (r *CompetitionScoreRepository) BatchUpsertPoolScores(
+	ctx context.Context,
+	competitionID int64,
+	userIDs []string,
+	exactScorePts int,
+) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		WITH scope_matches AS (
+			SELECT match_id AS id FROM competitions WHERE id = $1
 		),
 		computed AS (
 			SELECT
@@ -218,7 +308,7 @@ func (r *CompetitionScoreRepository) GetLeaderboard(
 	switch competitionType {
 	case domain.CompetitionTypePickem:
 		return r.getPickemLeaderboard(ctx, competitionID, page, limit, q)
-	case domain.CompetitionTypeMatch:
+	case domain.CompetitionTypeMatch, domain.CompetitionTypePool:
 		return r.getMatchLeaderboard(ctx, competitionID, page, limit, q)
 	default:
 		return nil, domain.ErrCompetitionNotFound

--- a/internal/repositories/errors.go
+++ b/internal/repositories/errors.go
@@ -98,6 +98,8 @@ func translateForeignKeyViolation(pqErr *pq.Error) error {
 		"board_members_board_id_fkey",
 		"board_members_user_id_fkey":
 		return domain.ErrUserNotFound
+	case "competitions_match_id_fkey":
+		return domain.ErrMatchNotFound
 	default:
 		return buildErrorFromPQError(pqErr)
 	}
@@ -115,6 +117,8 @@ func translateUniqueViolation(pqErr *pq.Error) error {
 		return domain.ErrBoardMemberAlreadyInBoard
 	case "idx_competitions_one_pickem_per_board":
 		return domain.ErrCompetitionPickemAlreadyExists
+	case "idx_competitions_one_pool_per_match":
+		return domain.ErrDuplicatePoolForMatch
 	case "competitions_board_id_name_key":
 		return domain.ErrCompetitionNameAlreadyExists
 	default:

--- a/internal/repositories/refresh_token_repository.go
+++ b/internal/repositories/refresh_token_repository.go
@@ -61,10 +61,8 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	// Join sessions so we can enforce session expiry at lookup time and carry
-	// session.expires_at to the service for capping the rotated token's TTL.
-	// rotated_at is carried too: a rotated-but-unexpired row is still returned so
-	// the service can grant it the grace window (or reject it as stale reuse).
+	// Join sessions to enforce session expiry at lookup time. rotated_at is carried so
+	// the service can grant the grace window (or reject the token as stale reuse).
 	query := `SELECT
 		rt.id,
 		rt.user_id,
@@ -72,8 +70,7 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 		rt.token_hash,
 		rt.expires_at,
 		rt.rotated_at,
-		rt.created_at,
-		s.expires_at AS session_expires_at
+		rt.created_at
 	FROM refresh_tokens rt
 	JOIN sessions s ON s.id = rt.session_id
 	WHERE rt.token_hash = $1
@@ -90,7 +87,6 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 		&refreshToken.ExpiresAt,
 		&refreshToken.RotatedAt,
 		&refreshToken.CreatedAt,
-		&refreshToken.SessionExpiresAt,
 	)
 
 	if err != nil {
@@ -100,17 +96,11 @@ func (r *RefreshTokenRepository) GetRefreshTokenByTokenHash(
 	return &refreshToken, nil
 }
 
-// RotateRefreshToken supersedes the presented token and issues the new one in a
-// single statement:
-//  1. mark the old token rotated (idempotent — a concurrent caller may have
-//     already marked it; we still issue the new token so the race loser keeps a
-//     working session),
-//  2. prune the session's *previous* grace token (any rotated row other than the
-//     one we just superseded), bounding an active session to ≤2 rows,
-//  3. insert the new token.
-//
-// The caller is responsible for validating the old token (existence, expiry,
-// grace window) before calling this.
+// RotateRefreshToken marks the presented token rotated and issues a new one in one
+// statement. The prune drops the session's spent tokens but keeps any still inside the
+// grace window, so concurrent refreshes (middleware + client) don't delete a token
+// another in-flight request is about to redeem. The presented token is never pruned;
+// the caller validates it first.
 func (r *RefreshTokenRepository) RotateRefreshToken(
 	ctx context.Context,
 	oldTokenHash string,
@@ -127,7 +117,10 @@ func (r *RefreshTokenRepository) RotateRefreshToken(
 	),
 	pruned AS (
 		DELETE FROM refresh_tokens
-		WHERE session_id = $3 AND rotated_at IS NOT NULL AND token_hash <> $1
+		WHERE session_id = $3
+		  AND token_hash <> $1
+		  AND created_at < NOW() - make_interval(secs => $6)
+		  AND (rotated_at IS NULL OR rotated_at < NOW() - make_interval(secs => $6))
 		RETURNING id
 	)
 	INSERT INTO refresh_tokens (
@@ -147,6 +140,7 @@ func (r *RefreshTokenRepository) RotateRefreshToken(
 		newToken.SessionID,
 		newToken.TokenHash,
 		newToken.ExpiresAt,
+		r.cfg.JWT.RefreshGraceWindow.Seconds(),
 	).Scan(&newToken.ID)
 
 	if err != nil {

--- a/internal/repositories/session_repository.go
+++ b/internal/repositories/session_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/infrastructure/config"
@@ -114,29 +115,37 @@ func (r *SessionRepository) GetSessions(
 	return sessions, nil
 }
 
+// UpdateLastUsedAt touches the session and slides its expiry to slideTo, capped at
+// created_at + maxLifetime. expires_at only ever grows. It returns the resulting
+// expiry so the caller can cap the rotated refresh token to it.
 func (r *SessionRepository) UpdateLastUsedAt(
 	ctx context.Context,
 	id string,
-) error {
+	slideTo time.Time,
+	maxLifetime time.Duration,
+) (time.Time, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	query := `UPDATE sessions SET last_used_at = NOW() WHERE id = $1 AND expires_at > NOW()`
-	result, err := r.db.ExecContext(ctx, query, id)
+	query := `UPDATE sessions
+		SET last_used_at = NOW(),
+			expires_at = GREATEST(
+				expires_at,
+				LEAST($2::timestamptz, created_at + make_interval(secs => $3))
+			)
+		WHERE id = $1 AND expires_at > NOW()
+		RETURNING expires_at`
+
+	var expiresAt time.Time
+	err := r.db.QueryRowContext(ctx, query, id, slideTo, maxLifetime.Seconds()).Scan(&expiresAt)
 	if err != nil {
-		return handleDBError(err, resourceSession)
+		if err == sql.ErrNoRows {
+			return time.Time{}, domain.ErrRefreshTokenInvalidOrExpired
+		}
+		return time.Time{}, handleDBError(err, resourceSession)
 	}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return handleDBError(err, resourceSession)
-	}
-
-	if rowsAffected == 0 {
-		return domain.ErrRefreshTokenInvalidOrExpired
-	}
-
-	return nil
+	return expiresAt, nil
 }
 
 func (r *SessionRepository) DeleteSession(

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/httpctx"
 	"github.com/fifawcp/api/internal/infrastructure/auth"
 	"github.com/fifawcp/api/internal/infrastructure/config"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
@@ -189,21 +190,21 @@ func (s *AuthService) RefreshToken(
 	ctx context.Context,
 	refreshTokenString string,
 ) (*dtos.AuthData, error) {
-	// Validate refresh token
-	refreshToken, err := s.refreshTokenRepository.GetRefreshTokenByTokenHash(ctx, hashToken(refreshTokenString))
+	tokenHash := hashToken(refreshTokenString)
+	refreshToken, err := s.refreshTokenRepository.GetRefreshTokenByTokenHash(ctx, tokenHash)
 	if err != nil {
 		if errors.Is(err, domain.ErrRefreshTokenNotFound) {
+			s.logRefreshOutcome(ctx, "not_found_or_expired", tokenHash, nil)
 			return nil, domain.ErrRefreshTokenInvalidOrExpired
 		}
 
 		return nil, err
 	}
 
-	// A token already superseded by rotation is honored only inside the grace
-	// window — this lets concurrent refreshes (e.g. the web middleware and client
-	// racing on the same cookie) both succeed instead of logging the user out.
-	// Reuse past the window is treated as invalid.
+	// A rotated token is still honored inside the grace window so concurrent refreshes
+	// don't log the user out; past the window it's invalid.
 	if refreshToken.RotatedAt != nil && time.Since(*refreshToken.RotatedAt) > s.cfg.JWT.RefreshGraceWindow {
+		s.logRefreshOutcome(ctx, "rotated_past_grace", tokenHash, refreshToken)
 		return nil, domain.ErrRefreshTokenInvalidOrExpired
 	}
 
@@ -219,9 +220,22 @@ func (s *AuthService) RefreshToken(
 		return nil, err
 	}
 
+	// Slide the session expiry forward (bounded by SessionMaxLifetime) before rotating,
+	// so the new refresh token can be capped to the post-slide expiry rather than the
+	// stale pre-slide one — otherwise an active session's token would be clamped short.
+	sessionExpiresAt, err := s.sessionRepository.UpdateLastUsedAt(
+		ctx,
+		refreshToken.SessionID,
+		time.Now().Add(s.cfg.Auth.SessionTTL),
+		s.cfg.Auth.SessionMaxLifetime,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	refreshTokenExpiresAt := refreshTokenResult.ExpiresAt
-	if refreshTokenExpiresAt.After(refreshToken.SessionExpiresAt) {
-		refreshTokenExpiresAt = refreshToken.SessionExpiresAt
+	if refreshTokenExpiresAt.After(sessionExpiresAt) {
+		refreshTokenExpiresAt = sessionExpiresAt
 	}
 
 	// Rotate refresh token
@@ -234,16 +248,50 @@ func (s *AuthService) RefreshToken(
 		return nil, err
 	}
 
-	// Update session last_used_at
-	if err := s.sessionRepository.UpdateLastUsedAt(ctx, refreshToken.SessionID); err != nil {
-		return nil, err
-	}
+	s.logRefreshOutcome(ctx, "success", tokenHash, refreshToken)
 
 	return &dtos.AuthData{
 		AccessToken:  accessTokenResult.Token,
 		RefreshToken: refreshTokenResult.Token,
 		ExpiresAt:    refreshTokenResult.ExpiresAt,
 	}, nil
+}
+
+// logRefreshOutcome emits one structured line per refresh attempt. rt is nil when no
+// live row was found. Only a hash fingerprint is logged, never the raw token.
+func (s *AuthService) logRefreshOutcome(ctx context.Context, outcome, tokenHash string, rt *domain.RefreshToken) {
+	fields := []any{
+		logging.RefreshOutcome, outcome,
+		logging.TokenFingerprint, tokenHash[:8],
+		logging.GraceWindowMS, s.cfg.JWT.RefreshGraceWindow.Milliseconds(),
+	}
+
+	if rt != nil {
+		fields = append(fields, logging.UserID, rt.UserID, logging.SessionID, rt.SessionID)
+		if !rt.CreatedAt.IsZero() {
+			fields = append(fields, logging.TokenAgeMS, time.Since(rt.CreatedAt).Milliseconds())
+		}
+		if rt.RotatedAt != nil {
+			fields = append(fields, logging.RotatedAgeMS, time.Since(*rt.RotatedAt).Milliseconds())
+		}
+	}
+
+	if diagnostics := httpctx.GetRefreshDiagnostics(ctx); diagnostics != nil {
+		if diagnostics.RequestID != "" {
+			fields = append(fields, logging.RequestID, diagnostics.RequestID)
+		}
+		if diagnostics.Source != "" {
+			fields = append(fields, logging.RefreshSource, diagnostics.Source)
+		}
+	}
+
+	// rotated_past_grace is the real anomaly (race lost past the window / reuse);
+	// success and the benign not_found_or_expired stay at info to avoid warn noise.
+	if outcome == "rotated_past_grace" {
+		s.logger.Warn("refresh outcome", fields...)
+	} else {
+		s.logger.Info("refresh outcome", fields...)
+	}
 }
 
 func (s *AuthService) Logout(ctx context.Context, refreshToken string) error {

--- a/internal/services/auth_service_test.go
+++ b/internal/services/auth_service_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/infrastructure/auth"
 	"github.com/fifawcp/api/internal/infrastructure/config"
-	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/fifawcp/api/internal/infrastructure/totp"
+	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,9 +34,10 @@ func newTestAuthService(
 			RefreshGraceWindow: 10 * time.Second,
 		},
 		Auth: config.AuthConfig{
-			OTPCooldown:    30 * time.Second,
-			MaxOTPAttempts: 3,
-			SessionTTL:     24 * time.Hour,
+			OTPCooldown:        30 * time.Second,
+			MaxOTPAttempts:     3,
+			SessionTTL:         24 * time.Hour,
+			SessionMaxLifetime: 72 * time.Hour,
 		},
 	}
 
@@ -1114,9 +1115,12 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
 				assert.Equal(t, sessionID, id)
-				return nil
+				// expiry slides to now + SessionTTL, bounded by SessionMaxLifetime
+				assert.WithinDuration(t, time.Now().Add(24*time.Hour), slideTo, time.Minute)
+				assert.Equal(t, 72*time.Hour, maxLifetime)
+				return slideTo, nil
 			},
 		}
 
@@ -1158,7 +1162,9 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error { return nil },
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
 		}
 
 		authenticator := &mocks.MockAuthenticator{
@@ -1252,8 +1258,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return errors.New("database error")
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return time.Time{}, errors.New("database error")
 			},
 		}
 
@@ -1288,8 +1294,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return nil
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
 			},
 		}
 
@@ -1328,8 +1334,8 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		}
 
 		sr := &mocks.MockSessionRepository{
-			UpdateLastUsedAtFunc: func(ctx context.Context, id string) error {
-				return nil
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
 			},
 		}
 
@@ -1367,13 +1373,19 @@ func TestAuthService_RefreshToken(t *testing.T) {
 			},
 		}
 
+		sr := &mocks.MockSessionRepository{
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
+		}
+
 		authenticator := &mocks.MockAuthenticator{
 			GenerateTokenFunc: func(uid string, tokenType auth.TokenType) (*auth.TokenResult, error) {
 				return &auth.TokenResult{Token: "access-token", ExpiresAt: time.Now().Add(time.Hour)}, nil
 			},
 		}
 
-		service := newTestAuthService(nil, nil, rtr, nil, &mocks.MockLogger{}, authenticator, nil)
+		service := newTestAuthService(nil, sr, rtr, nil, &mocks.MockLogger{}, authenticator, nil)
 
 		result, err := service.RefreshToken(context.Background(), "token")
 

--- a/internal/services/competition_scoring_service.go
+++ b/internal/services/competition_scoring_service.go
@@ -66,6 +66,30 @@ func (s *CompetitionScoringService) RecomputeForMatches(ctx context.Context, res
 		}
 	}
 
+	// Pool competitions (single-match pools share the match-score cache)
+	if len(result.ScoredMatchIDs) > 0 {
+		poolIDs, err := s.competitionScoreRepository.FindPoolCompetitionsByMatches(ctx, result.ScoredMatchIDs)
+		if err != nil {
+			s.logger.Error("failed to find pool competitions",
+				logging.Error, err.Error(),
+				"match_ids", result.ScoredMatchIDs,
+			)
+			return err
+		}
+
+		for _, competitionID := range poolIDs {
+			if err := s.competitionScoreRepository.BatchUpsertPoolScores(
+				ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
+			); err != nil {
+				s.logger.Error("failed to upsert pool scores",
+					logging.Error, err.Error(),
+					"competition_id", competitionID,
+				)
+				return err
+			}
+		}
+	}
+
 	// Pickem competitions
 	if result.PickemAffected {
 		if err := s.recomputeAllPickems(ctx, result.AffectedUserIDs); err != nil {

--- a/internal/services/competition_scoring_service_test.go
+++ b/internal/services/competition_scoring_service_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompetitionScoringService_RecomputeForMatches_Pools(t *testing.T) {
+	t.Parallel()
+
+	matchIDs := []int64{42}
+	userIDs := []string{"user-1", "user-2"}
+	poolID := int64(7)
+
+	var upsertedPoolID int64
+	var upsertedPts int
+	var upsertedUsers []string
+
+	scoreRepo := &mocks.MockCompetitionScoreRepository{
+		FindMatchCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
+			return nil, nil
+		},
+		FindPoolCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
+			assert.Equal(t, matchIDs, ids)
+			return []int64{poolID}, nil
+		},
+		BatchUpsertPoolScoresFunc: func(ctx context.Context, competitionID int64, users []string, exactScorePts int) error {
+			upsertedPoolID = competitionID
+			upsertedUsers = users
+			upsertedPts = exactScorePts
+			return nil
+		},
+	}
+
+	cfg := &config.Config{Scoring: config.ScoringConfig{MatchScoreExact: 5}}
+	service := NewCompetitionScoringService(&mocks.MockCompetitionRepository{}, scoreRepo, cfg, &mocks.MockLogger{})
+
+	err := service.RecomputeForMatches(context.Background(), &domain.ScoreMatchesResult{
+		AffectedUserIDs: userIDs,
+		ScoredMatchIDs:  matchIDs,
+		PickemAffected:  false,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, poolID, upsertedPoolID)
+	assert.Equal(t, userIDs, upsertedUsers)
+	assert.Equal(t, 5, upsertedPts)
+}

--- a/internal/services/competition_service.go
+++ b/internal/services/competition_service.go
@@ -48,10 +48,11 @@ func (s *CompetitionService) CreateCompetition(
 	}
 
 	competition := &domain.Competition{
-		BoardID:   boardID,
-		Type:      payload.Type,
-		Name:      payload.Name,
-		CreatedBy: &userID,
+		BoardID:     boardID,
+		Type:        payload.Type,
+		Name:        payload.Name,
+		CreatedBy:   &userID,
+		PoolMatchID: payload.MatchID,
 	}
 
 	if payload.Scope != nil {

--- a/internal/services/competition_service_test.go
+++ b/internal/services/competition_service_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/test/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestCompetitionService(br *mocks.MockBoardRepository, cr *mocks.MockCompetitionRepository) CompetitionServiceInterface {
@@ -20,6 +22,57 @@ func privateBoardRepo() *mocks.MockBoardRepository {
 			return &domain.Board{ID: bid, Privacy: domain.BoardPrivacyPrivate}, nil
 		},
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCompetitionService_CreateCompetition
+// ---------------------------------------------------------------------------
+func TestCompetitionService_CreateCompetition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates a pool competition carrying the match id", func(t *testing.T) {
+		t.Parallel()
+
+		boardID := gofakeit.Int64()
+		userID := gofakeit.UUID()
+		matchID := gofakeit.Int64()
+
+		var captured *domain.Competition
+		cr := &mocks.MockCompetitionRepository{
+			CreateCompetitionFunc: func(ctx context.Context, c *domain.Competition) error {
+				captured = c
+				return nil
+			},
+		}
+
+		service := newTestCompetitionService(privateBoardRepo(), cr)
+
+		_, err := service.CreateCompetition(context.Background(), boardID, userID, domain.BoardMemberRoleAdmin, dtos.CreateCompetitionDto{
+			Type:    domain.CompetitionTypePool,
+			Name:    "CvP",
+			MatchID: &matchID,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.PoolMatchID)
+		assert.Equal(t, matchID, *captured.PoolMatchID)
+		assert.Equal(t, domain.CompetitionTypePool, captured.Type)
+	})
+
+	t.Run("rejects a member without manage permission", func(t *testing.T) {
+		t.Parallel()
+
+		// Empty repos: the role check must short-circuit before any repo call.
+		service := newTestCompetitionService(&mocks.MockBoardRepository{}, &mocks.MockCompetitionRepository{})
+
+		_, err := service.CreateCompetition(context.Background(), gofakeit.Int64(), gofakeit.UUID(), domain.BoardMemberRoleMember, dtos.CreateCompetitionDto{
+			Type: domain.CompetitionTypePool,
+			Name: "CvP",
+		})
+
+		assert.ErrorIs(t, err, domain.ErrCompetitionForbidden)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/test/mocks/award_service_mock.go
+++ b/internal/test/mocks/award_service_mock.go
@@ -7,10 +7,10 @@ import (
 )
 
 type MockAwardService struct {
-	GetUserAwardsFunc    func(ctx context.Context, userID string) (*domain.UserAwards, error)
-	SaveAwardPicksFunc   func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
-	GetPopularPicksFunc  func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
-	RecordWinnersFunc    func(ctx context.Context, winners []*domain.AwardWinner) error
+	GetUserAwardsFunc   func(ctx context.Context, userID string) (*domain.UserAwards, error)
+	SaveAwardPicksFunc  func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
+	GetPopularPicksFunc func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
+	RecordWinnersFunc   func(ctx context.Context, winners []*domain.AwardWinner) error
 }
 
 func (m *MockAwardService) GetUserAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {

--- a/internal/test/mocks/competition_score_repository_mock.go
+++ b/internal/test/mocks/competition_score_repository_mock.go
@@ -8,7 +8,9 @@ import (
 
 type MockCompetitionScoreRepository struct {
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPoolCompetitionsByMatchesFunc  func(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScoresFunc         func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	BatchUpsertPoolScoresFunc          func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
 	BatchUpsertPickemScoresFunc        func(ctx context.Context, competitionIDs []int64, userIDs []string) error
 	GetLeaderboardFunc                 func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
 	GetUserPickemStatsFunc             func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error)
@@ -22,11 +24,25 @@ func (m *MockCompetitionScoreRepository) FindMatchCompetitionsByMatches(ctx cont
 	panic("FindMatchCompetitionsByMatches called unexpectedly")
 }
 
+func (m *MockCompetitionScoreRepository) FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error) {
+	if m.FindPoolCompetitionsByMatchesFunc != nil {
+		return m.FindPoolCompetitionsByMatchesFunc(ctx, matchIDs)
+	}
+	panic("FindPoolCompetitionsByMatches called unexpectedly")
+}
+
 func (m *MockCompetitionScoreRepository) BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
 	if m.BatchUpsertMatchScoresFunc != nil {
 		return m.BatchUpsertMatchScoresFunc(ctx, competitionID, userIDs, exactScorePts)
 	}
 	panic("BatchUpsertMatchScores called unexpectedly")
+}
+
+func (m *MockCompetitionScoreRepository) BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
+	if m.BatchUpsertPoolScoresFunc != nil {
+		return m.BatchUpsertPoolScoresFunc(ctx, competitionID, userIDs, exactScorePts)
+	}
+	panic("BatchUpsertPoolScores called unexpectedly")
 }
 
 func (m *MockCompetitionScoreRepository) BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error {

--- a/internal/test/mocks/competition_service_mock.go
+++ b/internal/test/mocks/competition_service_mock.go
@@ -1,0 +1,43 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+)
+
+type MockCompetitionService struct {
+	CreateCompetitionFunc    func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error)
+	GetBoardCompetitionsFunc func(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
+	GetLeaderboardFunc       func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
+	DeleteCompetitionFunc    func(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error
+}
+
+func (m *MockCompetitionService) CreateCompetition(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
+	if m.CreateCompetitionFunc != nil {
+		return m.CreateCompetitionFunc(ctx, boardID, userID, role, payload)
+	}
+	panic("CreateCompetition called unexpectedly")
+}
+
+func (m *MockCompetitionService) GetBoardCompetitions(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error) {
+	if m.GetBoardCompetitionsFunc != nil {
+		return m.GetBoardCompetitionsFunc(ctx, boardID, viewerUserID)
+	}
+	panic("GetBoardCompetitions called unexpectedly")
+}
+
+func (m *MockCompetitionService) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+	if m.GetLeaderboardFunc != nil {
+		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q)
+	}
+	panic("GetLeaderboard called unexpectedly")
+}
+
+func (m *MockCompetitionService) DeleteCompetition(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error {
+	if m.DeleteCompetitionFunc != nil {
+		return m.DeleteCompetitionFunc(ctx, boardID, competitionID, role)
+	}
+	panic("DeleteCompetition called unexpectedly")
+}

--- a/internal/test/mocks/session_repository_mock.go
+++ b/internal/test/mocks/session_repository_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"github.com/fifawcp/api/internal/domain"
 )
@@ -9,7 +10,7 @@ import (
 type MockSessionRepository struct {
 	CreateSessionFunc         func(ctx context.Context, session *domain.Session) error
 	GetSessionsFunc           func(ctx context.Context, refreshTokenHash string) ([]domain.Session, error)
-	UpdateLastUsedAtFunc      func(ctx context.Context, id string) error
+	UpdateLastUsedAtFunc      func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error)
 	DeleteSessionFunc         func(ctx context.Context, refreshTokenHash string) error
 	DeleteAllSessionsFunc     func(ctx context.Context, refreshTokenHash string) error
 	DeleteSessionByIdFunc     func(ctx context.Context, sessionID string, userID string) error
@@ -30,9 +31,9 @@ func (m *MockSessionRepository) GetSessions(ctx context.Context, refreshTokenHas
 	panic("GetSessions called unexpectedly")
 }
 
-func (m *MockSessionRepository) UpdateLastUsedAt(ctx context.Context, id string) error {
+func (m *MockSessionRepository) UpdateLastUsedAt(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
 	if m.UpdateLastUsedAtFunc != nil {
-		return m.UpdateLastUsedAtFunc(ctx, id)
+		return m.UpdateLastUsedAtFunc(ctx, id, slideTo, maxLifetime)
 	}
 	panic("UpdateLastUsedAt called unexpectedly")
 }


### PR DESCRIPTION
## Release v1.1.0

Adds pool competitions and hardens session handling.

### Highlights
- Pool competition type — single-match leaderboards tied to a match, with one-pool-per-match enforcement and match-driven score recompute.
- New board members are now backfilled into existing pool leaderboards on join.

### Fixes
- Sliding sessions + refresh-token rotation race conditions, with added diagnostics.