### PR TITLE
chore: release v1.2.0

### DIFF
--- a/cmd/db/migrations/000017_create_competition_awards.down.sql
+++ b/cmd/db/migrations/000017_create_competition_awards.down.sql
@@ -1,0 +1,25 @@
+-- Recreates competition_pickem_scores empty (it's a cache — repopulate with a
+-- rescore). Restores the pre-000017 schema: 000010 columns + the 000013 award_hits.
+
+CREATE TABLE competition_pickem_scores (
+    competition_id        BIGINT NOT NULL REFERENCES competitions(id) ON DELETE CASCADE,
+    user_id               UUID   NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    total_points          INT    NOT NULL DEFAULT 0,
+    group_exact_positions INT    NOT NULL DEFAULT 0,
+    group_qualifier_hits  INT    NOT NULL DEFAULT 0,
+    best_third_hits       INT    NOT NULL DEFAULT 0,
+    bracket_hits          INT    NOT NULL DEFAULT 0,
+    award_hits            INT    NOT NULL DEFAULT 0,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (competition_id, user_id)
+);
+
+CREATE INDEX idx_cps_competition_points
+    ON competition_pickem_scores(competition_id, total_points DESC);
+
+DELETE FROM competitions WHERE type = 'awards';
+DROP INDEX IF EXISTS idx_competitions_one_awards_per_board;
+
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pool'));

--- a/cmd/db/migrations/000017_create_competition_awards.up.sql
+++ b/cmd/db/migrations/000017_create_competition_awards.up.sql
@@ -1,0 +1,17 @@
+-- Awards becomes a standalone competition type. Pick'em and Awards leaderboards
+-- are computed on read from score_events, so their per-competition cache tables
+-- are removed (competition_pickem_scores dropped here; awards never cached).
+-- Match/pool keep competition_match_scores.
+
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pool', 'awards'));
+
+CREATE UNIQUE INDEX idx_competitions_one_awards_per_board
+    ON competitions(board_id) WHERE type = 'awards';
+
+INSERT INTO competitions (board_id, type, name, created_by, created_at)
+SELECT id, 'awards', 'Awards', NULL, NOW() FROM boards
+ON CONFLICT (board_id, name) DO NOTHING;
+
+DROP TABLE competition_pickem_scores;

--- a/cmd/db/migrations/000018_rename_pool_to_pick.down.sql
+++ b/cmd/db/migrations/000018_rename_pool_to_pick.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_pick_match;
+
+UPDATE competitions SET type = 'pool' WHERE type = 'pick';
+
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pool', 'awards'));
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_pool_match
+    CHECK ((type = 'pool') = (match_id IS NOT NULL));
+
+DROP INDEX IF EXISTS idx_competitions_one_pick_per_match;
+CREATE UNIQUE INDEX idx_competitions_one_pool_per_match
+    ON competitions(board_id, match_id) WHERE type = 'pool';

--- a/cmd/db/migrations/000018_rename_pool_to_pick.up.sql
+++ b/cmd/db/migrations/000018_rename_pool_to_pick.up.sql
@@ -1,0 +1,16 @@
+-- The single-match competition type is renamed 'pool' -> 'pick': it covers ONE
+-- match, not many. Both CHECK constraints reject the new value, so drop them
+-- first, rename the existing rows, then re-add the constraints and the index.
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_type;
+ALTER TABLE competitions DROP CONSTRAINT chk_competition_pool_match;
+
+UPDATE competitions SET type = 'pick' WHERE type = 'pool';
+
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_type
+    CHECK (type IN ('pickem', 'match', 'pick', 'awards'));
+ALTER TABLE competitions ADD CONSTRAINT chk_competition_pick_match
+    CHECK ((type = 'pick') = (match_id IS NOT NULL));
+
+DROP INDEX IF EXISTS idx_competitions_one_pool_per_match;
+CREATE UNIQUE INDEX idx_competitions_one_pick_per_match
+    ON competitions(board_id, match_id) WHERE type = 'pick';

