### PR TITLE
feat: clean up Google OAuth usernames and names

### DIFF
--- a/cmd/db/migrations/000019_clean_oauth_usernames_and_names.down.sql
+++ b/cmd/db/migrations/000019_clean_oauth_usernames_and_names.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the original random username prefix is not recoverable, and a
+-- blank name cannot be distinguished from one that was originally a placeholder.
+-- No-op.

--- a/cmd/db/migrations/000019_clean_oauth_usernames_and_names.up.sql
+++ b/cmd/db/migrations/000019_clean_oauth_usernames_and_names.up.sql
@@ -1,0 +1,31 @@
+-- Strip the legacy "<letter><3 digits>-" prefix from Google usernames, but only
+-- where the stripped handle is globally unique; colliding rows keep their prefix.
+WITH stripped AS (
+  SELECT u.id,
+         regexp_replace(u.username, '^[A-Z][0-9]{3}-', '') AS new_username
+  FROM users u
+  JOIN oauth_accounts oa ON oa.user_id = u.id AND oa.provider = 'google'
+  WHERE u.username ~ '^[A-Z][0-9]{3}-'
+),
+dupes AS (
+  SELECT new_username FROM stripped GROUP BY new_username HAVING count(*) > 1
+)
+UPDATE users u
+SET username = s.new_username, updated_at = NOW()
+FROM stripped s
+WHERE u.id = s.id
+  AND s.new_username NOT IN (SELECT new_username FROM dupes)
+  AND NOT EXISTS (
+    SELECT 1 FROM users e WHERE e.username = s.new_username AND e.id <> s.id
+  );
+
+-- Drop the literal name placeholders; missing names should render blank.
+UPDATE users u
+SET first_name = '', updated_at = NOW()
+FROM oauth_accounts oa
+WHERE oa.user_id = u.id AND oa.provider = 'google' AND u.first_name = 'Google';
+
+UPDATE users u
+SET last_name = '', updated_at = NOW()
+FROM oauth_accounts oa
+WHERE oa.user_id = u.id AND oa.provider = 'google' AND u.last_name = 'User';

