### PR TITLE
chore: release v1.2.1

### DIFF
--- a/internal/middlewares/real_ip_middleware.go
+++ b/internal/middlewares/real_ip_middleware.go
@@ -4,26 +4,83 @@ import (
 	"net"
 	"net/http"
 	"strings"
-
-	"github.com/go-chi/chi/v5/middleware"
 )
 
 func TrustedProxyRealIP(trustedCIDRs []string) func(http.Handler) http.Handler {
 	nets := parseCIDRs(trustedCIDRs)
 
 	return func(next http.Handler) http.Handler {
-		realIP := middleware.RealIP(next)
-
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if len(nets) == 0 || isFromTrustedProxy(r.RemoteAddr, nets) {
-				// Connection is from a known proxy — trust the forwarded headers.
-				realIP.ServeHTTP(w, r)
-			} else {
-				// Unknown source — ignore forwarded headers, use the raw TCP IP.
-				next.ServeHTTP(w, r)
-			}
+			r.RemoteAddr = resolveClientIP(r, nets)
+			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func resolveClientIP(r *http.Request, trusted []*net.IPNet) string {
+	peer := stripPort(r.RemoteAddr)
+	forwarded := forwardedChain(r)
+
+	// No trust list: trust every proxy and take the original (leftmost) forwarded address.
+	if len(trusted) == 0 {
+		if len(forwarded) > 0 {
+			return forwarded[0]
+		}
+		return peer
+	}
+
+	// The immediate peer must itself be a trusted proxy; otherwise the forwarded headers
+	// are attacker-controlled and the raw connection address is the only safe value.
+	if !ipInNets(peer, trusted) {
+		return peer
+	}
+
+	// Walk right-to-left, skipping trusted proxies; the first untrusted address is the client.
+	for i := len(forwarded) - 1; i >= 0; i-- {
+		if !ipInNets(forwarded[i], trusted) {
+			return forwarded[i]
+		}
+	}
+
+	// Entire chain is trusted (or empty) — the closest trusted hop is the best we have.
+	return peer
+}
+
+// forwardedChain returns the valid IPs from all X-Forwarded-For headers, left to right.
+func forwardedChain(r *http.Request) []string {
+	var ips []string
+	for _, header := range r.Header.Values("X-Forwarded-For") {
+		for _, part := range strings.Split(header, ",") {
+			if ip := strings.TrimSpace(part); net.ParseIP(ip) != nil {
+				ips = append(ips, ip)
+			}
+		}
+	}
+	return ips
+}
+
+func ipInNets(ipStr string, nets []*net.IPNet) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+
+	for _, network := range nets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// stripPort returns the host portion of an address, tolerating bare IPs (v4 and v6),
+// "host:port", and "[ipv6]:port".
+func stripPort(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }
 
 func parseCIDRs(cidrs []string) []*net.IPNet {
@@ -49,25 +106,4 @@ func parseCIDRs(cidrs []string) []*net.IPNet {
 	}
 
 	return nets
-}
-
-func isFromTrustedProxy(remoteAddr string, nets []*net.IPNet) bool {
-	// Strip port - remoteAddr may be "1.2.3.4:port" or "[::1]:port".
-	host := remoteAddr
-	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
-		host = h
-	}
-
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false
-	}
-
-	for _, network := range nets {
-		if network.Contains(ip) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/middlewares/real_ip_middleware_test.go
+++ b/internal/middlewares/real_ip_middleware_test.go
@@ -1,0 +1,104 @@
+package middlewares_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fifawcp/api/internal/httpctx"
+	"github.com/fifawcp/api/internal/middlewares"
+)
+
+// Runs the production middleware chain (TrustedProxyRealIP -> RequestInfo) and returns the
+// IP that handlers ultimately observe via the request context.
+func resolveIP(trustedCIDRs []string, remoteAddr string, headers map[string]string) string {
+	var observed string
+	terminal := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if info := httpctx.GetRequestInfo(r.Context()); info != nil {
+			observed = info.IPAddress
+		}
+	})
+
+	chain := middlewares.TrustedProxyRealIP(trustedCIDRs)(middlewares.RequestInfo()(terminal))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/token", nil)
+	req.RemoteAddr = remoteAddr
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	chain.ServeHTTP(httptest.NewRecorder(), req)
+	return observed
+}
+
+func TestResolveClientIP(t *testing.T) {
+	const (
+		realClient = "203.0.113.45"   // the actual end user
+		bffEgress  = "44.220.117.213" // web BFF egress — the constant IP that used to leak into the DB
+	)
+
+	// Mirrors production: the API trusts its own Railway edge plus the BFF's egress range.
+	prodTrusted := []string{"10.0.0.0/8", "44.220.117.0/24"}
+
+	tests := []struct {
+		name         string
+		trustedCIDRs []string
+		remoteAddr   string
+		headers      map[string]string
+		want         string
+	}{
+		{
+			name:         "real client recovered from forwarded chain behind the BFF",
+			trustedCIDRs: prodTrusted,
+			remoteAddr:   "10.0.0.1:5000", // Railway edge
+			headers:      map[string]string{"X-Forwarded-For": realClient + ", " + bffEgress},
+			want:         realClient,
+		},
+		{
+			name:         "X-Real-IP set to the BFF egress is ignored",
+			trustedCIDRs: prodTrusted,
+			remoteAddr:   "10.0.0.1:5000",
+			headers: map[string]string{
+				"X-Real-IP":       bffEgress,
+				"X-Forwarded-For": realClient + ", " + bffEgress,
+			},
+			want: realClient,
+		},
+		{
+			name:         "spoofed leftmost entry is not selected",
+			trustedCIDRs: prodTrusted,
+			remoteAddr:   "10.0.0.1:5000",
+			headers:      map[string]string{"X-Forwarded-For": "6.6.6.6, " + realClient + ", " + bffEgress},
+			want:         realClient,
+		},
+		{
+			name:         "untrusted peer falls back to the raw connection IP",
+			trustedCIDRs: prodTrusted,
+			remoteAddr:   "8.8.8.8:1234",
+			headers:      map[string]string{"X-Forwarded-For": "1.2.3.4"},
+			want:         "8.8.8.8",
+		},
+		{
+			name:         "no trust list takes the leftmost forwarded address",
+			trustedCIDRs: nil,
+			remoteAddr:   "10.0.0.1:5000",
+			headers:      map[string]string{"X-Forwarded-For": realClient + ", " + bffEgress},
+			want:         realClient,
+		},
+		{
+			name:         "no forwarded header falls back to the peer",
+			trustedCIDRs: prodTrusted,
+			remoteAddr:   "10.0.0.1:5000",
+			want:         "10.0.0.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveIP(tc.trustedCIDRs, tc.remoteAddr, tc.headers)
+			if got != tc.want {
+				t.Fatalf("resolved client IP = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/middlewares/request_info_middleware.go
+++ b/internal/middlewares/request_info_middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/httpctx"
@@ -34,23 +33,7 @@ func RequestInfo() func(next http.Handler) http.Handler {
 }
 
 func getClientIP(r *http.Request) string {
-	// Chi's middleware.RealIP has already processed X-Forwarded-For and X-Real-IP headers
-	// and set r.RemoteAddr to the real client IP. We just need to strip the port.
-	ip := r.RemoteAddr
-
-	// Handle IPv6 addresses like [::1]:63514 or [2001:db8::1]:8080
-	if len(ip) > 0 && ip[0] == '[' {
-		if idx := strings.Index(ip, "]"); idx != -1 {
-			return ip[1:idx]
-		}
-	}
-
-	// Handle IPv4 like 127.0.0.1:63514
-	if host, _, found := strings.Cut(ip, ":"); found {
-		return host
-	}
-
-	return ip
+	return stripPort(r.RemoteAddr)
 }
 
 func parseUserAgent(userAgent string) dtos.DeviceInfo {


### PR DESCRIPTION
## Release v1.2.1

Fixes client IP capture so sessions record the real user IP instead of one constant proxy address.

### Fixes
- Resolve the real client IP behind trusted proxies: ignore `X-Real-IP` (set by Railway to the BFF egress), walk `X-Forwarded-For` right-to-left skipping `TRUSTED_PROXY_CIDRS`, and fix IPv6 port stripping (#96)