--- a/cmd/db/seed/main.go
+++ b/cmd/db/seed/main.go
@@ -66,7 +66,7 @@ func main() {
 		cfg, logger,
 	)
 	competitionScoringService := services.NewCompetitionScoringService(
-		competitionRepository, competitionScoreRepository, cfg, logger,
+		competitionScoreRepository, cfg, logger,
 	)
 	competitionService := services.NewCompetitionService(
 		boardRepository, competitionRepository, competitionScoreRepository,

--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -376,7 +376,6 @@ func allMatchIDs() []int64 {
 func (s *Seeder) resetTournamentState(ctx context.Context) error {
 	queries := []string{
 		`DELETE FROM score_events`,
-		`DELETE FROM competition_pickem_scores`,
 		`DELETE FROM competition_match_scores`,
 		`DELETE FROM user_bracket_picks`,
 		`DELETE FROM user_match_score_picks`,

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -278,7 +278,7 @@ func (c *Container) initServices() {
 	)
 
 	c.competitionScoringService = services.NewCompetitionScoringService(
-		c.competitionRepository, c.competitionScoreRepository, c.Config, c.Logger,
+		c.competitionScoreRepository, c.Config, c.Logger,
 	)
 	c.competitionService = services.NewCompetitionService(
 		c.boardRepository, c.competitionRepository, c.competitionScoreRepository,
@@ -296,7 +296,7 @@ func (c *Container) initServices() {
 	c.playerService = services.NewPlayerService(c.playerRepository)
 	c.awardService = services.NewAwardService(
 		c.awardPickRepository, c.playerRepository,
-		c.pickemScoringService, c.competitionScoringService,
+		c.pickemScoringService,
 		c.firstKickoff, c.Config, c.Logger,
 	)
 

--- a/internal/app/routes_boards.go
+++ b/internal/app/routes_boards.go
@@ -37,6 +37,8 @@ func boardsRoutes(c *Container) chi.Router {
 				})
 			})
 
+			r.Get("/summary", c.CompetitionHandler.GetBoardSummary)
+
 			r.Route("/competitions", func(r chi.Router) {
 				r.Get("/", c.CompetitionHandler.GetBoardCompetitions)
 				r.Post("/", c.CompetitionHandler.CreateCompetition)

--- a/internal/domain/competition.go
+++ b/internal/domain/competition.go
@@ -10,7 +10,8 @@ type CompetitionType string
 const (
 	CompetitionTypePickem CompetitionType = "pickem"
 	CompetitionTypeMatch  CompetitionType = "match"
-	CompetitionTypePool   CompetitionType = "pool"
+	CompetitionTypePick   CompetitionType = "pick"
+	CompetitionTypeAwards CompetitionType = "awards"
 )
 
 type Competition struct {
@@ -21,7 +22,7 @@ type Competition struct {
 	CreatedBy   *string           `json:"-"`
 	CreatedAt   time.Time         `json:"created_at" example:"2026-01-15T10:30:00Z"`
 	Scope       *CompetitionScope `json:"scope,omitempty"`
-	PoolMatchID *int64            `json:"pool_match_id,omitempty" example:"42"`
+	PickMatchID *int64            `json:"pick_match_id,omitempty" example:"42"`
 }
 
 // CompetitionScope is only populated for match competitions
@@ -32,7 +33,25 @@ type CompetitionScope struct {
 
 type CompetitionListItem struct {
 	Competition
-	Viewer CompetitionViewer `json:"viewer"`
+	Viewer     CompetitionViewer              `json:"viewer"`
+	TopPreview []*CompetitionLeaderboardEntry `json:"top_preview"`
+}
+
+// BoardSummaryEntry is one member's board-wide standing: points per competition
+// type plus the raw-sum overall. Custom = match competitions.
+type BoardSummaryEntry struct {
+	Member CompetitionLeaderboardMember `json:"member"`
+	Rank   int                          `json:"rank"`
+	Total  int                          `json:"total"`
+	Pickem int                          `json:"pickem"`
+	Custom int                          `json:"custom"`
+	Pick   int                          `json:"pick"`
+	Awards int                          `json:"awards"`
+}
+
+type BoardSummaryPage struct {
+	Members    []*BoardSummaryEntry `json:"members"`
+	Pagination Pagination           `json:"-"`
 }
 
 type CompetitionViewer struct {
@@ -55,13 +74,20 @@ type PickemScore struct {
 	GroupQualifierHits  int `json:"group_qualifier_hits" example:"3"`
 	BestThirdHits       int `json:"best_third_hits" example:"2"`
 	BracketHits         int `json:"bracket_hits" example:"5"`
-	AwardHits           int `json:"award_hits" example:"1"`
 }
 
 type MatchScore struct {
 	Total           int `json:"total" example:"12"`
 	ExactHits       int `json:"exact_hits" example:"2"`
 	CorrectOutcomes int `json:"correct_outcomes" example:"3"`
+}
+
+type AwardsScore struct {
+	Total       int `json:"total" example:"40"`
+	GoldenBoot  int `json:"golden_boot" example:"1"`
+	GoldenBall  int `json:"golden_ball" example:"0"`
+	GoldenGlove int `json:"golden_glove" example:"1"`
+	YoungPlayer int `json:"young_player" example:"0"`
 }
 
 type CompetitionLeaderboardEntry struct {
@@ -80,7 +106,6 @@ type CompetitionRepository interface {
 	GetBoardCompetitions(ctx context.Context, boardID int64, viewerUserID string) ([]*CompetitionListItem, error)
 	GetCompetitionByID(ctx context.Context, boardID, competitionID int64) (*Competition, error)
 	DeleteCompetition(ctx context.Context, boardID, competitionID int64) error
-	GetAllPickemIDs(ctx context.Context) ([]int64, error)
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
 	GetGlobalCompetitions(ctx context.Context) (pickem *Competition, match *Competition, err error)
 }

--- a/internal/domain/competition_score.go
+++ b/internal/domain/competition_score.go
@@ -7,7 +7,6 @@ import "context"
 type ScoreMatchesResult struct {
 	AffectedUserIDs []string
 	ScoredMatchIDs  []int64
-	PickemAffected  bool
 }
 
 type CompetitionUserStats struct {
@@ -17,11 +16,12 @@ type CompetitionUserStats struct {
 
 type CompetitionScoreRepository interface {
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
-	FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPickCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
-	BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
-	BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error
-	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*CompetitionLeaderboardPage, error)
+	BatchUpsertPickScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*CompetitionLeaderboardPage, error)
+	GetBoardSummary(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*BoardSummaryPage, error)
+	GetBoardCompetitionPreviews(ctx context.Context, boardID int64, limit int) (map[int64][]*CompetitionLeaderboardEntry, error)
 	GetUserPickemStats(ctx context.Context, competitionID int64, userID string) (CompetitionUserStats, error)
 	GetUserMatchStats(ctx context.Context, competitionID int64, userID string) (CompetitionUserStats, error)
 }

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -108,9 +108,9 @@ var ErrOAuthAccountNotVerified = errors.New("oauth account not verified")
 var ErrCompetitionNotFound = errors.New("competition not found")
 var ErrCompetitionForbidden = errors.New("only board owner or admins can manage competitions")
 var ErrCompetitionPickemAlreadyExists = errors.New("a tournament pick'em competition already exists on this board")
+var ErrCompetitionAwardsAlreadyExists = errors.New("an awards competition already exists on this board")
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
-var ErrCompetitionPickemNotDeletable = errors.New("the tournament pick'em competition cannot be deleted")
-var ErrDuplicatePoolForMatch = errors.New("a pool for this match already exists on this board")
+var ErrDuplicatePickForMatch = errors.New("a pick for this match already exists on this board")
 
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")

--- a/internal/dtos/competition_dto.go
+++ b/internal/dtos/competition_dto.go
@@ -8,7 +8,7 @@ type CreateCompetitionScopeDto struct {
 }
 
 type CreateCompetitionDto struct {
-	Type    domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match pool" example:"pickem"`
+	Type    domain.CompetitionType     `json:"type" validate:"required,oneof=pickem match pick awards" example:"pickem"`
 	Name    string                     `json:"name" validate:"required,max=20" example:"Pick'em"`
 	Scope   *CreateCompetitionScopeDto `json:"scope,omitempty"`
 	MatchID *int64                     `json:"match_id,omitempty" example:"42"`

--- a/internal/handlers/competition_handler.go
+++ b/internal/handlers/competition_handler.go
@@ -124,13 +124,52 @@ func (h *CompetitionHandler) GetLeaderboard(w http.ResponseWriter, r *http.Reque
 		q = q[:64]
 	}
 
-	leaderboardPage, err := h.competitionService.GetLeaderboard(r.Context(), competitionID, page, limit, q)
+	sort := r.URL.Query().Get("sort")
+	dir := r.URL.Query().Get("dir")
+
+	leaderboardPage, err := h.competitionService.GetLeaderboard(r.Context(), competitionID, page, limit, q, sort, dir)
 	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return
 	}
 
 	httpx.RespondWithPaginatedData(w, http.StatusOK, leaderboardPage.Members, leaderboardPage.Pagination)
+}
+
+// GetBoardSummary godoc
+//
+//	@Summary		Get board summary standings
+//	@Description	Per-member points across all the board's competitions (per-type subtotals + raw-sum total), ranked.
+//	@Tags			competitions
+//	@Produce		json
+//	@Param			boardId	path		int					true	"Board ID"
+//	@Param			page	query		int					false	"Page number (1-indexed, default 1)"
+//	@Param			limit	query		int					false	"Page size (default 20, max 100)"
+//	@Param			q		query		string				false	"Filter by username, first name, or last name"
+//	@Success		200		{object}	httpx.Response		"Summary page retrieved successfully"
+//	@Failure		401		{object}	httpx.ErrorResponse	"Unauthorized"
+//	@Failure		500		{object}	httpx.ErrorResponse	"Internal server error"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/summary [get]
+func (h *CompetitionHandler) GetBoardSummary(w http.ResponseWriter, r *http.Request) {
+	boardID := httpctx.GetBoardID(r.Context())
+	page, limit := httpx.ParsePagination(w, r)
+
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if len(q) > 64 {
+		q = q[:64]
+	}
+
+	sort := r.URL.Query().Get("sort")
+	dir := r.URL.Query().Get("dir")
+
+	summary, err := h.competitionService.GetBoardSummary(r.Context(), boardID, page, limit, q, sort, dir)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithPaginatedData(w, http.StatusOK, summary.Members, summary.Pagination)
 }
 
 // DeleteCompetition godoc

--- a/internal/handlers/competition_handler_test.go
+++ b/internal/handlers/competition_handler_test.go
@@ -20,7 +20,7 @@ func newTestCompetitionHandler(cs *mocks.MockCompetitionService) *CompetitionHan
 	return NewCompetitionHandler(cs, testutils.NewTestConfig(), validator.NewValidator(), &mocks.MockLogger{})
 }
 
-func makeCreatePoolReq(t *testing.T, body any) *http.Request {
+func makeCreatePickReq(t *testing.T, body any) *http.Request {
 	return testutils.MakeJSONRequest(
 		t, http.MethodPost, "/boards/1/competitions", body,
 		testutils.WithAuthUser(testutils.CreateTestUser()),
@@ -29,7 +29,7 @@ func makeCreatePoolReq(t *testing.T, body any) *http.Request {
 	)
 }
 
-func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
+func TestCompetitionHandler_CreateCompetition_Pick(t *testing.T) {
 	t.Parallel()
 
 	matchID := int64(42)
@@ -40,13 +40,13 @@ func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
 		cs := &mocks.MockCompetitionService{
 			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
 				return &domain.CompetitionListItem{
-					Competition: domain.Competition{ID: 9, BoardID: boardID, Type: domain.CompetitionTypePool, Name: payload.Name, PoolMatchID: payload.MatchID},
+					Competition: domain.Competition{ID: 9, BoardID: boardID, Type: domain.CompetitionTypePick, Name: payload.Name, PickMatchID: payload.MatchID},
 				}, nil
 			},
 		}
 		h := newTestCompetitionHandler(cs)
 
-		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		req := makeCreatePickReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePick, Name: "CvP", MatchID: &matchID})
 		w := httptest.NewRecorder()
 
 		h.CreateCompetition(w, req)
@@ -56,22 +56,22 @@ func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
 			Data domain.CompetitionListItem `json:"data"`
 		}
 		testutils.ParseJSONResponse(t, w, &resp)
-		assert.Equal(t, domain.CompetitionTypePool, resp.Data.Type)
-		require.NotNil(t, resp.Data.PoolMatchID)
-		assert.Equal(t, matchID, *resp.Data.PoolMatchID)
+		assert.Equal(t, domain.CompetitionTypePick, resp.Data.Type)
+		require.NotNil(t, resp.Data.PickMatchID)
+		assert.Equal(t, matchID, *resp.Data.PickMatchID)
 	})
 
-	t.Run("returns 409 when a pool already exists for the match", func(t *testing.T) {
+	t.Run("returns 409 when a pick already exists for the match", func(t *testing.T) {
 		t.Parallel()
 
 		cs := &mocks.MockCompetitionService{
 			CreateCompetitionFunc: func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error) {
-				return nil, domain.ErrDuplicatePoolForMatch
+				return nil, domain.ErrDuplicatePickForMatch
 			},
 		}
 		h := newTestCompetitionHandler(cs)
 
-		req := makeCreatePoolReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePool, Name: "CvP", MatchID: &matchID})
+		req := makeCreatePickReq(t, dtos.CreateCompetitionDto{Type: domain.CompetitionTypePick, Name: "CvP", MatchID: &matchID})
 		w := httptest.NewRecorder()
 
 		h.CreateCompetition(w, req)
@@ -79,6 +79,6 @@ func TestCompetitionHandler_CreateCompetition_Pool(t *testing.T) {
 		require.Equal(t, http.StatusConflict, w.Code)
 		var resp httpx.ErrorResponse
 		testutils.ParseJSONResponse(t, w, &resp)
-		assert.Equal(t, "DUPLICATE_POOL_FOR_MATCH", resp.Error.Code)
+		assert.Equal(t, "DUPLICATE_PICK_FOR_MATCH", resp.Error.Code)
 	})
 }

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -29,9 +29,9 @@ const (
 	codeBoardUserAlreadyInBoard        = "BOARD_USER_ALREADY_IN_BOARD"
 	codeMaxBoardMembersExceeded        = "MAX_BOARD_MEMBERS_EXCEEDED"
 	codeCompetitionPickemAlreadyExists = "COMPETITION_PICKEM_ALREADY_EXISTS"
+	codeCompetitionAwardsAlreadyExists = "COMPETITION_AWARDS_ALREADY_EXISTS"
 	codeCompetitionNameAlreadyExists   = "COMPETITION_NAME_ALREADY_EXISTS"
-	codeCompetitionPickemNotDeletable  = "COMPETITION_PICKEM_NOT_DELETABLE"
-	codeDuplicatePoolForMatch          = "DUPLICATE_POOL_FOR_MATCH"
+	codeDuplicatePickForMatch          = "DUPLICATE_PICK_FOR_MATCH"
 
 	// 401 Unauthorized
 	codeOTPInvalidOrExpired          = "OTP_INVALID_OR_EXPIRED"
@@ -124,8 +124,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 	// 409 Conflict
 	case errors.Is(err, domain.ErrCompetitionPickemAlreadyExists):
 		httpx.Conflict(w, r, codeCompetitionPickemAlreadyExists, domain.ErrCompetitionPickemAlreadyExists.Error())
-	case errors.Is(err, domain.ErrCompetitionPickemNotDeletable):
-		httpx.Conflict(w, r, codeCompetitionPickemNotDeletable, domain.ErrCompetitionPickemNotDeletable.Error())
+	case errors.Is(err, domain.ErrCompetitionAwardsAlreadyExists):
+		httpx.Conflict(w, r, codeCompetitionAwardsAlreadyExists, domain.ErrCompetitionAwardsAlreadyExists.Error())
 	case errors.Is(err, domain.ErrUserAlreadyExists):
 		httpx.Conflict(w, r, codeUserAlreadyExists, domain.ErrUserAlreadyExists.Error())
 	case errors.Is(err, domain.ErrUsernameAlreadyExists):
@@ -234,8 +234,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.BadRequest(w, r, codeCannotTransferToSelf, domain.ErrCannotTransferOwnershipToSelf.Error())
 	case errors.Is(err, domain.ErrCompetitionNameAlreadyExists):
 		httpx.Conflict(w, r, codeCompetitionNameAlreadyExists, domain.ErrCompetitionNameAlreadyExists.Error())
-	case errors.Is(err, domain.ErrDuplicatePoolForMatch):
-		httpx.Conflict(w, r, codeDuplicatePoolForMatch, domain.ErrDuplicatePoolForMatch.Error())
+	case errors.Is(err, domain.ErrDuplicatePickForMatch):
+		httpx.Conflict(w, r, codeDuplicatePickForMatch, domain.ErrDuplicatePickForMatch.Error())
 
 	// 502 Bad Gateway
 	case errors.Is(err, domain.ErrMissingIDToken):

--- a/internal/infrastructure/validator/validator.go
+++ b/internal/infrastructure/validator/validator.go
@@ -170,15 +170,21 @@ func validateCreateCompetition(sl validator.StructLevel) {
 	input := sl.Current().Interface().(dtos.CreateCompetitionDto)
 
 	switch input.Type {
-	case domain.CompetitionTypePickem:
+	case domain.CompetitionTypePickem, domain.CompetitionTypeAwards:
 		if input.Scope != nil {
 			sl.ReportError(input.Scope, "scope", "Scope", "scope_forbidden", "")
+		}
+		if input.MatchID != nil {
+			sl.ReportError(input.MatchID, "match_id", "MatchID", "match_id_forbidden", "")
 		}
 	case domain.CompetitionTypeMatch:
 		if input.Scope == nil || len(input.Scope.Stages) == 0 {
 			sl.ReportError(input.Scope, "scope", "Scope", "scope_required", "")
 		}
-	case domain.CompetitionTypePool:
+		if input.MatchID != nil {
+			sl.ReportError(input.MatchID, "match_id", "MatchID", "match_id_forbidden", "")
+		}
+	case domain.CompetitionTypePick:
 		if input.Scope != nil {
 			sl.ReportError(input.Scope, "scope", "Scope", "scope_forbidden", "")
 		}

--- a/internal/infrastructure/validator/validator_test.go
+++ b/internal/infrastructure/validator/validator_test.go
@@ -347,11 +347,11 @@ func TestValidateStruct_UpdateMatchResult_RejectsTiedPenalties(t *testing.T) {
 	assert.Equal(t, "PENALTY_TIED", awayField.Code)
 }
 
-func TestValidateStruct_CreateCompetition_ValidPool(t *testing.T) {
+func TestValidateStruct_CreateCompetition_ValidPick(t *testing.T) {
 	matchID := int64(42)
 
 	result := v.ValidateStruct(dtos.CreateCompetitionDto{
-		Type:    domain.CompetitionTypePool,
+		Type:    domain.CompetitionTypePick,
 		Name:    "CvP",
 		MatchID: &matchID,
 	})
@@ -359,9 +359,9 @@ func TestValidateStruct_CreateCompetition_ValidPool(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func TestValidateStruct_CreateCompetition_PoolRequiresMatchID(t *testing.T) {
+func TestValidateStruct_CreateCompetition_PickRequiresMatchID(t *testing.T) {
 	result := v.ValidateStruct(dtos.CreateCompetitionDto{
-		Type: domain.CompetitionTypePool,
+		Type: domain.CompetitionTypePick,
 		Name: "CvP",
 	})
 
@@ -371,11 +371,11 @@ func TestValidateStruct_CreateCompetition_PoolRequiresMatchID(t *testing.T) {
 	assert.Equal(t, "REQUIRED", field.Code)
 }
 
-func TestValidateStruct_CreateCompetition_PoolForbidsScope(t *testing.T) {
+func TestValidateStruct_CreateCompetition_PickForbidsScope(t *testing.T) {
 	matchID := int64(42)
 
 	result := v.ValidateStruct(dtos.CreateCompetitionDto{
-		Type:    domain.CompetitionTypePool,
+		Type:    domain.CompetitionTypePick,
 		Name:    "CvP",
 		MatchID: &matchID,
 		Scope: &dtos.CreateCompetitionScopeDto{

--- a/internal/repositories/board_member_repository.go
+++ b/internal/repositories/board_member_repository.go
@@ -73,38 +73,6 @@ func (r *BoardMemberRepository) initCompetitionScoresForMember(
 	boardID int64,
 	userID string,
 ) error {
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO competition_pickem_scores (
-			competition_id, user_id,
-			total_points, group_exact_positions, group_qualifier_hits, best_third_hits, bracket_hits
-		)
-		SELECT
-			c.id,
-			$2,
-			COALESCE(agg.total_points, 0),
-			COALESCE(agg.group_exact_count, 0),
-			COALESCE(agg.group_qualifier_count, 0),
-			COALESCE(agg.best_third_hits_count, 0),
-			COALESCE(agg.bracket_hits_count, 0)
-		FROM competitions c
-		LEFT JOIN (
-			SELECT
-				SUM(se.points)                                                                         AS total_points,
-				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3)::int AS group_exact_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4)::int AS group_qualifier_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits_count
-			FROM score_events se
-			WHERE se.user_id = $2
-			  AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
-		) agg ON TRUE
-		WHERE c.board_id = $1 AND c.type = 'pickem'`,
-		boardID, userID,
-		r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies,
-	); err != nil {
-		return handleDBError(err, resourceBoardMember)
-	}
-
 	// Match aggregation depends on each competition's scope (stages + optional
 	// team filter), so the LATERAL subquery re-evaluates per competition
 	if _, err := tx.ExecContext(ctx, `
@@ -168,7 +136,7 @@ func (r *BoardMemberRepository) initCompetitionScoresForMember(
 			  AND se.source_type = 'match_score_pick'
 			  AND se.source_ref::bigint = c.match_id
 		) agg ON TRUE
-		WHERE c.board_id = $1 AND c.type = 'pool'`,
+		WHERE c.board_id = $1 AND c.type = 'pick'`,
 		boardID, userID,
 		r.cfg.Scoring.MatchScoreExact,
 	); err != nil {
@@ -444,15 +412,6 @@ func (r *BoardMemberRepository) deleteCompetitionScoresForMember(
 	boardID int64,
 	userID string,
 ) error {
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM competition_pickem_scores
-		 WHERE user_id = $2
-		   AND competition_id IN (SELECT id FROM competitions WHERE board_id = $1)`,
-		boardID, userID,
-	); err != nil {
-		return handleDBError(err, resourceBoardMember)
-	}
-
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM competition_match_scores
 		 WHERE user_id = $2

--- a/internal/repositories/competition_repository.go
+++ b/internal/repositories/competition_repository.go
@@ -40,7 +40,7 @@ func (r *CompetitionRepository) CreateCompetition(
 		competition.Type,
 		competition.Name,
 		competition.CreatedBy,
-		competition.PoolMatchID,
+		competition.PickMatchID,
 	).Scan(&competition.ID, &competition.CreatedAt)
 	if err != nil {
 		return handleDBError(err, resourceCompetition)
@@ -87,48 +87,6 @@ func (r *CompetitionRepository) seedScoresFromEvents(
 	competition *domain.Competition,
 ) error {
 	switch competition.Type {
-	case domain.CompetitionTypePickem:
-		_, err := tx.ExecContext(ctx, `
-			INSERT INTO competition_pickem_scores (
-				competition_id,
-				user_id,
-				total_points,
-				group_exact_positions,
-				group_qualifier_hits,
-				best_third_hits,
-				bracket_hits
-			)
-			SELECT
-				$1,
-				bm.user_id,
-				COALESCE(agg.total_points, 0),
-				COALESCE(agg.group_exact_count, 0),
-				COALESCE(agg.group_qualifier_count, 0),
-				COALESCE(agg.best_third_hits_count, 0),
-				COALESCE(agg.bracket_hits_count, 0)
-			FROM board_members bm
-			LEFT JOIN (
-				SELECT
-					se.user_id,
-					SUM(se.points) AS total_points,
-					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3) AS group_exact_count,
-					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4) AS group_qualifier_count,
-					COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')                         AS best_third_hits_count,
-					COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')                            AS bracket_hits_count
-				FROM score_events se
-				WHERE se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
-				GROUP BY se.user_id
-			) agg ON agg.user_id = bm.user_id
-			WHERE bm.board_id = $2`,
-			competition.ID,
-			competition.BoardID,
-			r.cfg.Scoring.GroupPositionExact,
-			r.cfg.Scoring.GroupQualifies,
-		)
-		if err != nil {
-			return handleDBError(err, resourceCompetition)
-		}
-
 	case domain.CompetitionTypeMatch:
 		_, err := tx.ExecContext(ctx, `
 			WITH scope_matches AS (
@@ -180,7 +138,7 @@ func (r *CompetitionRepository) seedScoresFromEvents(
 			return handleDBError(err, resourceCompetition)
 		}
 
-	case domain.CompetitionTypePool:
+	case domain.CompetitionTypePick:
 		_, err := tx.ExecContext(ctx, `
 			WITH user_agg AS (
 				SELECT
@@ -211,7 +169,7 @@ func (r *CompetitionRepository) seedScoresFromEvents(
 			WHERE bm.board_id = $2`,
 			competition.ID,
 			competition.BoardID,
-			competition.PoolMatchID,
+			competition.PickMatchID,
 			r.cfg.Scoring.MatchScoreExact,
 		)
 		if err != nil {
@@ -238,23 +196,34 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 		),
 		pickem_ranked AS (
 			SELECT
-				cps.competition_id,
-				cps.user_id,
-				cps.total_points,
+				bc.id AS competition_id,
+				bm.user_id,
+				agg.total_points,
 				RANK() OVER (
-					PARTITION BY cps.competition_id
+					PARTITION BY bc.id
 					ORDER BY
-						cps.total_points          DESC,
-						cps.bracket_hits          DESC,
-						cps.best_third_hits       DESC,
-						cps.group_exact_positions DESC,
-						cps.group_qualifier_hits  DESC,
+						agg.total_points          DESC,
+						agg.bracket_hits          DESC,
+						agg.best_third_hits       DESC,
+						agg.group_exact_positions DESC,
+						agg.group_qualifier_hits  DESC,
 						bm.created_at ASC,
-						cps.user_id ASC
+						bm.user_id ASC
 				) AS rank
-			FROM competition_pickem_scores cps
-			INNER JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = cps.user_id
-			WHERE cps.competition_id IN (SELECT id FROM board_competitions)
+			FROM board_competitions bc
+			JOIN board_members bm ON bm.board_id = $1
+			LEFT JOIN LATERAL (
+				SELECT
+					COALESCE(SUM(se.points), 0)::int                                                       AS total_points,
+					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3)::int AS group_exact_positions,
+					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4)::int AS group_qualifier_hits,
+					COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits,
+					COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits
+				FROM score_events se
+				WHERE se.user_id = bm.user_id
+				  AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
+			) agg ON TRUE
+			WHERE bc.type = 'pickem'
 		),
 		match_ranked AS (
 			SELECT
@@ -274,10 +243,34 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			INNER JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = cms.user_id
 			WHERE cms.competition_id IN (SELECT id FROM board_competitions)
 		),
+		awards_ranked AS (
+			SELECT
+				bc.id AS competition_id,
+				bm.user_id,
+				agg.total_points,
+				RANK() OVER (
+					PARTITION BY bc.id
+					ORDER BY
+						agg.total_points DESC,
+						bm.created_at ASC,
+						bm.user_id ASC
+				) AS rank
+			FROM board_competitions bc
+			JOIN board_members bm ON bm.board_id = $1
+			LEFT JOIN LATERAL (
+				SELECT COALESCE(SUM(se.points), 0)::int AS total_points
+				FROM score_events se
+				WHERE se.user_id = bm.user_id
+				  AND se.source_type = 'award_pick'
+			) agg ON TRUE
+			WHERE bc.type = 'awards'
+		),
 		viewer_ranked AS (
 			SELECT competition_id, user_id, total_points, rank FROM pickem_ranked
 			UNION ALL
 			SELECT competition_id, user_id, total_points, rank FROM match_ranked
+			UNION ALL
+			SELECT competition_id, user_id, total_points, rank FROM awards_ranked
 		)
 		SELECT
 			bc.id, bc.board_id, bc.type, bc.name, bc.created_by, bc.created_at, bc.match_id,
@@ -288,7 +281,9 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 		ORDER BY bc.created_at ASC
 	`
 
-	rows, err := r.db.QueryContext(ctx, query, boardID, viewerUserID)
+	rows, err := r.db.QueryContext(ctx, query, boardID, viewerUserID,
+		r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies,
+	)
 	if err != nil {
 		return nil, handleDBError(err, resourceCompetition)
 	}
@@ -320,7 +315,7 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 		}
 
 		if matchID.Valid {
-			competition.PoolMatchID = &matchID.Int64
+			competition.PickMatchID = &matchID.Int64
 		}
 
 		competitions = append(competitions, competition)
@@ -471,35 +466,10 @@ func (r *CompetitionRepository) GetCompetitionByID(
 	}
 
 	if matchID.Valid {
-		competition.PoolMatchID = &matchID.Int64
+		competition.PickMatchID = &matchID.Int64
 	}
 
 	return competition, nil
-}
-
-func (r *CompetitionRepository) GetAllPickemIDs(ctx context.Context) ([]int64, error) {
-	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
-	defer cancel()
-
-	rows, err := r.db.QueryContext(ctx,
-		`SELECT id FROM competitions WHERE type = 'pickem'`,
-	)
-	if err != nil {
-		return nil, handleDBError(err, resourceCompetition)
-	}
-	defer rows.Close()
-
-	var ids []int64
-
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, handleDBError(err, resourceCompetition)
-		}
-		ids = append(ids, id)
-	}
-
-	return ids, rows.Err()
 }
 
 func (r *CompetitionRepository) GetGlobalCompetitions(

--- a/internal/repositories/competition_score_repository.go
+++ b/internal/repositories/competition_score_repository.go
@@ -63,7 +63,7 @@ func (r *CompetitionScoreRepository) FindMatchCompetitionsByMatches(
 	return ids, rows.Err()
 }
 
-func (r *CompetitionScoreRepository) FindPoolCompetitionsByMatches(
+func (r *CompetitionScoreRepository) FindPickCompetitionsByMatches(
 	ctx context.Context,
 	matchIDs []int64,
 ) ([]int64, error) {
@@ -77,7 +77,7 @@ func (r *CompetitionScoreRepository) FindPoolCompetitionsByMatches(
 	query := `
 		SELECT id
 		FROM competitions
-		WHERE type = 'pool' AND match_id = ANY($1::bigint[])
+		WHERE type = 'pick' AND match_id = ANY($1::bigint[])
 	`
 
 	rows, err := r.db.QueryContext(ctx, query, pq.Array(matchIDs))
@@ -163,7 +163,7 @@ func (r *CompetitionScoreRepository) BatchUpsertMatchScores(
 	return nil
 }
 
-func (r *CompetitionScoreRepository) BatchUpsertPoolScores(
+func (r *CompetitionScoreRepository) BatchUpsertPickScores(
 	ctx context.Context,
 	competitionID int64,
 	userIDs []string,
@@ -218,81 +218,11 @@ func (r *CompetitionScoreRepository) BatchUpsertPoolScores(
 	return nil
 }
 
-func (r *CompetitionScoreRepository) BatchUpsertPickemScores(
-	ctx context.Context,
-	competitionIDs []int64,
-	userIDs []string,
-) error {
-	if len(competitionIDs) == 0 || len(userIDs) == 0 {
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
-	defer cancel()
-
-	// Recompute per user from score_events, then fan-out across competition IDs
-	query := `
-		WITH computed AS (
-			SELECT
-				se.user_id,
-				COALESCE(SUM(se.points), 0)                                                            AS total_points,
-				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3)::int AS group_exact_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4)::int AS group_qualifier_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits_count,
-				COUNT(*) FILTER (WHERE se.source_type = 'award_pick')::int                             AS award_hits_count
-			FROM score_events se
-			WHERE se.user_id = ANY($2::uuid[])
-			  AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick', 'award_pick')
-			GROUP BY se.user_id
-		)
-		INSERT INTO competition_pickem_scores (
-			competition_id, user_id, total_points,
-			group_exact_positions, group_qualifier_hits, best_third_hits, bracket_hits, award_hits, updated_at
-		)
-		SELECT
-			comp_id,
-			c.user_id,
-			c.total_points,
-			c.group_exact_count,
-			c.group_qualifier_count,
-			c.best_third_hits_count,
-			c.bracket_hits_count,
-			c.award_hits_count,
-			NOW()
-		FROM computed c
-		CROSS JOIN UNNEST($1::bigint[]) AS comp_id
-		WHERE EXISTS (
-			SELECT 1 FROM competitions co
-			INNER JOIN board_members bm ON bm.board_id = co.board_id AND bm.user_id = c.user_id
-			WHERE co.id = comp_id
-		)
-		ON CONFLICT (competition_id, user_id) DO UPDATE SET
-			total_points          = EXCLUDED.total_points,
-			group_exact_positions = EXCLUDED.group_exact_positions,
-			group_qualifier_hits  = EXCLUDED.group_qualifier_hits,
-			best_third_hits       = EXCLUDED.best_third_hits,
-			bracket_hits          = EXCLUDED.bracket_hits,
-			award_hits            = EXCLUDED.award_hits,
-			updated_at            = EXCLUDED.updated_at
-	`
-
-	_, err := r.db.ExecContext(ctx, query,
-		pq.Array(competitionIDs), pq.Array(userIDs),
-		r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies,
-	)
-	if err != nil {
-		return handleDBError(err, resourceCompetitionScore)
-	}
-
-	return nil
-}
-
 func (r *CompetitionScoreRepository) GetLeaderboard(
 	ctx context.Context,
 	competitionID int64,
 	page, limit int,
-	q string,
+	q, sort, dir string,
 ) (*domain.CompetitionLeaderboardPage, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
@@ -307,53 +237,102 @@ func (r *CompetitionScoreRepository) GetLeaderboard(
 
 	switch competitionType {
 	case domain.CompetitionTypePickem:
-		return r.getPickemLeaderboard(ctx, competitionID, page, limit, q)
-	case domain.CompetitionTypeMatch, domain.CompetitionTypePool:
-		return r.getMatchLeaderboard(ctx, competitionID, page, limit, q)
+		return r.getPickemLeaderboard(ctx, competitionID, page, limit, q, sort, dir)
+	case domain.CompetitionTypeMatch, domain.CompetitionTypePick:
+		return r.getMatchLeaderboard(ctx, competitionID, page, limit, q, sort, dir)
+	case domain.CompetitionTypeAwards:
+		return r.getAwardsLeaderboard(ctx, competitionID, page, limit, q, sort, dir)
 	default:
 		return nil, domain.ErrCompetitionNotFound
 	}
+}
+
+// Per-type sort whitelists (frontend column id → output column). These drive the
+// row ORDER only; rank() always uses the canonical total-DESC standing, so a
+// member's position never changes with the view's sort.
+var pickemSortCols = map[string]string{
+	"total":           "total_points",
+	"groupExact":      "group_exact_positions",
+	"groupQualifiers": "group_qualifier_hits",
+	"bestThirds":      "best_third_hits",
+	"bracket":         "bracket_hits",
+}
+
+var awardsSortCols = map[string]string{
+	"total":        "total_points",
+	"golden_boot":  "golden_boot",
+	"golden_ball":  "golden_ball",
+	"golden_glove": "golden_glove",
+	"young_player": "young_player",
+}
+
+var matchSortCols = map[string]string{
+	"total":     "total_points",
+	"exactHits": "exact_hits",
+	"outcomes":  "correct_outcomes",
+}
+
+// leaderboardRowOrder builds the final ORDER BY: the chosen column + direction,
+// then rank as the stable tiebreak. Whitelisted column → safe to interpolate.
+func leaderboardRowOrder(cols map[string]string, sort, dir string) string {
+	col, ok := cols[sort]
+	if !ok {
+		col = cols["total"]
+	}
+	direction := "DESC"
+	if dir == "asc" {
+		direction = "ASC"
+	}
+	return col + " " + direction + ", rank ASC, user_id ASC"
 }
 
 func (r *CompetitionScoreRepository) getPickemLeaderboard(
 	ctx context.Context,
 	competitionID int64,
 	page, limit int,
-	q string,
+	q, sort, dir string,
 ) (*domain.CompetitionLeaderboardPage, error) {
 	offset := (page - 1) * limit
+	rowOrder := leaderboardRowOrder(pickemSortCols, sort, dir)
 
 	query := `
-		WITH ranked AS (
+		WITH comp AS (
+			SELECT id, board_id FROM competitions WHERE id = $1
+		),
+		scores AS (
 			SELECT
-				cps.user_id,
+				bm.user_id,
 				u.username,
 				u.first_name,
 				u.last_name,
 				bm.role,
 				bm.created_at AS joined_at,
-				cps.total_points,
-				cps.group_exact_positions,
-				cps.group_qualifier_hits,
-				cps.best_third_hits,
-				cps.bracket_hits,
-				cps.award_hits,
+				COALESCE(SUM(se.points), 0)::int                                                       AS total_points,
+				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $5)::int AS group_exact_positions,
+				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $6)::int AS group_qualifier_hits,
+				COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits,
+				COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits
+			FROM comp
+			JOIN board_members bm ON bm.board_id = comp.board_id
+			JOIN users u          ON u.id = bm.user_id
+			LEFT JOIN score_events se
+				ON se.user_id = bm.user_id
+			   AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
+			GROUP BY bm.user_id, u.username, u.first_name, u.last_name, bm.role, bm.created_at
+		),
+		ranked AS (
+			SELECT *,
 				RANK() OVER (
 					ORDER BY
-						cps.total_points          DESC,
-						cps.bracket_hits          DESC,
-						cps.award_hits            DESC,
-						cps.best_third_hits       DESC,
-						cps.group_exact_positions DESC,
-						cps.group_qualifier_hits  DESC,
-						bm.created_at ASC,
-						cps.user_id ASC
+						total_points          DESC,
+						bracket_hits          DESC,
+						best_third_hits       DESC,
+						group_exact_positions DESC,
+						group_qualifier_hits  DESC,
+						joined_at ASC,
+						user_id ASC
 				) AS rank
-			FROM competition_pickem_scores cps
-			INNER JOIN competitions comp ON comp.id = cps.competition_id
-			INNER JOIN users u           ON u.id = cps.user_id
-			INNER JOIN board_members bm  ON bm.board_id = comp.board_id AND bm.user_id = cps.user_id
-			WHERE cps.competition_id = $1
+			FROM scores
 		),
 		filtered AS (
 			SELECT *, COUNT(*) OVER () AS total
@@ -366,14 +345,16 @@ func (r *CompetitionScoreRepository) getPickemLeaderboard(
 		SELECT
 			user_id, username, first_name, last_name, role, joined_at,
 			rank, total_points,
-			group_exact_positions, group_qualifier_hits, best_third_hits, bracket_hits, award_hits,
+			group_exact_positions, group_qualifier_hits, best_third_hits, bracket_hits,
 			total
 		FROM filtered
-		ORDER BY rank ASC, joined_at ASC, user_id ASC
+		ORDER BY ` + rowOrder + `
 		OFFSET $2 LIMIT $3
 	`
 
-	rows, err := r.db.QueryContext(ctx, query, competitionID, offset, limit, q)
+	rows, err := r.db.QueryContext(ctx, query, competitionID, offset, limit, q,
+		r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies,
+	)
 	if err != nil {
 		return nil, handleDBError(err, resourceCompetitionScore)
 	}
@@ -402,7 +383,6 @@ func (r *CompetitionScoreRepository) getPickemLeaderboard(
 			&score.GroupQualifierHits,
 			&score.BestThirdHits,
 			&score.BracketHits,
-			&score.AwardHits,
 			&total,
 		); err != nil {
 			return nil, handleDBError(err, resourceCompetitionScore)
@@ -418,23 +398,406 @@ func (r *CompetitionScoreRepository) getPickemLeaderboard(
 	}
 
 	if len(leaderboard.Members) == 0 {
-		if err := r.db.QueryRowContext(ctx,
-			`SELECT COUNT(*)
-			 FROM competition_pickem_scores cps
-			 INNER JOIN users u ON u.id = cps.user_id
-			 WHERE cps.competition_id = $1
-			   AND ($2::text = ''
-			        OR u.username   ILIKE '%' || $2 || '%'
-			        OR u.first_name ILIKE '%' || $2 || '%'
-			        OR u.last_name  ILIKE '%' || $2 || '%')`,
-			competitionID, q,
-		).Scan(&leaderboard.Pagination.Total); err != nil && err != sql.ErrNoRows {
-			return nil, handleDBError(err, resourceCompetitionScore)
+		leaderboard.Pagination.Total, err = r.countLeaderboardMembers(ctx, competitionID, q)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	leaderboard.Pagination.HasMore = page*limit < leaderboard.Pagination.Total
 	return leaderboard, nil
+}
+
+// countLeaderboardMembers returns the number of a competition's board members
+// matching the search term — used as the total when a page lands past the last row.
+func (r *CompetitionScoreRepository) countLeaderboardMembers(ctx context.Context, competitionID int64, q string) (int, error) {
+	var total int
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		 FROM competitions comp
+		 JOIN board_members bm ON bm.board_id = comp.board_id
+		 JOIN users u          ON u.id = bm.user_id
+		 WHERE comp.id = $1
+		   AND ($2::text = ''
+		        OR u.username   ILIKE '%' || $2 || '%'
+		        OR u.first_name ILIKE '%' || $2 || '%'
+		        OR u.last_name  ILIKE '%' || $2 || '%')`,
+		competitionID, q,
+	).Scan(&total); err != nil && err != sql.ErrNoRows {
+		return 0, handleDBError(err, resourceCompetitionScore)
+	}
+	return total, nil
+}
+
+func (r *CompetitionScoreRepository) getAwardsLeaderboard(
+	ctx context.Context,
+	competitionID int64,
+	page, limit int,
+	q, sort, dir string,
+) (*domain.CompetitionLeaderboardPage, error) {
+	offset := (page - 1) * limit
+	rowOrder := leaderboardRowOrder(awardsSortCols, sort, dir)
+
+	query := `
+		WITH comp AS (
+			SELECT id, board_id FROM competitions WHERE id = $1
+		),
+		scores AS (
+			SELECT
+				bm.user_id,
+				u.username,
+				u.first_name,
+				u.last_name,
+				bm.role,
+				bm.created_at AS joined_at,
+				COALESCE(SUM(se.points), 0)::int                            AS total_points,
+				COUNT(*) FILTER (WHERE se.source_ref = 'golden_boot')::int  AS golden_boot,
+				COUNT(*) FILTER (WHERE se.source_ref = 'golden_ball')::int  AS golden_ball,
+				COUNT(*) FILTER (WHERE se.source_ref = 'golden_glove')::int AS golden_glove,
+				COUNT(*) FILTER (WHERE se.source_ref = 'young_player')::int AS young_player
+			FROM comp
+			JOIN board_members bm ON bm.board_id = comp.board_id
+			JOIN users u          ON u.id = bm.user_id
+			LEFT JOIN score_events se
+				ON se.user_id = bm.user_id
+			   AND se.source_type = 'award_pick'
+			GROUP BY bm.user_id, u.username, u.first_name, u.last_name, bm.role, bm.created_at
+		),
+		ranked AS (
+			SELECT *,
+				RANK() OVER (ORDER BY total_points DESC, joined_at ASC, user_id ASC) AS rank
+			FROM scores
+		),
+		filtered AS (
+			SELECT *, COUNT(*) OVER () AS total
+			FROM ranked
+			WHERE $4::text = ''
+			   OR username   ILIKE '%' || $4 || '%'
+			   OR first_name ILIKE '%' || $4 || '%'
+			   OR last_name  ILIKE '%' || $4 || '%'
+		)
+		SELECT
+			user_id, username, first_name, last_name, role, joined_at,
+			rank, total_points, golden_boot, golden_ball, golden_glove, young_player,
+			total
+		FROM filtered
+		ORDER BY ` + rowOrder + `
+		OFFSET $2 LIMIT $3
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, competitionID, offset, limit, q)
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+	defer rows.Close()
+
+	leaderboard := &domain.CompetitionLeaderboardPage{
+		Members:    []*domain.CompetitionLeaderboardEntry{},
+		Pagination: domain.Pagination{Page: page, Limit: limit},
+	}
+
+	for rows.Next() {
+		entry := &domain.CompetitionLeaderboardEntry{}
+		score := &domain.AwardsScore{}
+		var total int
+
+		if err := rows.Scan(
+			&entry.Member.UserID,
+			&entry.Member.UserName,
+			&entry.Member.FirstName,
+			&entry.Member.LastName,
+			&entry.Member.Role,
+			&entry.Member.JoinedAt,
+			&entry.Rank,
+			&score.Total,
+			&score.GoldenBoot,
+			&score.GoldenBall,
+			&score.GoldenGlove,
+			&score.YoungPlayer,
+			&total,
+		); err != nil {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+
+		entry.Score = score
+		leaderboard.Pagination.Total = total
+		leaderboard.Members = append(leaderboard.Members, entry)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+
+	if len(leaderboard.Members) == 0 {
+		leaderboard.Pagination.Total, err = r.countLeaderboardMembers(ctx, competitionID, q)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	leaderboard.Pagination.HasMore = page*limit < leaderboard.Pagination.Total
+	return leaderboard, nil
+}
+
+// previewScore carries only the total — the card mini-leaderboard shows nothing else.
+type previewScore struct {
+	Total int `json:"total"`
+}
+
+// GetBoardCompetitionPreviews returns the top-`limit` members per competition for
+// the whole board in one query, matching each type's leaderboard ordering.
+func (r *CompetitionScoreRepository) GetBoardCompetitionPreviews(
+	ctx context.Context,
+	boardID int64,
+	limit int,
+) (map[int64][]*domain.CompetitionLeaderboardEntry, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		WITH bc AS (
+			SELECT id, type FROM competitions WHERE board_id = $1
+		),
+		pickem AS (
+			SELECT c.id AS competition_id, bm.user_id, agg.total_points,
+				RANK() OVER (
+					PARTITION BY c.id
+					ORDER BY agg.total_points DESC, agg.bracket_hits DESC, agg.best_third_hits DESC,
+						agg.group_exact_positions DESC, agg.group_qualifier_hits DESC, bm.created_at ASC, bm.user_id ASC
+				) AS rank
+			FROM bc c
+			JOIN board_members bm ON bm.board_id = $1
+			LEFT JOIN LATERAL (
+				SELECT
+					COALESCE(SUM(se.points), 0)::int                                                       AS total_points,
+					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3)::int AS group_exact_positions,
+					COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4)::int AS group_qualifier_hits,
+					COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits,
+					COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits
+				FROM score_events se
+				WHERE se.user_id = bm.user_id AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
+			) agg ON TRUE
+			WHERE c.type = 'pickem'
+		),
+		awards AS (
+			SELECT c.id AS competition_id, bm.user_id, agg.total_points,
+				RANK() OVER (PARTITION BY c.id ORDER BY agg.total_points DESC, bm.created_at ASC, bm.user_id ASC) AS rank
+			FROM bc c
+			JOIN board_members bm ON bm.board_id = $1
+			LEFT JOIN LATERAL (
+				SELECT COALESCE(SUM(se.points), 0)::int AS total_points
+				FROM score_events se WHERE se.user_id = bm.user_id AND se.source_type = 'award_pick'
+			) agg ON TRUE
+			WHERE c.type = 'awards'
+		),
+		matchpick AS (
+			SELECT cms.competition_id, cms.user_id, cms.total_points,
+				RANK() OVER (
+					PARTITION BY cms.competition_id
+					ORDER BY cms.total_points DESC, cms.exact_hits DESC, cms.correct_outcomes DESC, bm.created_at ASC, cms.user_id ASC
+				) AS rank
+			FROM competition_match_scores cms
+			JOIN bc c ON c.id = cms.competition_id
+			JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = cms.user_id
+			WHERE c.type IN ('match', 'pick')
+		),
+		unioned AS (
+			SELECT competition_id, user_id, total_points, rank FROM pickem
+			UNION ALL SELECT competition_id, user_id, total_points, rank FROM awards
+			UNION ALL SELECT competition_id, user_id, total_points, rank FROM matchpick
+		)
+		SELECT un.competition_id, un.user_id, u.username, u.first_name, u.last_name, bm.role, bm.created_at, un.rank, un.total_points
+		FROM unioned un
+		JOIN users u          ON u.id = un.user_id
+		JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = un.user_id
+		WHERE un.rank <= $2
+		ORDER BY un.competition_id, un.rank ASC, bm.created_at ASC, un.user_id ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, boardID, limit, r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies)
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+	defer rows.Close()
+
+	previews := map[int64][]*domain.CompetitionLeaderboardEntry{}
+	for rows.Next() {
+		var competitionID int64
+		entry := &domain.CompetitionLeaderboardEntry{}
+		score := previewScore{}
+
+		if err := rows.Scan(
+			&competitionID,
+			&entry.Member.UserID,
+			&entry.Member.UserName,
+			&entry.Member.FirstName,
+			&entry.Member.LastName,
+			&entry.Member.Role,
+			&entry.Member.JoinedAt,
+			&entry.Rank,
+			&score.Total,
+		); err != nil {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+
+		entry.Score = score
+		previews[competitionID] = append(previews[competitionID], entry)
+	}
+
+	return previews, rows.Err()
+}
+
+// boardSummarySortCols whitelists the sortable output columns (custom = match).
+// Rank is always the canonical total-DESC standing; this only drives row order.
+var boardSummarySortCols = map[string]string{
+	"total":  "total",
+	"pickem": "pickem",
+	"custom": "custom",
+	"pick":   "pick",
+	"awards": "awards",
+}
+
+// GetBoardSummary ranks every board member by their raw-sum points across all the
+// board's competitions, with per-type subtotals (custom = match competitions).
+func (r *CompetitionScoreRepository) GetBoardSummary(
+	ctx context.Context,
+	boardID int64,
+	page, limit int,
+	q, sort, dir string,
+) (*domain.BoardSummaryPage, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	offset := (page - 1) * limit
+	rowOrder := leaderboardRowOrder(boardSummarySortCols, sort, dir)
+
+	query := `
+		WITH members AS (
+			SELECT bm.user_id, u.username, u.first_name, u.last_name, bm.role, bm.created_at AS joined_at
+			FROM board_members bm JOIN users u ON u.id = bm.user_id
+			WHERE bm.board_id = $1
+		),
+		has AS (
+			SELECT bool_or(type = 'pickem') AS has_pickem, bool_or(type = 'awards') AS has_awards
+			FROM competitions WHERE board_id = $1
+		),
+		pickem AS (
+			SELECT m.user_id, COALESCE(SUM(se.points), 0)::int AS pts
+			FROM members m
+			LEFT JOIN score_events se ON se.user_id = m.user_id AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
+			GROUP BY m.user_id
+		),
+		awards AS (
+			SELECT m.user_id, COALESCE(SUM(se.points), 0)::int AS pts
+			FROM members m
+			LEFT JOIN score_events se ON se.user_id = m.user_id AND se.source_type = 'award_pick'
+			GROUP BY m.user_id
+		),
+		custom AS (
+			SELECT cms.user_id, SUM(cms.total_points)::int AS pts
+			FROM competition_match_scores cms JOIN competitions c ON c.id = cms.competition_id
+			WHERE c.board_id = $1 AND c.type = 'match'
+			GROUP BY cms.user_id
+		),
+		pick AS (
+			SELECT cms.user_id, SUM(cms.total_points)::int AS pts
+			FROM competition_match_scores cms JOIN competitions c ON c.id = cms.competition_id
+			WHERE c.board_id = $1 AND c.type = 'pick'
+			GROUP BY cms.user_id
+		),
+		scored AS (
+			SELECT
+				m.user_id, m.username, m.first_name, m.last_name, m.role, m.joined_at,
+				CASE WHEN h.has_pickem THEN COALESCE(p.pts, 0) ELSE 0 END  AS pickem,
+				COALESCE(cu.pts, 0)                                        AS custom,
+				COALESCE(pk.pts, 0)                                        AS pick,
+				CASE WHEN h.has_awards THEN COALESCE(a.pts, 0) ELSE 0 END  AS awards
+			FROM members m
+			CROSS JOIN has h
+			LEFT JOIN pickem p  ON p.user_id = m.user_id
+			LEFT JOIN awards a  ON a.user_id = m.user_id
+			LEFT JOIN custom cu ON cu.user_id = m.user_id
+			LEFT JOIN pick pk   ON pk.user_id = m.user_id
+		),
+		ranked AS (
+			SELECT *, (pickem + custom + pick + awards) AS total,
+				RANK() OVER (ORDER BY (pickem + custom + pick + awards) DESC, joined_at ASC, user_id ASC) AS rank
+			FROM scored
+		),
+		filtered AS (
+			SELECT *, COUNT(*) OVER () AS total_count
+			FROM ranked
+			WHERE $4::text = ''
+			   OR username   ILIKE '%' || $4 || '%'
+			   OR first_name ILIKE '%' || $4 || '%'
+			   OR last_name  ILIKE '%' || $4 || '%'
+		)
+		SELECT
+			user_id, username, first_name, last_name, role, joined_at,
+			rank, total, pickem, custom, pick, awards, total_count
+		FROM filtered
+		ORDER BY ` + rowOrder + `
+		OFFSET $2 LIMIT $3
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, boardID, offset, limit, q)
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+	defer rows.Close()
+
+	summary := &domain.BoardSummaryPage{
+		Members:    []*domain.BoardSummaryEntry{},
+		Pagination: domain.Pagination{Page: page, Limit: limit},
+	}
+
+	for rows.Next() {
+		entry := &domain.BoardSummaryEntry{}
+		var total int
+
+		if err := rows.Scan(
+			&entry.Member.UserID,
+			&entry.Member.UserName,
+			&entry.Member.FirstName,
+			&entry.Member.LastName,
+			&entry.Member.Role,
+			&entry.Member.JoinedAt,
+			&entry.Rank,
+			&entry.Total,
+			&entry.Pickem,
+			&entry.Custom,
+			&entry.Pick,
+			&entry.Awards,
+			&total,
+		); err != nil {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+
+		summary.Pagination.Total = total
+		summary.Members = append(summary.Members, entry)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, handleDBError(err, resourceCompetitionScore)
+	}
+
+	if len(summary.Members) == 0 {
+		if err := r.db.QueryRowContext(ctx,
+			`SELECT COUNT(*)
+			 FROM board_members bm JOIN users u ON u.id = bm.user_id
+			 WHERE bm.board_id = $1
+			   AND ($2::text = ''
+			        OR u.username   ILIKE '%' || $2 || '%'
+			        OR u.first_name ILIKE '%' || $2 || '%'
+			        OR u.last_name  ILIKE '%' || $2 || '%')`,
+			boardID, q,
+		).Scan(&summary.Pagination.Total); err != nil && err != sql.ErrNoRows {
+			return nil, handleDBError(err, resourceCompetitionScore)
+		}
+	}
+
+	summary.Pagination.HasMore = page*limit < summary.Pagination.Total
+	return summary, nil
 }
 
 func (r *CompetitionScoreRepository) GetUserPickemStats(
@@ -446,25 +809,40 @@ func (r *CompetitionScoreRepository) GetUserPickemStats(
 	defer cancel()
 
 	query := `
-		WITH ranked AS (
+		WITH comp AS (
+			SELECT id, board_id FROM competitions WHERE id = $1
+		),
+		scores AS (
 			SELECT
-				cps.user_id,
-				cps.total_points,
+				bm.user_id,
+				bm.created_at AS joined_at,
+				COALESCE(SUM(se.points), 0)::int                                                       AS total_points,
+				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $3)::int AS group_exact_positions,
+				COUNT(*) FILTER (WHERE se.source_type = 'group_standing_pick' AND se.points = $4)::int AS group_qualifier_hits,
+				COUNT(*) FILTER (WHERE se.source_type = 'best_third_pick')::int                        AS best_third_hits,
+				COUNT(*) FILTER (WHERE se.source_type = 'bracket_pick')::int                           AS bracket_hits
+			FROM comp
+			JOIN board_members bm ON bm.board_id = comp.board_id
+			LEFT JOIN score_events se
+				ON se.user_id = bm.user_id
+			   AND se.source_type IN ('group_standing_pick', 'best_third_pick', 'bracket_pick')
+			GROUP BY bm.user_id, bm.created_at
+		),
+		ranked AS (
+			SELECT
+				user_id,
+				total_points,
 				RANK() OVER (
 					ORDER BY
-						cps.total_points          DESC,
-						cps.bracket_hits          DESC,
-						cps.award_hits            DESC,
-						cps.best_third_hits       DESC,
-						cps.group_exact_positions DESC,
-						cps.group_qualifier_hits  DESC,
-						bm.created_at ASC,
-						cps.user_id ASC
+						total_points          DESC,
+						bracket_hits          DESC,
+						best_third_hits       DESC,
+						group_exact_positions DESC,
+						group_qualifier_hits  DESC,
+						joined_at ASC,
+						user_id ASC
 				) AS rank
-			FROM competition_pickem_scores cps
-			INNER JOIN competitions comp ON comp.id = cps.competition_id
-			INNER JOIN board_members bm  ON bm.board_id = comp.board_id AND bm.user_id = cps.user_id
-			WHERE cps.competition_id = $1
+			FROM scores
 		)
 		SELECT rank, total_points
 		FROM ranked
@@ -472,7 +850,9 @@ func (r *CompetitionScoreRepository) GetUserPickemStats(
 	`
 
 	var stats domain.CompetitionUserStats
-	err := r.db.QueryRowContext(ctx, query, competitionID, userID).Scan(&stats.Rank, &stats.Points)
+	err := r.db.QueryRowContext(ctx, query, competitionID, userID,
+		r.cfg.Scoring.GroupPositionExact, r.cfg.Scoring.GroupQualifies,
+	).Scan(&stats.Rank, &stats.Points)
 	if err == sql.ErrNoRows {
 		return domain.CompetitionUserStats{}, nil
 	}
@@ -530,9 +910,10 @@ func (r *CompetitionScoreRepository) getMatchLeaderboard(
 	ctx context.Context,
 	competitionID int64,
 	page, limit int,
-	q string,
+	q, sort, dir string,
 ) (*domain.CompetitionLeaderboardPage, error) {
 	offset := (page - 1) * limit
+	rowOrder := leaderboardRowOrder(matchSortCols, sort, dir)
 
 	query := `
 		WITH ranked AS (
@@ -574,7 +955,7 @@ func (r *CompetitionScoreRepository) getMatchLeaderboard(
 			exact_hits, correct_outcomes,
 			total
 		FROM filtered
-		ORDER BY rank ASC, joined_at ASC, user_id ASC
+		ORDER BY ` + rowOrder + `
 		OFFSET $2 LIMIT $3
 	`
 

--- a/internal/repositories/errors.go
+++ b/internal/repositories/errors.go
@@ -117,8 +117,10 @@ func translateUniqueViolation(pqErr *pq.Error) error {
 		return domain.ErrBoardMemberAlreadyInBoard
 	case "idx_competitions_one_pickem_per_board":
 		return domain.ErrCompetitionPickemAlreadyExists
-	case "idx_competitions_one_pool_per_match":
-		return domain.ErrDuplicatePoolForMatch
+	case "idx_competitions_one_awards_per_board":
+		return domain.ErrCompetitionAwardsAlreadyExists
+	case "idx_competitions_one_pick_per_match":
+		return domain.ErrDuplicatePickForMatch
 	case "competitions_board_id_name_key":
 		return domain.ErrCompetitionNameAlreadyExists
 	default:

--- a/internal/repositories/oauth_account_repository.go
+++ b/internal/repositories/oauth_account_repository.go
@@ -121,16 +121,6 @@ func (r *OAuthAccountRepository) CreateUserWithOAuthAccount(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO competition_pickem_scores (competition_id, user_id)
-		 SELECT id, $1 FROM competitions WHERE board_id = $2 AND type = 'pickem'`,
-		user.ID,
-		globalBoardID,
-	); err != nil {
-		return handleDBError(err, resourceCompetitionScore)
-	}
-
-	if _, err := tx.ExecContext(
-		ctx,
 		`INSERT INTO competition_match_scores (competition_id, user_id)
 		 SELECT id, $1 FROM competitions WHERE board_id = $2 AND type = 'match'`,
 		user.ID,

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -79,16 +79,6 @@ func (r *UserRepository) CreateUser(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO competition_pickem_scores (competition_id, user_id)
-		 SELECT id, $1 FROM competitions WHERE board_id = $2 AND type = 'pickem'`,
-		user.ID,
-		globalBoardID,
-	); err != nil {
-		return handleDBError(err, resourceCompetitionScore)
-	}
-
-	if _, err := tx.ExecContext(
-		ctx,
 		`INSERT INTO competition_match_scores (competition_id, user_id)
 		 SELECT id, $1 FROM competitions WHERE board_id = $2 AND type = 'match'`,
 		user.ID,

--- a/internal/services/award_service.go
+++ b/internal/services/award_service.go
@@ -21,32 +21,29 @@ type AwardServiceInterface interface {
 }
 
 type AwardService struct {
-	awardRepository           domain.AwardPickRepository
-	playerRepository          domain.PlayerRepository
-	scoringService            ScoringServiceInterface
-	competitionScoringService CompetitionScoringServiceInterface
-	lockTime                  time.Time
-	cfg                       *config.Config
-	logger                    logging.Logger
+	awardRepository  domain.AwardPickRepository
+	playerRepository domain.PlayerRepository
+	scoringService   ScoringServiceInterface
+	lockTime         time.Time
+	cfg              *config.Config
+	logger           logging.Logger
 }
 
 func NewAwardService(
 	awardRepository domain.AwardPickRepository,
 	playerRepository domain.PlayerRepository,
 	scoringService ScoringServiceInterface,
-	competitionScoringService CompetitionScoringServiceInterface,
 	lockTime time.Time,
 	cfg *config.Config,
 	logger logging.Logger,
 ) AwardServiceInterface {
 	return &AwardService{
-		awardRepository:           awardRepository,
-		playerRepository:          playerRepository,
-		scoringService:            scoringService,
-		competitionScoringService: competitionScoringService,
-		lockTime:                  lockTime,
-		cfg:                       cfg,
-		logger:                    logger,
+		awardRepository:  awardRepository,
+		playerRepository: playerRepository,
+		scoringService:   scoringService,
+		lockTime:         lockTime,
+		cfg:              cfg,
+		logger:           logger,
 	}
 }
 
@@ -259,17 +256,8 @@ func (s *AwardService) isPlayerEligible(awardType domain.AwardType, player *doma
 
 func (s *AwardService) asyncScoreAwards() {
 	go func() {
-		ctx := context.Background()
-		affectedUserIDs, err := s.scoringService.ScoreAwards(ctx)
-		if err != nil {
+		if _, err := s.scoringService.ScoreAwards(context.Background()); err != nil {
 			s.logger.Error("award scoring failed",
-				logging.Error, err.Error(),
-			)
-			return
-		}
-
-		if err := s.competitionScoringService.RecomputeForAwards(ctx, affectedUserIDs); err != nil {
-			s.logger.Error("competition scoring recompute for awards failed",
 				logging.Error, err.Error(),
 			)
 		}

--- a/internal/services/award_service_test.go
+++ b/internal/services/award_service_test.go
@@ -22,14 +22,13 @@ func newTestAwardService(
 	awardRepo *mocks.MockAwardPickRepository,
 	playerRepo *mocks.MockPlayerRepository,
 	scoringSvc *mocks.MockScoringService,
-	competitionSvc *mocks.MockCompetitionScoringService,
 	lockTime time.Time,
 ) AwardServiceInterface {
 	cfg := &config.Config{
 		Scoring: config.ScoringConfig{Award: 50},
 	}
 	logger := &mocks.MockLogger{}
-	return NewAwardService(awardRepo, playerRepo, scoringSvc, competitionSvc, lockTime, cfg, logger)
+	return NewAwardService(awardRepo, playerRepo, scoringSvc, lockTime, cfg, logger)
 }
 
 func ageRef(value int) *int { return &value }
@@ -77,7 +76,7 @@ func pastLock() time.Time { return time.Now().UTC().Add(-24 * time.Hour) }
 func TestAwardService_SaveAwardPicks_RejectsWhenLocked(t *testing.T) {
 	t.Parallel()
 
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, nil, pastLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, pastLock())
 
 	picks := []*domain.UserAwardPick{{AwardType: domain.AwardGoldenBoot, PlayerID: 1}}
 	_, err := service.SaveAwardPicks(context.Background(), gofakeit.UUID(), picks)
@@ -93,7 +92,7 @@ func TestAwardService_SaveAwardPicks_RejectsGoldenGloveForOutfielder(t *testing.
 			return []*domain.Player{attacker(7)}, nil
 		},
 	}
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, futureLock())
 
 	picks := []*domain.UserAwardPick{{AwardType: domain.AwardGoldenGlove, PlayerID: 7}}
 	_, err := service.SaveAwardPicks(context.Background(), gofakeit.UUID(), picks)
@@ -109,7 +108,7 @@ func TestAwardService_SaveAwardPicks_RejectsYoungPlayerOverCutoff(t *testing.T) 
 			return []*domain.Player{attacker(11)}, nil
 		},
 	}
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, futureLock())
 
 	picks := []*domain.UserAwardPick{{AwardType: domain.AwardYoungPlayer, PlayerID: 11}}
 	_, err := service.SaveAwardPicks(context.Background(), gofakeit.UUID(), picks)
@@ -138,7 +137,7 @@ func TestAwardService_SaveAwardPicks_AcceptsYoungPlayerWithUnknownAge(t *testing
 			return nil
 		},
 	}
-	service := newTestAwardService(awardRepo, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(awardRepo, playerRepo, nil, futureLock())
 
 	picks := []*domain.UserAwardPick{{AwardType: domain.AwardYoungPlayer, PlayerID: 42}}
 	_, err := service.SaveAwardPicks(context.Background(), gofakeit.UUID(), picks)
@@ -154,7 +153,7 @@ func TestAwardService_SaveAwardPicks_RejectsUnknownPlayer(t *testing.T) {
 			return []*domain.Player{}, nil
 		},
 	}
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, futureLock())
 
 	picks := []*domain.UserAwardPick{{AwardType: domain.AwardGoldenBoot, PlayerID: 999}}
 	_, err := service.SaveAwardPicks(context.Background(), gofakeit.UUID(), picks)
@@ -183,7 +182,7 @@ func TestAwardService_SaveAwardPicks_AcceptsValidMixedPicks(t *testing.T) {
 		},
 	}
 
-	service := newTestAwardService(awardRepo, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(awardRepo, playerRepo, nil, futureLock())
 
 	picks := []*domain.UserAwardPick{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: bootPlayer.ID},
@@ -221,7 +220,7 @@ func TestAwardService_GetUserAwards_ResolvesInCanonicalOrderWithGaps(t *testing.
 		},
 	}
 
-	service := newTestAwardService(awardRepo, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(awardRepo, playerRepo, nil, futureLock())
 
 	awards, err := service.GetUserAwards(context.Background(), gofakeit.UUID())
 
@@ -246,7 +245,7 @@ func TestAwardService_GetUserAwards_SignalsLockAfterDeadline(t *testing.T) {
 	}
 	playerRepo := &mocks.MockPlayerRepository{}
 
-	service := newTestAwardService(awardRepo, playerRepo, nil, nil, pastLock())
+	service := newTestAwardService(awardRepo, playerRepo, nil, pastLock())
 
 	awards, err := service.GetUserAwards(context.Background(), gofakeit.UUID())
 
@@ -287,7 +286,7 @@ func TestAwardService_GetPopularPicks_FansOutPerAwardAndPropagatesLimit(t *testi
 			return nil, nil
 		},
 	}
-	service := newTestAwardService(awardRepo, &mocks.MockPlayerRepository{}, nil, nil, futureLock())
+	service := newTestAwardService(awardRepo, &mocks.MockPlayerRepository{}, nil, futureLock())
 
 	result, err := service.GetPopularPicks(context.Background(), 10)
 
@@ -321,7 +320,7 @@ type callRecord struct {
 func TestAwardService_RecordWinners_RejectsIncompleteSet(t *testing.T) {
 	t.Parallel()
 
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, futureLock())
 
 	winners := []*domain.AwardWinner{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: 1},
@@ -334,7 +333,7 @@ func TestAwardService_RecordWinners_RejectsIncompleteSet(t *testing.T) {
 func TestAwardService_RecordWinners_RejectsDuplicateAwardType(t *testing.T) {
 	t.Parallel()
 
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, futureLock())
 
 	winners := []*domain.AwardWinner{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: 1},
@@ -357,7 +356,7 @@ func TestAwardService_RecordWinners_RejectsIneligibleWinner(t *testing.T) {
 			}, nil
 		},
 	}
-	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, playerRepo, nil, futureLock())
 
 	winners := []*domain.AwardWinner{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: 1},
@@ -393,21 +392,14 @@ func TestAwardService_RecordWinners_PersistsAndTriggersScoring(t *testing.T) {
 	}
 
 	scoreCalled := make(chan struct{}, 1)
-	recomputeCalled := make(chan struct{}, 1)
 	scoringSvc := &mocks.MockScoringService{
 		ScoreAwardsFunc: func(ctx context.Context) ([]string, error) {
 			scoreCalled <- struct{}{}
 			return []string{"user-1", "user-2"}, nil
 		},
 	}
-	competitionSvc := &mocks.MockCompetitionScoringService{
-		RecomputeForAwardsFunc: func(ctx context.Context, affectedUserIDs []string) error {
-			recomputeCalled <- struct{}{}
-			return nil
-		},
-	}
 
-	service := newTestAwardService(awardRepo, playerRepo, scoringSvc, competitionSvc, futureLock())
+	service := newTestAwardService(awardRepo, playerRepo, scoringSvc, futureLock())
 
 	winners := []*domain.AwardWinner{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: bootPlayer.ID},
@@ -421,7 +413,6 @@ func TestAwardService_RecordWinners_PersistsAndTriggersScoring(t *testing.T) {
 	assert.Len(t, persisted, 4)
 
 	assertSignaledWithin(t, scoreCalled, time.Second, "ScoreAwards not invoked")
-	assertSignaledWithin(t, recomputeCalled, time.Second, "RecomputeForAwards not invoked")
 }
 
 func TestAwardService_RecordWinners_SurfacesPersistenceFailureSynchronously(t *testing.T) {
@@ -445,7 +436,7 @@ func TestAwardService_RecordWinners_SurfacesPersistenceFailureSynchronously(t *t
 		},
 	}
 
-	service := newTestAwardService(awardRepo, playerRepo, nil, nil, futureLock())
+	service := newTestAwardService(awardRepo, playerRepo, nil, futureLock())
 
 	winners := []*domain.AwardWinner{
 		{AwardType: domain.AwardGoldenBoot, PlayerID: bootPlayer.ID},

--- a/internal/services/board_service.go
+++ b/internal/services/board_service.go
@@ -96,6 +96,16 @@ func (s *BoardService) CreateBoard(
 			return nil, err
 		}
 
+		if err := s.competitionRepository.CreateCompetition(ctx, &domain.Competition{
+			BoardID:   board.ID,
+			Type:      domain.CompetitionTypeAwards,
+			Name:      "Awards",
+			CreatedBy: &userID,
+		}); err != nil {
+			_ = s.boardRepository.DeleteBoard(ctx, board.ID)
+			return nil, err
+		}
+
 		return board, nil
 	}
 

--- a/internal/services/board_service_test.go
+++ b/internal/services/board_service_test.go
@@ -57,7 +57,7 @@ func TestBoardService_CreateBoard(t *testing.T) {
 		assert.Equal(t, domain.BoardPrivacyPrivate, result.Privacy)
 	})
 
-	t.Run("creates default Pick'em and All Matches competitions", func(t *testing.T) {
+	t.Run("creates default Pick'em, All Matches and Awards competitions", func(t *testing.T) {
 		t.Parallel()
 
 		payload := dtos.CreateBoardDto{Name: "Test Board"}
@@ -84,7 +84,7 @@ func TestBoardService_CreateBoard(t *testing.T) {
 		_, err := service.CreateBoard(context.Background(), payload, userID)
 
 		assert.NoError(t, err)
-		assert.Len(t, createdCompetitions, 2)
+		assert.Len(t, createdCompetitions, 3)
 
 		pickem := createdCompetitions[0]
 		assert.Equal(t, expectedID, pickem.BoardID)
@@ -111,6 +111,14 @@ func TestBoardService_CreateBoard(t *testing.T) {
 			domain.MatchStageCodeFinal,
 		}, match.Scope.Stages)
 		assert.Empty(t, match.Scope.TeamFifaCodes)
+
+		awards := createdCompetitions[2]
+		assert.Equal(t, expectedID, awards.BoardID)
+		assert.Equal(t, domain.CompetitionTypeAwards, awards.Type)
+		assert.Equal(t, "Awards", awards.Name)
+		assert.NotNil(t, awards.CreatedBy)
+		assert.Equal(t, userID, *awards.CreatedBy)
+		assert.Nil(t, awards.Scope)
 	})
 
 	t.Run("rolls back board when default competition creation fails", func(t *testing.T) {

--- a/internal/services/competition_scoring_service.go
+++ b/internal/services/competition_scoring_service.go
@@ -10,132 +10,74 @@ import (
 
 type CompetitionScoringServiceInterface interface {
 	RecomputeForMatches(ctx context.Context, result *domain.ScoreMatchesResult) error
-	RecomputeForBestThirds(ctx context.Context, affectedUserIDs []string) error
-	RecomputeForAwards(ctx context.Context, affectedUserIDs []string) error
 }
 
 type CompetitionScoringService struct {
-	competitionRepository      domain.CompetitionRepository
 	competitionScoreRepository domain.CompetitionScoreRepository
 	cfg                        *config.Config
 	logger                     logging.Logger
 }
 
 func NewCompetitionScoringService(
-	competitionRepository domain.CompetitionRepository,
 	competitionScoreRepository domain.CompetitionScoreRepository,
 	cfg *config.Config,
 	logger logging.Logger,
 ) CompetitionScoringServiceInterface {
 	return &CompetitionScoringService{
-		competitionRepository:      competitionRepository,
 		competitionScoreRepository: competitionScoreRepository,
 		cfg:                        cfg,
 		logger:                     logger,
 	}
 }
 
-// RecomputeForMatches recomputes the per-type score caches for all competitions
-// affected by a scoring run. Called after ScoreMatches completes
+// RecomputeForMatches refreshes the match/pick score caches for competitions
+// affected by a scoring run. Pick'em and awards leaderboards are computed on
+// read, so they need no recompute.
 func (s *CompetitionScoringService) RecomputeForMatches(ctx context.Context, result *domain.ScoreMatchesResult) error {
-	if len(result.AffectedUserIDs) == 0 {
+	if len(result.AffectedUserIDs) == 0 || len(result.ScoredMatchIDs) == 0 {
 		return nil
 	}
 
-	// Match competitions
-	if len(result.ScoredMatchIDs) > 0 {
-		competitionIDs, err := s.competitionScoreRepository.FindMatchCompetitionsByMatches(ctx, result.ScoredMatchIDs)
-		if err != nil {
-			s.logger.Error("failed to find match competitions",
-				logging.Error, err.Error(),
-				"match_ids", result.ScoredMatchIDs,
-			)
-			return err
-		}
-
-		for _, competitionID := range competitionIDs {
-			if err := s.competitionScoreRepository.BatchUpsertMatchScores(
-				ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
-			); err != nil {
-				s.logger.Error("failed to upsert match scores",
-					logging.Error, err.Error(),
-					"competition_id", competitionID,
-				)
-				return err
-			}
-		}
-	}
-
-	// Pool competitions (single-match pools share the match-score cache)
-	if len(result.ScoredMatchIDs) > 0 {
-		poolIDs, err := s.competitionScoreRepository.FindPoolCompetitionsByMatches(ctx, result.ScoredMatchIDs)
-		if err != nil {
-			s.logger.Error("failed to find pool competitions",
-				logging.Error, err.Error(),
-				"match_ids", result.ScoredMatchIDs,
-			)
-			return err
-		}
-
-		for _, competitionID := range poolIDs {
-			if err := s.competitionScoreRepository.BatchUpsertPoolScores(
-				ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
-			); err != nil {
-				s.logger.Error("failed to upsert pool scores",
-					logging.Error, err.Error(),
-					"competition_id", competitionID,
-				)
-				return err
-			}
-		}
-	}
-
-	// Pickem competitions
-	if result.PickemAffected {
-		if err := s.recomputeAllPickems(ctx, result.AffectedUserIDs); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *CompetitionScoringService) RecomputeForBestThirds(ctx context.Context, affectedUserIDs []string) error {
-	if len(affectedUserIDs) == 0 {
-		return nil
-	}
-
-	return s.recomputeAllPickems(ctx, affectedUserIDs)
-}
-
-func (s *CompetitionScoringService) RecomputeForAwards(ctx context.Context, affectedUserIDs []string) error {
-	if len(affectedUserIDs) == 0 {
-		return nil
-	}
-
-	return s.recomputeAllPickems(ctx, affectedUserIDs)
-}
-
-func (s *CompetitionScoringService) recomputeAllPickems(ctx context.Context, userIDs []string) error {
-	competitionIDs, err := s.competitionRepository.GetAllPickemIDs(ctx)
+	competitionIDs, err := s.competitionScoreRepository.FindMatchCompetitionsByMatches(ctx, result.ScoredMatchIDs)
 	if err != nil {
-		s.logger.Error("failed to get pickem competition IDs",
+		s.logger.Error("failed to find match competitions",
 			logging.Error, err.Error(),
+			"match_ids", result.ScoredMatchIDs,
 		)
 		return err
 	}
 
-	if len(competitionIDs) == 0 {
-		return nil
+	for _, competitionID := range competitionIDs {
+		if err := s.competitionScoreRepository.BatchUpsertMatchScores(
+			ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
+		); err != nil {
+			s.logger.Error("failed to upsert match scores",
+				logging.Error, err.Error(),
+				"competition_id", competitionID,
+			)
+			return err
+		}
 	}
 
-	if err := s.competitionScoreRepository.BatchUpsertPickemScores(ctx, competitionIDs, userIDs); err != nil {
-		s.logger.Error("failed to upsert pickem scores",
+	pickIDs, err := s.competitionScoreRepository.FindPickCompetitionsByMatches(ctx, result.ScoredMatchIDs)
+	if err != nil {
+		s.logger.Error("failed to find pick competitions",
 			logging.Error, err.Error(),
-			"competition_count", len(competitionIDs),
-			"user_count", len(userIDs),
+			"match_ids", result.ScoredMatchIDs,
 		)
 		return err
+	}
+
+	for _, competitionID := range pickIDs {
+		if err := s.competitionScoreRepository.BatchUpsertPickScores(
+			ctx, competitionID, result.AffectedUserIDs, s.cfg.Scoring.MatchScoreExact,
+		); err != nil {
+			s.logger.Error("failed to upsert pick scores",
+				logging.Error, err.Error(),
+				"competition_id", competitionID,
+			)
+			return err
+		}
 	}
 
 	return nil

--- a/internal/services/competition_scoring_service_test.go
+++ b/internal/services/competition_scoring_service_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompetitionScoringService_RecomputeForMatches_Pools(t *testing.T) {
+func TestCompetitionScoringService_RecomputeForMatches_Picks(t *testing.T) {
 	t.Parallel()
 
 	matchIDs := []int64{42}
 	userIDs := []string{"user-1", "user-2"}
-	poolID := int64(7)
+	pickID := int64(7)
 
-	var upsertedPoolID int64
+	var upsertedPickID int64
 	var upsertedPts int
 	var upsertedUsers []string
 
@@ -26,12 +26,12 @@ func TestCompetitionScoringService_RecomputeForMatches_Pools(t *testing.T) {
 		FindMatchCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
 			return nil, nil
 		},
-		FindPoolCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
+		FindPickCompetitionsByMatchesFunc: func(ctx context.Context, ids []int64) ([]int64, error) {
 			assert.Equal(t, matchIDs, ids)
-			return []int64{poolID}, nil
+			return []int64{pickID}, nil
 		},
-		BatchUpsertPoolScoresFunc: func(ctx context.Context, competitionID int64, users []string, exactScorePts int) error {
-			upsertedPoolID = competitionID
+		BatchUpsertPickScoresFunc: func(ctx context.Context, competitionID int64, users []string, exactScorePts int) error {
+			upsertedPickID = competitionID
 			upsertedUsers = users
 			upsertedPts = exactScorePts
 			return nil
@@ -39,16 +39,15 @@ func TestCompetitionScoringService_RecomputeForMatches_Pools(t *testing.T) {
 	}
 
 	cfg := &config.Config{Scoring: config.ScoringConfig{MatchScoreExact: 5}}
-	service := NewCompetitionScoringService(&mocks.MockCompetitionRepository{}, scoreRepo, cfg, &mocks.MockLogger{})
+	service := NewCompetitionScoringService(scoreRepo, cfg, &mocks.MockLogger{})
 
 	err := service.RecomputeForMatches(context.Background(), &domain.ScoreMatchesResult{
 		AffectedUserIDs: userIDs,
 		ScoredMatchIDs:  matchIDs,
-		PickemAffected:  false,
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, poolID, upsertedPoolID)
+	assert.Equal(t, pickID, upsertedPickID)
 	assert.Equal(t, userIDs, upsertedUsers)
 	assert.Equal(t, 5, upsertedPts)
 }

--- a/internal/services/competition_service.go
+++ b/internal/services/competition_service.go
@@ -7,10 +7,14 @@ import (
 	"github.com/fifawcp/api/internal/dtos"
 )
 
+// Top-N members previewed on each competition card.
+const competitionTopPreviewLimit = 3
+
 type CompetitionServiceInterface interface {
 	CreateCompetition(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error)
 	GetBoardCompetitions(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
-	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
+	GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error)
+	GetBoardSummary(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*domain.BoardSummaryPage, error)
 	DeleteCompetition(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error
 }
 
@@ -52,7 +56,7 @@ func (s *CompetitionService) CreateCompetition(
 		Type:        payload.Type,
 		Name:        payload.Name,
 		CreatedBy:   &userID,
-		PoolMatchID: payload.MatchID,
+		PickMatchID: payload.MatchID,
 	}
 
 	if payload.Scope != nil {
@@ -74,16 +78,42 @@ func (s *CompetitionService) GetBoardCompetitions(
 	boardID int64,
 	viewerUserID string,
 ) ([]*domain.CompetitionListItem, error) {
-	return s.competitionRepository.GetBoardCompetitions(ctx, boardID, viewerUserID)
+	competitions, err := s.competitionRepository.GetBoardCompetitions(ctx, boardID, viewerUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	previews, err := s.competitionScoreRepository.GetBoardCompetitionPreviews(ctx, boardID, competitionTopPreviewLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, competition := range competitions {
+		competition.TopPreview = previews[competition.ID]
+		if competition.TopPreview == nil {
+			competition.TopPreview = []*domain.CompetitionLeaderboardEntry{}
+		}
+	}
+
+	return competitions, nil
+}
+
+func (s *CompetitionService) GetBoardSummary(
+	ctx context.Context,
+	boardID int64,
+	page, limit int,
+	q, sort, dir string,
+) (*domain.BoardSummaryPage, error) {
+	return s.competitionScoreRepository.GetBoardSummary(ctx, boardID, page, limit, q, sort, dir)
 }
 
 func (s *CompetitionService) GetLeaderboard(
 	ctx context.Context,
 	competitionID int64,
 	page, limit int,
-	q string,
+	q, sort, dir string,
 ) (*domain.CompetitionLeaderboardPage, error) {
-	return s.competitionScoreRepository.GetLeaderboard(ctx, competitionID, page, limit, q)
+	return s.competitionScoreRepository.GetLeaderboard(ctx, competitionID, page, limit, q, sort, dir)
 }
 
 func (s *CompetitionService) DeleteCompetition(
@@ -99,14 +129,8 @@ func (s *CompetitionService) DeleteCompetition(
 		return err
 	}
 
-	competition, err := s.competitionRepository.GetCompetitionByID(ctx, boardID, competitionID)
-	if err != nil {
+	if _, err := s.competitionRepository.GetCompetitionByID(ctx, boardID, competitionID); err != nil {
 		return err
-	}
-
-	// The tournament pick'em is the board's anchor competition and must never be removed.
-	if competition.Type == domain.CompetitionTypePickem {
-		return domain.ErrCompetitionPickemNotDeletable
 	}
 
 	return s.competitionRepository.DeleteCompetition(ctx, boardID, competitionID)

--- a/internal/services/competition_service_test.go
+++ b/internal/services/competition_service_test.go
@@ -30,7 +30,7 @@ func privateBoardRepo() *mocks.MockBoardRepository {
 func TestCompetitionService_CreateCompetition(t *testing.T) {
 	t.Parallel()
 
-	t.Run("creates a pool competition carrying the match id", func(t *testing.T) {
+	t.Run("creates a pick competition carrying the match id", func(t *testing.T) {
 		t.Parallel()
 
 		boardID := gofakeit.Int64()
@@ -48,16 +48,16 @@ func TestCompetitionService_CreateCompetition(t *testing.T) {
 		service := newTestCompetitionService(privateBoardRepo(), cr)
 
 		_, err := service.CreateCompetition(context.Background(), boardID, userID, domain.BoardMemberRoleAdmin, dtos.CreateCompetitionDto{
-			Type:    domain.CompetitionTypePool,
+			Type:    domain.CompetitionTypePick,
 			Name:    "CvP",
 			MatchID: &matchID,
 		})
 
 		require.NoError(t, err)
 		require.NotNil(t, captured)
-		require.NotNil(t, captured.PoolMatchID)
-		assert.Equal(t, matchID, *captured.PoolMatchID)
-		assert.Equal(t, domain.CompetitionTypePool, captured.Type)
+		require.NotNil(t, captured.PickMatchID)
+		assert.Equal(t, matchID, *captured.PickMatchID)
+		assert.Equal(t, domain.CompetitionTypePick, captured.Type)
 	})
 
 	t.Run("rejects a member without manage permission", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCompetitionService_CreateCompetition(t *testing.T) {
 		service := newTestCompetitionService(&mocks.MockBoardRepository{}, &mocks.MockCompetitionRepository{})
 
 		_, err := service.CreateCompetition(context.Background(), gofakeit.Int64(), gofakeit.UUID(), domain.BoardMemberRoleMember, dtos.CreateCompetitionDto{
-			Type: domain.CompetitionTypePool,
+			Type: domain.CompetitionTypePick,
 			Name: "CvP",
 		})
 
@@ -81,24 +81,29 @@ func TestCompetitionService_CreateCompetition(t *testing.T) {
 func TestCompetitionService_DeleteCompetition(t *testing.T) {
 	t.Parallel()
 
-	t.Run("rejects deleting the tournament pick'em competition", func(t *testing.T) {
+	t.Run("deletes the tournament pick'em competition", func(t *testing.T) {
 		t.Parallel()
 
 		boardID := gofakeit.Int64()
 		competitionID := gofakeit.Int64()
+		deleteCalled := false
 
 		cr := &mocks.MockCompetitionRepository{
 			GetCompetitionByIDFunc: func(ctx context.Context, bid, cid int64) (*domain.Competition, error) {
 				return &domain.Competition{ID: cid, BoardID: bid, Type: domain.CompetitionTypePickem}, nil
 			},
-			// DeleteCompetitionFunc intentionally unset — it must never be called for a pick'em.
+			DeleteCompetitionFunc: func(ctx context.Context, bid, cid int64) error {
+				deleteCalled = true
+				return nil
+			},
 		}
 
 		service := newTestCompetitionService(privateBoardRepo(), cr)
 
 		err := service.DeleteCompetition(context.Background(), boardID, competitionID, domain.BoardMemberRoleAdmin)
 
-		assert.ErrorIs(t, err, domain.ErrCompetitionPickemNotDeletable)
+		assert.NoError(t, err)
+		assert.True(t, deleteCalled)
 	})
 
 	t.Run("deletes a match competition", func(t *testing.T) {

--- a/internal/services/dashboard_service.go
+++ b/internal/services/dashboard_service.go
@@ -65,11 +65,11 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 		return
 	})
 	eg.Go(func() (err error) {
-		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 5, "")
+		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 5, "", "", "")
 		return
 	})
 	eg.Go(func() (err error) {
-		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 5, "")
+		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 5, "", "", "")
 		return
 	})
 
@@ -163,6 +163,8 @@ func extractPoints(score any) int {
 	case *domain.PickemScore:
 		return s.Total
 	case *domain.MatchScore:
+		return s.Total
+	case *domain.AwardsScore:
 		return s.Total
 	}
 

--- a/internal/services/dashboard_service_test.go
+++ b/internal/services/dashboard_service_test.go
@@ -73,7 +73,7 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			GetUserMatchStatsFunc: func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error) {
 				return domain.CompetitionUserStats{Rank: 5, Points: 90}, nil
 			},
-			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 				assert.Equal(t, 1, page)
 				assert.Equal(t, 5, limit)
 				if competitionID == 11 {
@@ -177,7 +177,7 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			GetUserMatchStatsFunc: func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error) {
 				return domain.CompetitionUserStats{}, nil
 			},
-			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 				return &domain.CompetitionLeaderboardPage{Members: []*domain.CompetitionLeaderboardEntry{}}, nil
 			},
 		}
@@ -242,7 +242,7 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		}
 
 		competitionScoreRepo := &mocks.MockCompetitionScoreRepository{
-			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 				return &domain.CompetitionLeaderboardPage{
 					Members: []*domain.CompetitionLeaderboardEntry{
 						{Rank: 1, Member: domain.CompetitionLeaderboardMember{UserID: "u1", UserName: "alice"}, Score: &domain.PickemScore{Total: 100}},

--- a/internal/services/match_service.go
+++ b/internal/services/match_service.go
@@ -211,16 +211,8 @@ func (s *MatchService) scoreMatchOutcomes(ctx context.Context, outcomes *domain.
 
 	if outcomes != nil && outcomes.PromotionOutcome != nil &&
 		outcomes.PromotionOutcome.Status == domain.PromotionStatusCompleted {
-		bestThirdUserIDs, err := s.scoringService.ScoreBestThirds(ctx)
-		if err != nil {
+		if _, err := s.scoringService.ScoreBestThirds(ctx); err != nil {
 			s.logger.Error("pickem best-thirds scoring failed",
-				logging.Error, err.Error(),
-			)
-			return err
-		}
-
-		if err := s.competitionScoringService.RecomputeForBestThirds(ctx, bestThirdUserIDs); err != nil {
-			s.logger.Error("competition scoring recompute for best-thirds failed",
 				logging.Error, err.Error(),
 			)
 			return err
@@ -333,16 +325,8 @@ func (s *MatchService) ResolveThirdPlaceConflict(ctx context.Context, payload dt
 
 	// Third-place qualifiers are now resolved -> best_third_pick events can be scored
 	go func() {
-		bestThirdUserIDs, err := s.scoringService.ScoreBestThirds(context.Background())
-		if err != nil {
+		if _, err := s.scoringService.ScoreBestThirds(context.Background()); err != nil {
 			s.logger.Error("pickem best-thirds scoring failed (post conflict resolve)",
-				logging.Error, err.Error(),
-			)
-			return
-		}
-
-		if err := s.competitionScoringService.RecomputeForBestThirds(context.Background(), bestThirdUserIDs); err != nil {
-			s.logger.Error("competition scoring recompute for best-thirds failed (post conflict resolve)",
 				logging.Error, err.Error(),
 			)
 		}

--- a/internal/services/match_service_test.go
+++ b/internal/services/match_service_test.go
@@ -258,7 +258,6 @@ func TestMatchService_UpdateMatchResult(t *testing.T) {
 
 		service := newTestMatchService(mr, gsr, gss, ss, &mocks.MockCompetitionScoringService{
 			RecomputeForMatchesFunc:    func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
-			RecomputeForBestThirdsFunc: func(ctx context.Context, affectedUserIDs []string) error { return nil },
 		}, nil)
 
 		home, away := 1, 0
@@ -314,7 +313,6 @@ func TestMatchService_UpdateMatchResult(t *testing.T) {
 
 		service := newTestMatchService(mr, nil, gss, ss, &mocks.MockCompetitionScoringService{
 			RecomputeForMatchesFunc:    func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
-			RecomputeForBestThirdsFunc: func(ctx context.Context, affectedUserIDs []string) error { return nil },
 		}, nil)
 
 		home, away := 1, 0
@@ -464,7 +462,6 @@ func TestMatchService_UpdateMatchResultsBulk(t *testing.T) {
 
 		service := newTestMatchService(mr, nil, gss, ss, &mocks.MockCompetitionScoringService{
 			RecomputeForMatchesFunc:    func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
-			RecomputeForBestThirdsFunc: func(ctx context.Context, affectedUserIDs []string) error { return nil },
 		}, nil)
 
 		home, away := 1, 0
@@ -518,7 +515,6 @@ func TestMatchService_UpdateMatchResultsBulk(t *testing.T) {
 
 		service := newTestMatchService(mr, gsr, gss, ss, &mocks.MockCompetitionScoringService{
 			RecomputeForMatchesFunc:    func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
-			RecomputeForBestThirdsFunc: func(ctx context.Context, affectedUserIDs []string) error { return nil },
 		}, nil)
 
 		home, away := 1, 0
@@ -736,7 +732,6 @@ func TestMatchService_ResolveThirdPlaceConflict(t *testing.T) {
 
 		service := newTestMatchService(mr, gsr, gss, ss, &mocks.MockCompetitionScoringService{
 			RecomputeForMatchesFunc:    func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
-			RecomputeForBestThirdsFunc: func(ctx context.Context, affectedUserIDs []string) error { return nil },
 		}, nil)
 
 		// Select POR (group I) over NED (group A) from the tied pair — both are valid candidates.

--- a/internal/services/scoring_service.go
+++ b/internal/services/scoring_service.go
@@ -72,7 +72,6 @@ func (s *ScoringService) ScoreMatches(ctx context.Context, matchIDs []int64) (*d
 	affectedUserIDs := make(map[string]struct{})
 	scoredMatchIDs := make([]int64, 0, len(matches))
 	seenGroups := make(map[string]struct{})
-	pickemAffected := false
 
 	for _, match := range matches {
 		// Match score picks (every finished match, group or bracket)
@@ -122,7 +121,6 @@ func (s *ScoringService) ScoreMatches(ctx context.Context, matchIDs []int64) (*d
 
 				allScoreEvents = append(allScoreEvents, groupScoreEvents...)
 				addUserIDsToSet(affectedUserIDs, groupScoreUserIDs)
-				pickemAffected = true
 			}
 
 			continue
@@ -140,9 +138,6 @@ func (s *ScoringService) ScoreMatches(ctx context.Context, matchIDs []int64) (*d
 
 		allScoreEvents = append(allScoreEvents, bracketEvents...)
 		addUserIDsToSet(affectedUserIDs, bracketUserIDs)
-		if len(bracketEvents) > 0 {
-			pickemAffected = true
-		}
 	}
 
 	if err := s.scoreEventRepository.BatchUpsertScoreEvents(ctx, allScoreEvents); err != nil {
@@ -165,7 +160,6 @@ func (s *ScoringService) ScoreMatches(ctx context.Context, matchIDs []int64) (*d
 	return &domain.ScoreMatchesResult{
 		AffectedUserIDs: userIDs,
 		ScoredMatchIDs:  scoredMatchIDs,
-		PickemAffected:  pickemAffected,
 	}, nil
 }
 

--- a/internal/test/mocks/competition_repository_mock.go
+++ b/internal/test/mocks/competition_repository_mock.go
@@ -11,7 +11,6 @@ type MockCompetitionRepository struct {
 	GetBoardCompetitionsFunc           func(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
 	GetCompetitionByIDFunc             func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error)
 	DeleteCompetitionFunc              func(ctx context.Context, boardID, competitionID int64) error
-	GetAllPickemIDsFunc                func(ctx context.Context) ([]int64, error)
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
 	GetGlobalCompetitionsFunc          func(ctx context.Context) (*domain.Competition, *domain.Competition, error)
 }
@@ -42,13 +41,6 @@ func (m *MockCompetitionRepository) DeleteCompetition(ctx context.Context, board
 		return m.DeleteCompetitionFunc(ctx, boardID, competitionID)
 	}
 	panic("DeleteCompetition called unexpectedly")
-}
-
-func (m *MockCompetitionRepository) GetAllPickemIDs(ctx context.Context) ([]int64, error) {
-	if m.GetAllPickemIDsFunc != nil {
-		return m.GetAllPickemIDsFunc(ctx)
-	}
-	panic("GetAllPickemIDs called unexpectedly")
 }
 
 func (m *MockCompetitionRepository) FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error) {

--- a/internal/test/mocks/competition_score_repository_mock.go
+++ b/internal/test/mocks/competition_score_repository_mock.go
@@ -8,11 +8,12 @@ import (
 
 type MockCompetitionScoreRepository struct {
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
-	FindPoolCompetitionsByMatchesFunc  func(ctx context.Context, matchIDs []int64) ([]int64, error)
+	FindPickCompetitionsByMatchesFunc  func(ctx context.Context, matchIDs []int64) ([]int64, error)
 	BatchUpsertMatchScoresFunc         func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
-	BatchUpsertPoolScoresFunc          func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
-	BatchUpsertPickemScoresFunc        func(ctx context.Context, competitionIDs []int64, userIDs []string) error
-	GetLeaderboardFunc                 func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
+	BatchUpsertPickScoresFunc          func(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error
+	GetLeaderboardFunc                 func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error)
+	GetBoardSummaryFunc                func(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*domain.BoardSummaryPage, error)
+	GetBoardCompetitionPreviewsFunc    func(ctx context.Context, boardID int64, limit int) (map[int64][]*domain.CompetitionLeaderboardEntry, error)
 	GetUserPickemStatsFunc             func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error)
 	GetUserMatchStatsFunc              func(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error)
 }
@@ -24,11 +25,11 @@ func (m *MockCompetitionScoreRepository) FindMatchCompetitionsByMatches(ctx cont
 	panic("FindMatchCompetitionsByMatches called unexpectedly")
 }
 
-func (m *MockCompetitionScoreRepository) FindPoolCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error) {
-	if m.FindPoolCompetitionsByMatchesFunc != nil {
-		return m.FindPoolCompetitionsByMatchesFunc(ctx, matchIDs)
+func (m *MockCompetitionScoreRepository) FindPickCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error) {
+	if m.FindPickCompetitionsByMatchesFunc != nil {
+		return m.FindPickCompetitionsByMatchesFunc(ctx, matchIDs)
 	}
-	panic("FindPoolCompetitionsByMatches called unexpectedly")
+	panic("FindPickCompetitionsByMatches called unexpectedly")
 }
 
 func (m *MockCompetitionScoreRepository) BatchUpsertMatchScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
@@ -38,25 +39,32 @@ func (m *MockCompetitionScoreRepository) BatchUpsertMatchScores(ctx context.Cont
 	panic("BatchUpsertMatchScores called unexpectedly")
 }
 
-func (m *MockCompetitionScoreRepository) BatchUpsertPoolScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
-	if m.BatchUpsertPoolScoresFunc != nil {
-		return m.BatchUpsertPoolScoresFunc(ctx, competitionID, userIDs, exactScorePts)
+func (m *MockCompetitionScoreRepository) BatchUpsertPickScores(ctx context.Context, competitionID int64, userIDs []string, exactScorePts int) error {
+	if m.BatchUpsertPickScoresFunc != nil {
+		return m.BatchUpsertPickScoresFunc(ctx, competitionID, userIDs, exactScorePts)
 	}
-	panic("BatchUpsertPoolScores called unexpectedly")
+	panic("BatchUpsertPickScores called unexpectedly")
 }
 
-func (m *MockCompetitionScoreRepository) BatchUpsertPickemScores(ctx context.Context, competitionIDs []int64, userIDs []string) error {
-	if m.BatchUpsertPickemScoresFunc != nil {
-		return m.BatchUpsertPickemScoresFunc(ctx, competitionIDs, userIDs)
-	}
-	panic("BatchUpsertPickemScores called unexpectedly")
-}
-
-func (m *MockCompetitionScoreRepository) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+func (m *MockCompetitionScoreRepository) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 	if m.GetLeaderboardFunc != nil {
-		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q)
+		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q, sort, dir)
 	}
 	panic("GetLeaderboard called unexpectedly")
+}
+
+func (m *MockCompetitionScoreRepository) GetBoardSummary(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*domain.BoardSummaryPage, error) {
+	if m.GetBoardSummaryFunc != nil {
+		return m.GetBoardSummaryFunc(ctx, boardID, page, limit, q, sort, dir)
+	}
+	panic("GetBoardSummary called unexpectedly")
+}
+
+func (m *MockCompetitionScoreRepository) GetBoardCompetitionPreviews(ctx context.Context, boardID int64, limit int) (map[int64][]*domain.CompetitionLeaderboardEntry, error) {
+	if m.GetBoardCompetitionPreviewsFunc != nil {
+		return m.GetBoardCompetitionPreviewsFunc(ctx, boardID, limit)
+	}
+	panic("GetBoardCompetitionPreviews called unexpectedly")
 }
 
 func (m *MockCompetitionScoreRepository) GetUserPickemStats(ctx context.Context, competitionID int64, userID string) (domain.CompetitionUserStats, error) {

--- a/internal/test/mocks/competition_scoring_service_mock.go
+++ b/internal/test/mocks/competition_scoring_service_mock.go
@@ -7,9 +7,7 @@ import (
 )
 
 type MockCompetitionScoringService struct {
-	RecomputeForMatchesFunc    func(ctx context.Context, result *domain.ScoreMatchesResult) error
-	RecomputeForBestThirdsFunc func(ctx context.Context, affectedUserIDs []string) error
-	RecomputeForAwardsFunc     func(ctx context.Context, affectedUserIDs []string) error
+	RecomputeForMatchesFunc func(ctx context.Context, result *domain.ScoreMatchesResult) error
 }
 
 func (m *MockCompetitionScoringService) RecomputeForMatches(ctx context.Context, result *domain.ScoreMatchesResult) error {
@@ -17,18 +15,4 @@ func (m *MockCompetitionScoringService) RecomputeForMatches(ctx context.Context,
 		return m.RecomputeForMatchesFunc(ctx, result)
 	}
 	panic("RecomputeForMatches called unexpectedly")
-}
-
-func (m *MockCompetitionScoringService) RecomputeForBestThirds(ctx context.Context, affectedUserIDs []string) error {
-	if m.RecomputeForBestThirdsFunc != nil {
-		return m.RecomputeForBestThirdsFunc(ctx, affectedUserIDs)
-	}
-	panic("RecomputeForBestThirds called unexpectedly")
-}
-
-func (m *MockCompetitionScoringService) RecomputeForAwards(ctx context.Context, affectedUserIDs []string) error {
-	if m.RecomputeForAwardsFunc != nil {
-		return m.RecomputeForAwardsFunc(ctx, affectedUserIDs)
-	}
-	panic("RecomputeForAwards called unexpectedly")
 }

--- a/internal/test/mocks/competition_service_mock.go
+++ b/internal/test/mocks/competition_service_mock.go
@@ -10,7 +10,8 @@ import (
 type MockCompetitionService struct {
 	CreateCompetitionFunc    func(ctx context.Context, boardID int64, userID string, role domain.BoardMemberRole, payload dtos.CreateCompetitionDto) (*domain.CompetitionListItem, error)
 	GetBoardCompetitionsFunc func(ctx context.Context, boardID int64, viewerUserID string) ([]*domain.CompetitionListItem, error)
-	GetLeaderboardFunc       func(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error)
+	GetLeaderboardFunc       func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error)
+	GetBoardSummaryFunc      func(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*domain.BoardSummaryPage, error)
 	DeleteCompetitionFunc    func(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error
 }
 
@@ -28,11 +29,18 @@ func (m *MockCompetitionService) GetBoardCompetitions(ctx context.Context, board
 	panic("GetBoardCompetitions called unexpectedly")
 }
 
-func (m *MockCompetitionService) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q string) (*domain.CompetitionLeaderboardPage, error) {
+func (m *MockCompetitionService) GetLeaderboard(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 	if m.GetLeaderboardFunc != nil {
-		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q)
+		return m.GetLeaderboardFunc(ctx, competitionID, page, limit, q, sort, dir)
 	}
 	panic("GetLeaderboard called unexpectedly")
+}
+
+func (m *MockCompetitionService) GetBoardSummary(ctx context.Context, boardID int64, page, limit int, q, sort, dir string) (*domain.BoardSummaryPage, error) {
+	if m.GetBoardSummaryFunc != nil {
+		return m.GetBoardSummaryFunc(ctx, boardID, page, limit, q, sort, dir)
+	}
+	panic("GetBoardSummary called unexpectedly")
 }
 
 func (m *MockCompetitionService) DeleteCompetition(ctx context.Context, boardID, competitionID int64, role domain.BoardMemberRole) error {


### PR DESCRIPTION
## Release v1.2.0

Adds the pick & awards competition types and a board-wide summary endpoint.

### Highlights
- New `pick` (single-match) and standalone `awards` competition types; awards auto-created per board
- `GET /boards/{boardId}/summary` — ranked per-member standings with per-type subtotals + total
- Pick'em and awards leaderboards now computed on read; sort/dir params and top-3 previews on competition cards