--- a/internal/services/oauth_service.go
+++ b/internal/services/oauth_service.go
@@ -166,21 +166,11 @@ func (s *OAuthService) registerNewUserViaOAuth(
 	returnTo string,
 	requestInfo dtos.RequestInfo,
 ) (*dtos.AuthenticationDto, string, error) {
-	firstName := idToken.GivenName
-	if firstName == "" {
-		firstName = "Google"
-	}
-
-	lastName := idToken.FamilyName
-	if lastName == "" {
-		lastName = "User"
-	}
-
 	user := &domain.User{
 		Email:     strings.ToLower(idToken.Email),
-		FirstName: firstName,
-		LastName:  lastName,
-		Username:  generateUsernameFromEmail(idToken.Email, idToken.Provider),
+		FirstName: idToken.GivenName,
+		LastName:  idToken.FamilyName,
+		Username:  s.resolveAvailableUsername(ctx, idToken.Email, idToken.Provider),
 	}
 
 	account := &domain.OAuthAccount{
@@ -200,16 +190,34 @@ func (s *OAuthService) registerNewUserViaOAuth(
 	return authentication, returnTo, nil
 }
 
-func generateUsernameFromEmail(email string, provider string) string {
-	// Extract and lowercase the local part (everything before @)
+// resolveAvailableUsername prefers the clean email local part and only falls
+// back to the prefixed format when that handle is already taken.
+func (s *OAuthService) resolveAvailableUsername(ctx context.Context, email string, provider string) string {
+	base := usernameBaseFromEmail(email)
+
+	if _, err := s.userRepository.GetUserByIdentifier(ctx, base); errors.Is(err, domain.ErrUserNotFound) {
+		return base
+	}
+
+	return generateUsernameFromEmail(email, provider)
+}
+
+// usernameBaseFromEmail returns the lowercased email local part, capped so the
+// prefixed fallback still fits in VARCHAR(20):
+// <provider-letter>(1) + 3-digit suffix(3) + "-"(1) + base → base max = 15.
+func usernameBaseFromEmail(email string) string {
 	base := strings.ToLower(strings.SplitN(email, "@", 2)[0])
 
-	// Cap the local part so the final username fits in VARCHAR(20).
-	// Format: <provider-letter>(1) + 3-digit suffix(3) + "-"(1) + base → base max = 15.
 	const maxBaseLen = 15
 	if len(base) > maxBaseLen {
 		base = base[:maxBaseLen]
 	}
+
+	return base
+}
+
+func generateUsernameFromEmail(email string, provider string) string {
+	base := usernameBaseFromEmail(email)
 
 	// Random 3-digit suffix to reduce collisions on the same (provider, base) pair
 	n, err := rand.Int(rand.Reader, big.NewInt(1000))

--- a/internal/services/oauth_service_test.go
+++ b/internal/services/oauth_service_test.go
@@ -343,14 +343,14 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "test-given-name", authentication.User.FirstName)
 		assert.Equal(t, "test-family-name", authentication.User.LastName)
-		assert.Regexp(t, `^G\d{3}-test-email$`, authentication.User.Username)
+		assert.Equal(t, "test-email", authentication.User.Username)
 		assert.Equal(t, "test-email", authentication.User.Email)
 		assert.Equal(t, "test-access-token", authentication.Auth.AccessToken)
 		assert.Equal(t, "test-refresh-token", authentication.Auth.RefreshToken)
 		assert.Equal(t, "https://return-to.com", redirectURL)
 	})
 
-	t.Run("returns authentication data with default names when given name and family name are empty", func(t *testing.T) {
+	t.Run("leaves names empty when given name and family name are empty", func(t *testing.T) {
 		t.Parallel()
 
 		oauthStorage := &mocks.MockOAuthStorage{
@@ -426,10 +426,10 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 		)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "Google", authentication.User.FirstName)
-		assert.Equal(t, "User", authentication.User.LastName)
+		assert.Equal(t, "", authentication.User.FirstName)
+		assert.Equal(t, "", authentication.User.LastName)
 		assert.Equal(t, "newuser@example.com", authentication.User.Email)
-		assert.Regexp(t, `^G\d{3}-newuser$`, authentication.User.Username)
+		assert.Equal(t, "newuser", authentication.User.Username)
 		assert.Equal(t, "https://return-to.com", redirectURL)
 	})
 
@@ -514,8 +514,89 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, strings.ToLower(email), authentication.User.Email)
-		assert.Regexp(t, `^G\d{3}-`+cappedLocal+`$`, authentication.User.Username)
+		assert.Equal(t, cappedLocal, authentication.User.Username)
 		assert.Equal(t, "https://return-to.com", redirectURL)
+	})
+
+	t.Run("falls back to a prefixed username when the plain handle is taken", func(t *testing.T) {
+		t.Parallel()
+
+		oauthStorage := &mocks.MockOAuthStorage{
+			GetAndDeleteOAuthStateFunc: func(ctx context.Context, state string) (string, error) {
+				return "https://return-to.com", nil
+			},
+		}
+
+		oauth2Client := &mocks.MockGoogleOAuth2Client{
+			ExchangeCodeForTokenFunc: func(ctx context.Context, code string) (*domain.OIDCToken, error) {
+				return &domain.OIDCToken{
+					RawIDToken: "test-raw-id-token",
+				}, nil
+			},
+		}
+
+		idTokenVerifier := &mocks.MockGoogleIDTokenVerifier{
+			VerifyFunc: func(ctx context.Context, rawIDToken string) (*domain.IDToken, error) {
+				return &domain.IDToken{
+					Sub:           "test-sub",
+					Email:         "taken@example.com",
+					EmailVerified: true,
+					GivenName:     "test-given-name",
+					FamilyName:    "test-family-name",
+					Provider:      "google",
+				}, nil
+			},
+		}
+
+		oauthAccountRepository := &mocks.MockOAuthAccountRepository{
+			GetByProviderSubFunc: func(ctx context.Context, provider string, providerSub string) (*domain.OAuthAccount, error) {
+				return nil, domain.ErrOAuthAccountNotFound
+			},
+			CreateUserWithOAuthAccountFunc: func(ctx context.Context, user *domain.User, oauthAccount *domain.OAuthAccount) error {
+				return nil
+			},
+		}
+
+		userRepository := &mocks.MockUserRepository{
+			GetUserByIdentifierFunc: func(ctx context.Context, identifier string) (*domain.User, error) {
+				// Email lookup finds no existing user; the username "taken" is already in use.
+				if identifier == "taken" {
+					return &domain.User{Username: "taken"}, nil
+				}
+				return nil, domain.ErrUserNotFound
+			},
+		}
+
+		authService := &mocks.MockAuthService{
+			IssueAuthenticationFunc: func(ctx context.Context, user *domain.User, requestInfo dtos.RequestInfo) (*dtos.AuthenticationDto, error) {
+				return &dtos.AuthenticationDto{
+					User: user,
+					Auth: dtos.AuthData{
+						AccessToken:  "test-access-token",
+						RefreshToken: "test-refresh-token",
+					},
+				}, nil
+			},
+		}
+
+		s := newTestOAuthService(
+			oauthStorage,
+			oauth2Client,
+			idTokenVerifier,
+			oauthAccountRepository,
+			userRepository,
+			authService,
+		)
+
+		authentication, _, err := s.CompleteGoogleLogin(
+			context.Background(),
+			"test-state",
+			"test-code",
+			dtos.RequestInfo{},
+		)
+
+		assert.NoError(t, err)
+		assert.Regexp(t, `^G\d{3}-taken$`, authentication.User.Username)
 	})
 
 	t.Run("returns error when get and delete oauth state error", func(t *testing.T) {


### PR DESCRIPTION
## What changed

- Google sign-ups now get the clean email local part as their username; the `G###-` prefix is only used as a fallback when that handle is already taken
- Drop the `Google` / `User` name placeholders — missing Google names are now stored blank
- Migration `000019` backfills existing Google users: strips username prefixes where the bare handle is collision-free (keeps the prefix otherwise) and clears the name placeholders

## How to test

- [ ] Sign in with a Google account whose email local part is free → username is the bare handle, no prefix
- [ ] Sign in with a second account whose local part collides → username falls back to `G###-<base>`
- [ ] Sign in with a Google account missing given/family name → `first_name`/`last_name` come back empty, not `Google`/`User`
- [ ] Run `make db-migrate-up`, then `SELECT username, first_name, last_name FROM users u JOIN oauth_accounts oa ON oa.user_id=u.id WHERE oa.provider='google';` → no `G###-` prefixes except forced collisions, no placeholders
- [ ] `make test-unit` passes