### PR TITLE
feat: add enable/disable toggle for match-results sync job

### DIFF
--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -46,6 +46,7 @@ type Container struct {
 	mailer               mailer.Mailer
 	Authenticator        auth.Authenticator
 	Scheduler            scheduler.Scheduler
+	syncMatchResultsJob  *jobs.SyncMatchResultsJob
 	GoogleOauthConfig    domain.OAuth2Client
 	OIDCIdentityVerifier domain.IDTokenVerifier
 
@@ -335,8 +336,13 @@ func (c *Container) initJobs() {
 		)
 	}
 
+	if !c.Config.Cron.SyncMatchResultsEnabled {
+		c.Logger.Info("sync:match_results disabled via config")
+		return
+	}
+
 	footballClient := football.NewFootballClient(c.Config.FootballAPI)
-	syncMatchResultsJob := jobs.NewSyncMatchResultsJob(
+	c.syncMatchResultsJob = jobs.NewSyncMatchResultsJob(
 		c.matchService,
 		footballClient,
 		c.matchFairPlayRepository,
@@ -346,10 +352,10 @@ func (c *Container) initJobs() {
 
 	// Run once at startup to register timers for upcoming matches and backfill any
 	// matches whose sync window has already passed (e.g. after a server restart)
-	go syncMatchResultsJob.Run(context.Background())
+	go c.syncMatchResultsJob.Run(context.Background())
 
 	// Re-run at midnight to pick up newly-assigned knockout teams and re-register timers
-	if err := c.Scheduler.RegisterJob(c.Config.Cron.SyncMatchResultsSchedule, syncMatchResultsJob); err != nil {
+	if err := c.Scheduler.RegisterJob(c.Config.Cron.SyncMatchResultsSchedule, c.syncMatchResultsJob); err != nil {
 		c.Logger.Error(
 			"failed to register job",
 			"job", "sync:match_results",
@@ -391,7 +397,7 @@ func (c *Container) StartServer(r *chi.Mux) error {
 
 	select {
 	case err := <-serverErrors:
-		c.Scheduler.Stop()
+		c.stopJobs()
 		return fmt.Errorf("server error: %w", err)
 	case sig := <-quit:
 		c.Logger.Info("Shutting down server", "signal", sig)
@@ -399,11 +405,19 @@ func (c *Container) StartServer(r *chi.Mux) error {
 	}
 }
 
+// stopJobs halts the cron scheduler and cancels any pending match-sync timers.
+func (c *Container) stopJobs() {
+	c.Scheduler.Stop()
+	if c.syncMatchResultsJob != nil {
+		c.syncMatchResultsJob.Stop()
+	}
+}
+
 func (c *Container) ShutdownServer(server *http.Server) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Config.Server.ShutdownTimeout)
 	defer cancel()
 
-	c.Scheduler.Stop()
+	c.stopJobs()
 
 	if err := server.Shutdown(ctx); err != nil {
 		server.Close()

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -105,6 +105,7 @@ type MailerConfig struct {
 type CronConfig struct {
 	CleanupSessionsSchedule  string
 	SyncMatchResultsSchedule string
+	SyncMatchResultsEnabled  bool
 }
 
 type FootballAPIConfig struct {
@@ -186,6 +187,7 @@ func NewConfig() *Config {
 		Cron: CronConfig{
 			CleanupSessionsSchedule:  env.GetString("CRON_CLEANUP_SESSIONS_SCHEDULE", "0 0 * * *"),   // Every day at midnight
 			SyncMatchResultsSchedule: env.GetString("CRON_SYNC_MATCH_RESULTS_SCHEDULE", "0 0 * * *"), // Every day at midnight (planning-only run)
+			SyncMatchResultsEnabled:  env.GetBool("CRON_SYNC_MATCH_RESULTS_ENABLED", true),
 		},
 		FootballAPI: FootballAPIConfig{
 			Key:     env.GetString("FOOTBALL_API_KEY", ""),

--- a/internal/jobs/sync_match_results_job.go
+++ b/internal/jobs/sync_match_results_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/fifawcp/api/internal/domain"
@@ -25,6 +26,8 @@ type SyncMatchResultsJob struct {
 	fairPlayRepo   domain.MatchFairPlayRepository
 	apiFixtureRepo domain.MatchAPIFixtureRepository
 	logger         logging.Logger
+	timersMutex    sync.Mutex
+	timers         map[int64]*time.Timer
 }
 
 func NewSyncMatchResultsJob(
@@ -40,6 +43,7 @@ func NewSyncMatchResultsJob(
 		fairPlayRepo:   fairPlayRepo,
 		apiFixtureRepo: apiFixtureRepo,
 		logger:         logger,
+		timers:         make(map[int64]*time.Timer),
 	}
 }
 
@@ -79,9 +83,7 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 
 		// Schedule the sync if the match is in the future
 		if delay > 0 {
-			time.AfterFunc(delay, func() {
-				j.syncMatch(context.Background(), matchID, fixtureID, syncMaxRetries)
-			})
+			j.scheduleSync(matchID, fixtureID, delay)
 		} else {
 			// Sync the match immediately if it's in the past
 			go j.syncMatch(ctx, matchID, fixtureID, syncMaxRetries)
@@ -94,6 +96,33 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 		"matches_scheduled", scheduled,
 	)
 	return nil
+}
+
+// scheduleSync registers a single pending sync timer per match. A re-run stops
+// the previous timer before installing the new one so timers never accumulate.
+func (j *SyncMatchResultsJob) scheduleSync(matchID, fixtureID int64, delay time.Duration) {
+	j.timersMutex.Lock()
+	defer j.timersMutex.Unlock()
+
+	if existing, ok := j.timers[matchID]; ok {
+		existing.Stop()
+	}
+
+	j.timers[matchID] = time.AfterFunc(delay, func() {
+		j.syncMatch(context.Background(), matchID, fixtureID, syncMaxRetries)
+	})
+}
+
+// Stop cancels all pending sync timers. Called on shutdown so timers do not fire
+// during teardown; the next startup re-arms them from the scheduled matches.
+func (j *SyncMatchResultsJob) Stop() {
+	j.timersMutex.Lock()
+	defer j.timersMutex.Unlock()
+
+	for matchID, timer := range j.timers {
+		timer.Stop()
+		delete(j.timers, matchID)
+	}
 }
 
 func (j *SyncMatchResultsJob) syncMatch(ctx context.Context, matchID, fixtureID int64, retriesLeft int) {

--- a/internal/jobs/sync_match_results_job_test.go
+++ b/internal/jobs/sync_match_results_job_test.go
@@ -1,0 +1,52 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScheduleSync_ReplacesExistingTimer verifies that re-scheduling the same
+// match stops the previous timer and keeps exactly one pending timer, so daily
+// re-runs do not accumulate duplicate timers.
+func TestScheduleSync_ReplacesExistingTimer(t *testing.T) {
+	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
+
+	const matchID int64 = 1
+	const fixtureID int64 = 10
+
+	// A long delay guarantees neither timer fires during the test.
+	job.scheduleSync(matchID, fixtureID, time.Hour)
+	firstTimer := job.timers[matchID]
+
+	job.scheduleSync(matchID, fixtureID, time.Hour)
+	secondTimer := job.timers[matchID]
+
+	if len(job.timers) != 1 {
+		t.Fatalf("expected exactly 1 pending timer, got %d", len(job.timers))
+	}
+	if firstTimer == secondTimer {
+		t.Fatal("expected the timer to be replaced on re-schedule")
+	}
+	// The first timer should already be stopped by the helper, so Stop() reports false.
+	if firstTimer.Stop() {
+		t.Fatal("expected the previous timer to have been stopped")
+	}
+}
+
+// TestStop_CancelsAllPendingTimers verifies shutdown cancels every pending timer.
+func TestStop_CancelsAllPendingTimers(t *testing.T) {
+	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
+
+	job.scheduleSync(1, 10, time.Hour)
+	job.scheduleSync(2, 20, time.Hour)
+	timer := job.timers[1]
+
+	job.Stop()
+
+	if len(job.timers) != 0 {
+		t.Fatalf("expected all timers cleared, got %d", len(job.timers))
+	}
+	if timer.Stop() {
+		t.Fatal("expected pending timer to have been stopped")
+	}
+}


### PR DESCRIPTION
## Related issue

Closes #106

## What changed

- Add `CRON_SYNC_MATCH_RESULTS_ENABLED` env toggle (default `true`) to enable/disable the match-results sync job, following the `RATE_LIMIT_ENABLED` pattern
- Fix daily re-run accumulating duplicate in-memory timers: `scheduleSync` now stops any existing timer per match before re-arming, keeping exactly one
- Add `SyncMatchResultsJob.Stop()` to cancel pending timers on shutdown, wired into both shutdown paths via a new `stopJobs()` helper
- Add unit tests for timer dedup and shutdown cancellation

## How to test

- [ ] Start the server with `CRON_SYNC_MATCH_RESULTS_ENABLED=false`; confirm log line `sync:match_results disabled via config` and no planning run
- [ ] Start with it unset/`true`; confirm `sync:match_results planning run started` and a `matches_scheduled` count
- [ ] Run `docker compose exec server go test -race -count=1 ./internal/jobs/...` — dedup + stop tests pass
- [ ] Trigger shutdown (SIGTERM); confirm clean exit with no timers firing afterward