### PR TITLE
fix: normalize auth email before validation to prevent registration 500

### DIFF
--- a/internal/dtos/auth_dto.go
+++ b/internal/dtos/auth_dto.go
@@ -48,6 +48,10 @@ func (dto *AuthenticationInputDto) Normalize() {
 	if isEmail(dto.Identifier) {
 		dto.Identifier = strings.ToLower(dto.Identifier)
 	}
+
+	if dto.User != nil {
+		dto.User.Email = strings.ToLower(strings.TrimSpace(dto.User.Email))
+	}
 }
 
 type AuthenticationDto struct {

--- a/internal/dtos/auth_dto_test.go
+++ b/internal/dtos/auth_dto_test.go
@@ -60,6 +60,27 @@ func TestAuthenticationInputDto_Normalize(t *testing.T) {
 
 		assert.Equal(t, "john_doe", dto.Identifier)
 	})
+
+	t.Run("normalize registration user email to lowercase and trimmed", func(t *testing.T) {
+		t.Parallel()
+
+		dto := &AuthenticationInputDto{
+			Identifier: "John.Doe@Example.com",
+			User:       &CreateUserDto{Email: "  John.Doe@Example.com  "},
+		}
+
+		dto.Normalize()
+
+		assert.Equal(t, "john.doe@example.com", dto.User.Email)
+	})
+
+	t.Run("tolerates a nil user", func(t *testing.T) {
+		t.Parallel()
+
+		dto := &AuthenticationInputDto{Identifier: "john.doe@example.com"}
+
+		assert.NotPanics(t, func() { dto.Normalize() })
+	})
 }
 
 func TestIsEmail(t *testing.T) {

--- a/internal/handlers/auth_handler_test.go
+++ b/internal/handlers/auth_handler_test.go
@@ -448,6 +448,41 @@ func TestAuthHandler_Authenticate(t *testing.T) {
 		assert.True(t, cookie.HttpOnly)
 	})
 
+	t.Run("normalizes a mixed-case registration email before reaching the service", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedEmail string
+		s := &mocks.MockAuthService{
+			AuthenticateFunc: func(
+				_ context.Context,
+				input *dtos.AuthenticationInputDto,
+				_ dtos.RequestInfo,
+			) (*dtos.AuthenticationDto, error) {
+				capturedEmail = input.User.Email
+				return &dtos.AuthenticationDto{User: testutils.CreateTestUser()}, nil
+			},
+		}
+		h := newTestAuthHandler(s)
+
+		req := makeAuthReq(t, map[string]any{
+			"identifier": "John.Doe@Example.com",
+			"purpose":    "registration",
+			"otp":        "123456",
+			"user": map[string]any{
+				"email":      "  John.Doe@Example.com  ",
+				"username":   "johndoe",
+				"first_name": "John",
+				"last_name":  "Doe",
+			},
+		})
+		w := httptest.NewRecorder()
+
+		h.Authenticate(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "john.doe@example.com", capturedEmail)
+	})
+
 	t.Run("returns 400 when validation fails", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -18,6 +18,10 @@ import (
 const refreshTokenCookieName = "refresh_token"
 const maxBodySizeInBytes = 1_048_576 // 1 MB
 
+type Normalizer interface {
+	Normalize()
+}
+
 // Response is the envelope for every successful API response.
 // `data` carries the resource (object or array). `pagination` is set only for
 // list endpoints — it sits at envelope level so client code can handle
@@ -122,6 +126,12 @@ func ReadAndValidateJSON(
 	if err := readJSON(w, r, data); err != nil {
 		RespondWithError(w, r, http.StatusBadRequest, codeInvalidRequestBody, err.Error())
 		return err
+	}
+
+	// Normalize before validation so canonical values (trimmed, lowercased) are
+	// what we validate and persist.
+	if normalizer, ok := data.(Normalizer); ok {
+		normalizer.Normalize()
 	}
 
 	if validationErrors := v.ValidateStruct(data); len(validationErrors) > 0 {


### PR DESCRIPTION
## Related issue

Closes #99

## What changed

- `ReadAndValidateJSON` now runs a DTO's `Normalize()` (via a new `Normalizer` interface) after decode and before validation — previously these methods were defined but never invoked
- `AuthenticationInputDto.Normalize()` now also lowercases + trims the registration `User.Email`, so it satisfies the `check_users_email_lowercase` DB constraint
- Fixes a prod 500 on `POST /api/auth/token` when registering with a mixed-case or whitespace email (e.g. `Juan@Gmail.com`)

## How to test

- [ ] Register via `POST /api/auth/token` with `purpose=registration` and `user.email = "Juan@Gmail.com"` → 200, user stored as `juan@gmail.com`
- [ ] Confirm pre-fix behavior reproduces the failure: `INSERT INTO users (first_name,last_name,username,email) VALUES ('T','U','x','Juan@Gmail.com');` → `check_users_email_lowercase` violation
- [ ] Register with surrounding whitespace in the email → trimmed before insert
- [ ] `make test-unit` passes