### PR TITLE
chore: release v1.2.2

### DIFF
--- a/cmd/db/migrations/000019_clean_oauth_usernames_and_names.down.sql
+++ b/cmd/db/migrations/000019_clean_oauth_usernames_and_names.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the original random username prefix is not recoverable, and a
+-- blank name cannot be distinguished from one that was originally a placeholder.
+-- No-op.

--- a/cmd/db/migrations/000019_clean_oauth_usernames_and_names.up.sql
+++ b/cmd/db/migrations/000019_clean_oauth_usernames_and_names.up.sql
@@ -1,0 +1,31 @@
+-- Strip the legacy "<letter><3 digits>-" prefix from Google usernames, but only
+-- where the stripped handle is globally unique; colliding rows keep their prefix.
+WITH stripped AS (
+  SELECT u.id,
+         regexp_replace(u.username, '^[A-Z][0-9]{3}-', '') AS new_username
+  FROM users u
+  JOIN oauth_accounts oa ON oa.user_id = u.id AND oa.provider = 'google'
+  WHERE u.username ~ '^[A-Z][0-9]{3}-'
+),
+dupes AS (
+  SELECT new_username FROM stripped GROUP BY new_username HAVING count(*) > 1
+)
+UPDATE users u
+SET username = s.new_username, updated_at = NOW()
+FROM stripped s
+WHERE u.id = s.id
+  AND s.new_username NOT IN (SELECT new_username FROM dupes)
+  AND NOT EXISTS (
+    SELECT 1 FROM users e WHERE e.username = s.new_username AND e.id <> s.id
+  );
+
+-- Drop the literal name placeholders; missing names should render blank.
+UPDATE users u
+SET first_name = '', updated_at = NOW()
+FROM oauth_accounts oa
+WHERE oa.user_id = u.id AND oa.provider = 'google' AND u.first_name = 'Google';
+
+UPDATE users u
+SET last_name = '', updated_at = NOW()
+FROM oauth_accounts oa
+WHERE oa.user_id = u.id AND oa.provider = 'google' AND u.last_name = 'User';

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -14,7 +14,7 @@ func (c *Container) NewRouter() *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
-	r.Use(middlewares.TrustedProxyRealIP(c.Config.Server.TrustedProxyCIDRs))
+	r.Use(middlewares.TrustedProxyRealIP(c.Config.Server.TrustedProxyCIDRs, c.Config.Server.IPForwardSecret))
 	r.Use(middleware.Recoverer)
 	r.Use(middlewares.LogRequest(c.Logger))
 	r.Use(middleware.Timeout(c.Config.Server.ContextTimeout))

--- a/internal/dtos/auth_dto.go
+++ b/internal/dtos/auth_dto.go
@@ -48,6 +48,10 @@ func (dto *AuthenticationInputDto) Normalize() {
 	if isEmail(dto.Identifier) {
 		dto.Identifier = strings.ToLower(dto.Identifier)
 	}
+
+	if dto.User != nil {
+		dto.User.Email = strings.ToLower(strings.TrimSpace(dto.User.Email))
+	}
 }
 
 type AuthenticationDto struct {

--- a/internal/dtos/auth_dto_test.go
+++ b/internal/dtos/auth_dto_test.go
@@ -60,6 +60,27 @@ func TestAuthenticationInputDto_Normalize(t *testing.T) {
 
 		assert.Equal(t, "john_doe", dto.Identifier)
 	})
+
+	t.Run("normalize registration user email to lowercase and trimmed", func(t *testing.T) {
+		t.Parallel()
+
+		dto := &AuthenticationInputDto{
+			Identifier: "John.Doe@Example.com",
+			User:       &CreateUserDto{Email: "  John.Doe@Example.com  "},
+		}
+
+		dto.Normalize()
+
+		assert.Equal(t, "john.doe@example.com", dto.User.Email)
+	})
+
+	t.Run("tolerates a nil user", func(t *testing.T) {
+		t.Parallel()
+
+		dto := &AuthenticationInputDto{Identifier: "john.doe@example.com"}
+
+		assert.NotPanics(t, func() { dto.Normalize() })
+	})
 }
 
 func TestIsEmail(t *testing.T) {

--- a/internal/handlers/auth_handler_test.go
+++ b/internal/handlers/auth_handler_test.go
@@ -448,6 +448,41 @@ func TestAuthHandler_Authenticate(t *testing.T) {
 		assert.True(t, cookie.HttpOnly)
 	})
 
+	t.Run("normalizes a mixed-case registration email before reaching the service", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedEmail string
+		s := &mocks.MockAuthService{
+			AuthenticateFunc: func(
+				_ context.Context,
+				input *dtos.AuthenticationInputDto,
+				_ dtos.RequestInfo,
+			) (*dtos.AuthenticationDto, error) {
+				capturedEmail = input.User.Email
+				return &dtos.AuthenticationDto{User: testutils.CreateTestUser()}, nil
+			},
+		}
+		h := newTestAuthHandler(s)
+
+		req := makeAuthReq(t, map[string]any{
+			"identifier": "John.Doe@Example.com",
+			"purpose":    "registration",
+			"otp":        "123456",
+			"user": map[string]any{
+				"email":      "  John.Doe@Example.com  ",
+				"username":   "johndoe",
+				"first_name": "John",
+				"last_name":  "Doe",
+			},
+		})
+		w := httptest.NewRecorder()
+
+		h.Authenticate(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "john.doe@example.com", capturedEmail)
+	})
+
 	t.Run("returns 400 when validation fails", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -18,6 +18,10 @@ import (
 const refreshTokenCookieName = "refresh_token"
 const maxBodySizeInBytes = 1_048_576 // 1 MB
 
+type Normalizer interface {
+	Normalize()
+}
+
 // Response is the envelope for every successful API response.
 // `data` carries the resource (object or array). `pagination` is set only for
 // list endpoints — it sits at envelope level so client code can handle
@@ -122,6 +126,12 @@ func ReadAndValidateJSON(
 	if err := readJSON(w, r, data); err != nil {
 		RespondWithError(w, r, http.StatusBadRequest, codeInvalidRequestBody, err.Error())
 		return err
+	}
+
+	// Normalize before validation so canonical values (trimmed, lowercased) are
+	// what we validate and persist.
+	if normalizer, ok := data.(Normalizer); ok {
+		normalizer.Normalize()
 	}
 
 	if validationErrors := v.ValidateStruct(data); len(validationErrors) > 0 {

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -46,6 +46,7 @@ type ServerConfig struct {
 	ShutdownTimeout   time.Duration
 	CORS              CORSConfig
 	TrustedProxyCIDRs []string
+	IPForwardSecret   string
 }
 
 type CORSConfig struct {
@@ -135,6 +136,7 @@ func NewConfig() *Config {
 			IdleTimeout:       env.GetDuration("SERVER_IDLE_TIMEOUT", 60*time.Second),
 			ShutdownTimeout:   env.GetDuration("SERVER_SHUTDOWN_TIMEOUT", 3*time.Second),
 			TrustedProxyCIDRs: strings.Split(env.GetString("TRUSTED_PROXY_CIDRS", ""), ","),
+			IPForwardSecret:   env.GetString("IP_FORWARD_SECRET", ""),
 			CORS: CORSConfig{
 				AllowedOrigins: strings.Split(env.GetString("CORS_ALLOWED_ORIGINS", "*"), ","),
 			},

--- a/internal/middlewares/logging_middleware.go
+++ b/internal/middlewares/logging_middleware.go
@@ -3,6 +3,7 @@ package middlewares
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/fifawcp/api/internal/httpctx"
@@ -30,6 +31,13 @@ func LogRequest(logger logging.Logger) func(next http.Handler) http.Handler {
 			ctx := context.WithValue(r.Context(), httpctx.ResponseErrorContextKey, responseErr)
 			r = r.WithContext(ctx)
 
+			// TEMP DEBUG (revert): raw forwarding headers to diagnose client IP on Railway.
+			// r.RemoteAddr is already rewritten by TrustedProxyRealIP, so capture the peer too.
+			dbgXFF := strings.Join(r.Header.Values("X-Forwarded-For"), " | ")
+			dbgXRealIP := r.Header.Get("X-Real-Ip")
+			dbgXEnvoy := r.Header.Get("X-Envoy-External-Address")
+			dbgResolvedIP := getClientIP(r)
+
 			// Run after ServeHTTP returns
 			defer func() {
 				status := wrapResponseWriter.Status()
@@ -47,6 +55,11 @@ func LogRequest(logger logging.Logger) func(next http.Handler) http.Handler {
 					logging.Status, status,
 					logging.DurationMS, time.Since(start).Milliseconds(),
 					logging.Outcome, outcome,
+					// TEMP DEBUG (revert): raw forwarding headers vs resolved IP.
+					"dbg_xff", dbgXFF,
+					"dbg_x_real_ip", dbgXRealIP,
+					"dbg_x_envoy_external", dbgXEnvoy,
+					"dbg_resolved_ip", dbgResolvedIP,
 				}
 
 				// Append user ID if the endpoint is authenticated

--- a/internal/middlewares/logging_middleware.go
+++ b/internal/middlewares/logging_middleware.go
@@ -36,6 +36,7 @@ func LogRequest(logger logging.Logger) func(next http.Handler) http.Handler {
 			dbgXFF := strings.Join(r.Header.Values("X-Forwarded-For"), " | ")
 			dbgXRealIP := r.Header.Get("X-Real-Ip")
 			dbgXEnvoy := r.Header.Get("X-Envoy-External-Address")
+			dbgXClientIP := r.Header.Get("X-Client-Ip")
 			dbgResolvedIP := getClientIP(r)
 
 			// Run after ServeHTTP returns
@@ -59,6 +60,7 @@ func LogRequest(logger logging.Logger) func(next http.Handler) http.Handler {
 					"dbg_xff", dbgXFF,
 					"dbg_x_real_ip", dbgXRealIP,
 					"dbg_x_envoy_external", dbgXEnvoy,
+					"dbg_x_client_ip", dbgXClientIP,
 					"dbg_resolved_ip", dbgResolvedIP,
 				}
 

--- a/internal/middlewares/real_ip_middleware.go
+++ b/internal/middlewares/real_ip_middleware.go
@@ -1,23 +1,33 @@
 package middlewares
 
 import (
+	"crypto/subtle"
 	"net"
 	"net/http"
 	"strings"
 )
 
-func TrustedProxyRealIP(trustedCIDRs []string) func(http.Handler) http.Handler {
+const (
+	clientIPHeader      = "X-Client-IP"
+	forwardSecretHeader = "X-IP-Forward-Secret"
+)
+
+func TrustedProxyRealIP(trustedCIDRs []string, forwardSecret string) func(http.Handler) http.Handler {
 	nets := parseCIDRs(trustedCIDRs)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r.RemoteAddr = resolveClientIP(r, nets)
+			r.RemoteAddr = resolveClientIP(r, nets, forwardSecret)
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
-func resolveClientIP(r *http.Request, trusted []*net.IPNet) string {
+func resolveClientIP(r *http.Request, trusted []*net.IPNet, forwardSecret string) string {
+	if ip := clientIPFromTrustedHeader(r, forwardSecret); ip != "" {
+		return ip
+	}
+
 	peer := stripPort(r.RemoteAddr)
 	forwarded := forwardedChain(r)
 
@@ -46,7 +56,24 @@ func resolveClientIP(r *http.Request, trusted []*net.IPNet) string {
 	return peer
 }
 
-// forwardedChain returns the valid IPs from all X-Forwarded-For headers, left to right.
+func clientIPFromTrustedHeader(r *http.Request, forwardSecret string) string {
+	if forwardSecret == "" {
+		return ""
+	}
+
+	provided := r.Header.Get(forwardSecretHeader)
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(forwardSecret)) != 1 {
+		return ""
+	}
+
+	ip := strings.TrimSpace(r.Header.Get(clientIPHeader))
+	if net.ParseIP(ip) == nil {
+		return ""
+	}
+
+	return ip
+}
+
 func forwardedChain(r *http.Request) []string {
 	var ips []string
 	for _, header := range r.Header.Values("X-Forwarded-For") {
@@ -74,8 +101,6 @@ func ipInNets(ipStr string, nets []*net.IPNet) bool {
 	return false
 }
 
-// stripPort returns the host portion of an address, tolerating bare IPs (v4 and v6),
-// "host:port", and "[ipv6]:port".
 func stripPort(addr string) string {
 	if host, _, err := net.SplitHostPort(addr); err == nil {
 		return host

--- a/internal/middlewares/real_ip_middleware_test.go
+++ b/internal/middlewares/real_ip_middleware_test.go
@@ -11,7 +11,7 @@ import (
 
 // Runs the production middleware chain (TrustedProxyRealIP -> RequestInfo) and returns the
 // IP that handlers ultimately observe via the request context.
-func resolveIP(trustedCIDRs []string, remoteAddr string, headers map[string]string) string {
+func resolveIP(trustedCIDRs []string, forwardSecret, remoteAddr string, headers map[string]string) string {
 	var observed string
 	terminal := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		if info := httpctx.GetRequestInfo(r.Context()); info != nil {
@@ -19,7 +19,7 @@ func resolveIP(trustedCIDRs []string, remoteAddr string, headers map[string]stri
 		}
 	})
 
-	chain := middlewares.TrustedProxyRealIP(trustedCIDRs)(middlewares.RequestInfo()(terminal))
+	chain := middlewares.TrustedProxyRealIP(trustedCIDRs, forwardSecret)(middlewares.RequestInfo()(terminal))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/token", nil)
 	req.RemoteAddr = remoteAddr
@@ -40,13 +40,59 @@ func TestResolveClientIP(t *testing.T) {
 	// Mirrors production: the API trusts its own Railway edge plus the BFF's egress range.
 	prodTrusted := []string{"10.0.0.0/8", "44.220.117.0/24"}
 
+	const secret = "s3cret-shared-with-frontend"
+
 	tests := []struct {
-		name         string
-		trustedCIDRs []string
-		remoteAddr   string
-		headers      map[string]string
-		want         string
+		name          string
+		trustedCIDRs  []string
+		forwardSecret string
+		remoteAddr    string
+		headers       map[string]string
+		want          string
 	}{
+		{
+			name:          "trusted X-Client-IP wins when the shared secret matches",
+			forwardSecret: secret,
+			remoteAddr:    "10.0.0.1:5000",
+			headers: map[string]string{
+				"X-Ip-Forward-Secret": secret,
+				"X-Client-Ip":         realClient,
+				"X-Forwarded-For":     bffEgress, // edge-rewritten chain is ignored
+			},
+			want: realClient,
+		},
+		{
+			name:          "X-Client-IP is ignored when the secret does not match",
+			forwardSecret: secret,
+			remoteAddr:    "10.0.0.1:5000",
+			headers: map[string]string{
+				"X-Ip-Forward-Secret": "wrong",
+				"X-Client-Ip":         "6.6.6.6",
+				"X-Forwarded-For":     realClient,
+			},
+			want: realClient,
+		},
+		{
+			name:         "X-Client-IP is ignored when no secret is configured",
+			remoteAddr:   "10.0.0.1:5000",
+			headers: map[string]string{
+				"X-Ip-Forward-Secret": secret,
+				"X-Client-Ip":         "6.6.6.6",
+				"X-Forwarded-For":     realClient,
+			},
+			want: realClient,
+		},
+		{
+			name:          "invalid X-Client-IP falls back to the forwarded chain",
+			forwardSecret: secret,
+			remoteAddr:    "10.0.0.1:5000",
+			headers: map[string]string{
+				"X-Ip-Forward-Secret": secret,
+				"X-Client-Ip":         "not-an-ip",
+				"X-Forwarded-For":     realClient,
+			},
+			want: realClient,
+		},
 		{
 			name:         "real client recovered from forwarded chain behind the BFF",
 			trustedCIDRs: prodTrusted,
@@ -95,7 +141,7 @@ func TestResolveClientIP(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveIP(tc.trustedCIDRs, tc.remoteAddr, tc.headers)
+			got := resolveIP(tc.trustedCIDRs, tc.forwardSecret, tc.remoteAddr, tc.headers)
 			if got != tc.want {
 				t.Fatalf("resolved client IP = %q, want %q", got, tc.want)
 			}

--- a/internal/services/oauth_service.go
+++ b/internal/services/oauth_service.go
@@ -166,21 +166,11 @@ func (s *OAuthService) registerNewUserViaOAuth(
 	returnTo string,
 	requestInfo dtos.RequestInfo,
 ) (*dtos.AuthenticationDto, string, error) {
-	firstName := idToken.GivenName
-	if firstName == "" {
-		firstName = "Google"
-	}
-
-	lastName := idToken.FamilyName
-	if lastName == "" {
-		lastName = "User"
-	}
-
 	user := &domain.User{
 		Email:     strings.ToLower(idToken.Email),
-		FirstName: firstName,
-		LastName:  lastName,
-		Username:  generateUsernameFromEmail(idToken.Email, idToken.Provider),
+		FirstName: idToken.GivenName,
+		LastName:  idToken.FamilyName,
+		Username:  s.resolveAvailableUsername(ctx, idToken.Email, idToken.Provider),
 	}
 
 	account := &domain.OAuthAccount{
@@ -200,16 +190,34 @@ func (s *OAuthService) registerNewUserViaOAuth(
 	return authentication, returnTo, nil
 }
 
-func generateUsernameFromEmail(email string, provider string) string {
-	// Extract and lowercase the local part (everything before @)
+// resolveAvailableUsername prefers the clean email local part and only falls
+// back to the prefixed format when that handle is already taken.
+func (s *OAuthService) resolveAvailableUsername(ctx context.Context, email string, provider string) string {
+	base := usernameBaseFromEmail(email)
+
+	if _, err := s.userRepository.GetUserByIdentifier(ctx, base); errors.Is(err, domain.ErrUserNotFound) {
+		return base
+	}
+
+	return generateUsernameFromEmail(email, provider)
+}
+
+// usernameBaseFromEmail returns the lowercased email local part, capped so the
+// prefixed fallback still fits in VARCHAR(20):
+// <provider-letter>(1) + 3-digit suffix(3) + "-"(1) + base → base max = 15.
+func usernameBaseFromEmail(email string) string {
 	base := strings.ToLower(strings.SplitN(email, "@", 2)[0])
 
-	// Cap the local part so the final username fits in VARCHAR(20).
-	// Format: <provider-letter>(1) + 3-digit suffix(3) + "-"(1) + base → base max = 15.
 	const maxBaseLen = 15
 	if len(base) > maxBaseLen {
 		base = base[:maxBaseLen]
 	}
+
+	return base
+}
+
+func generateUsernameFromEmail(email string, provider string) string {
+	base := usernameBaseFromEmail(email)
 
 	// Random 3-digit suffix to reduce collisions on the same (provider, base) pair
 	n, err := rand.Int(rand.Reader, big.NewInt(1000))

--- a/internal/services/oauth_service_test.go
+++ b/internal/services/oauth_service_test.go
@@ -343,14 +343,14 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "test-given-name", authentication.User.FirstName)
 		assert.Equal(t, "test-family-name", authentication.User.LastName)
-		assert.Regexp(t, `^G\d{3}-test-email$`, authentication.User.Username)
+		assert.Equal(t, "test-email", authentication.User.Username)
 		assert.Equal(t, "test-email", authentication.User.Email)
 		assert.Equal(t, "test-access-token", authentication.Auth.AccessToken)
 		assert.Equal(t, "test-refresh-token", authentication.Auth.RefreshToken)
 		assert.Equal(t, "https://return-to.com", redirectURL)
 	})
 
-	t.Run("returns authentication data with default names when given name and family name are empty", func(t *testing.T) {
+	t.Run("leaves names empty when given name and family name are empty", func(t *testing.T) {
 		t.Parallel()
 
 		oauthStorage := &mocks.MockOAuthStorage{
@@ -426,10 +426,10 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 		)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "Google", authentication.User.FirstName)
-		assert.Equal(t, "User", authentication.User.LastName)
+		assert.Equal(t, "", authentication.User.FirstName)
+		assert.Equal(t, "", authentication.User.LastName)
 		assert.Equal(t, "newuser@example.com", authentication.User.Email)
-		assert.Regexp(t, `^G\d{3}-newuser$`, authentication.User.Username)
+		assert.Equal(t, "newuser", authentication.User.Username)
 		assert.Equal(t, "https://return-to.com", redirectURL)
 	})
 
@@ -514,8 +514,89 @@ func TestOAuthService_CompleteGoogleLogin(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, strings.ToLower(email), authentication.User.Email)
-		assert.Regexp(t, `^G\d{3}-`+cappedLocal+`$`, authentication.User.Username)
+		assert.Equal(t, cappedLocal, authentication.User.Username)
 		assert.Equal(t, "https://return-to.com", redirectURL)
+	})
+
+	t.Run("falls back to a prefixed username when the plain handle is taken", func(t *testing.T) {
+		t.Parallel()
+
+		oauthStorage := &mocks.MockOAuthStorage{
+			GetAndDeleteOAuthStateFunc: func(ctx context.Context, state string) (string, error) {
+				return "https://return-to.com", nil
+			},
+		}
+
+		oauth2Client := &mocks.MockGoogleOAuth2Client{
+			ExchangeCodeForTokenFunc: func(ctx context.Context, code string) (*domain.OIDCToken, error) {
+				return &domain.OIDCToken{
+					RawIDToken: "test-raw-id-token",
+				}, nil
+			},
+		}
+
+		idTokenVerifier := &mocks.MockGoogleIDTokenVerifier{
+			VerifyFunc: func(ctx context.Context, rawIDToken string) (*domain.IDToken, error) {
+				return &domain.IDToken{
+					Sub:           "test-sub",
+					Email:         "taken@example.com",
+					EmailVerified: true,
+					GivenName:     "test-given-name",
+					FamilyName:    "test-family-name",
+					Provider:      "google",
+				}, nil
+			},
+		}
+
+		oauthAccountRepository := &mocks.MockOAuthAccountRepository{
+			GetByProviderSubFunc: func(ctx context.Context, provider string, providerSub string) (*domain.OAuthAccount, error) {
+				return nil, domain.ErrOAuthAccountNotFound
+			},
+			CreateUserWithOAuthAccountFunc: func(ctx context.Context, user *domain.User, oauthAccount *domain.OAuthAccount) error {
+				return nil
+			},
+		}
+
+		userRepository := &mocks.MockUserRepository{
+			GetUserByIdentifierFunc: func(ctx context.Context, identifier string) (*domain.User, error) {
+				// Email lookup finds no existing user; the username "taken" is already in use.
+				if identifier == "taken" {
+					return &domain.User{Username: "taken"}, nil
+				}
+				return nil, domain.ErrUserNotFound
+			},
+		}
+
+		authService := &mocks.MockAuthService{
+			IssueAuthenticationFunc: func(ctx context.Context, user *domain.User, requestInfo dtos.RequestInfo) (*dtos.AuthenticationDto, error) {
+				return &dtos.AuthenticationDto{
+					User: user,
+					Auth: dtos.AuthData{
+						AccessToken:  "test-access-token",
+						RefreshToken: "test-refresh-token",
+					},
+				}, nil
+			},
+		}
+
+		s := newTestOAuthService(
+			oauthStorage,
+			oauth2Client,
+			idTokenVerifier,
+			oauthAccountRepository,
+			userRepository,
+			authService,
+		)
+
+		authentication, _, err := s.CompleteGoogleLogin(
+			context.Background(),
+			"test-state",
+			"test-code",
+			dtos.RequestInfo{},
+		)
+
+		assert.NoError(t, err)
+		assert.Regexp(t, `^G\d{3}-taken$`, authentication.User.Username)
 	})
 
 	t.Run("returns error when get and delete oauth state error", func(t *testing.T) {


### PR DESCRIPTION
## Release v1.2.2

Cleaner Google sign-up identities and a fix for registration failures on mixed-case emails.

### Highlights
- Google usernames now default to the clean email handle, with the `G###-` prefix only as a collision fallback; existing users backfilled via migration `000019`
- Empty Google names are stored blank instead of `Google` / `User` placeholders

### Fixes
- Registration via `POST /api/auth/token` no longer 500s on mixed-case or whitespace emails — DTO `Normalize()` is now actually run before validation and canonicalizes the email