### PR TITLE
fix: make POST /boards/join idempotent for existing members

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -55,6 +55,15 @@ var ErrBoardIsGlobal = errors.New("operation not allowed on global board")
 var ErrBoardMemberNotFound = errors.New("board member not found")
 var ErrBoardMemberAlreadyInBoard = errors.New("user is already a member of this board")
 var ErrCannotTransferOwnershipToSelf = errors.New("cannot transfer ownership to yourself")
+
+type BoardMemberAlreadyInBoardError struct {
+	BoardID int64
+}
+
+func (e BoardMemberAlreadyInBoardError) Error() string {
+	return ErrBoardMemberAlreadyInBoard.Error()
+}
+
 var ErrBoardManageAdminForbidden = errors.New("only the board owner can manage admins")
 
 // Group Standings

--- a/internal/handlers/board_handler.go
+++ b/internal/handlers/board_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -105,7 +106,7 @@ func (h *BoardHandler) GetUserBoards(w http.ResponseWriter, r *http.Request) {
 //	@Failure		400			{object}	httpx.ErrorResponse	"Invalid request body or validation error"
 //	@Failure		401			{object}	httpx.ErrorResponse	"Unauthorized - missing or invalid authentication"
 //	@Failure		401			{object}	httpx.ErrorResponse	"Invalid or expired board join code"
-//	@Failure		409			{object}	httpx.ErrorResponse	"User is already a member of this board"
+//	@Failure		409			{object}	httpx.ErrorResponse	"User is already a member of this board — error.details contains board_id"
 //	@Failure		500			{object}	httpx.ErrorResponse	"Internal server error"
 //	@Security		BearerAuth
 //	@Router			/boards/join [post]
@@ -119,6 +120,14 @@ func (h *BoardHandler) JoinBoard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	boardID, err := h.boardMemberService.JoinBoard(r.Context(), body.JoinCode, user.ID)
+
+	if alreadyInBoardErr, ok := errors.AsType[domain.BoardMemberAlreadyInBoardError](err); ok {
+		httpx.RespondWithData(w, http.StatusOK, &dtos.JoinBoardResponseDto{
+			BoardID: alreadyInBoardErr.BoardID,
+		})
+		return
+	}
+
 	if err != nil {
 		handleServiceError(w, r, err, h.logger)
 		return

--- a/internal/handlers/board_handler_test.go
+++ b/internal/handlers/board_handler_test.go
@@ -357,6 +357,37 @@ func TestBoardHandler_JoinBoard(t *testing.T) {
 		}
 	})
 
+	t.Run("returns 200 with board id when user is already a member", func(t *testing.T) {
+		t.Parallel()
+
+		body := dtos.JoinBoardDto{
+			JoinCode: "ABCD1234",
+		}
+		expectedBoardID := int64(91)
+
+		bms := &mocks.MockBoardMemberService{
+			JoinBoardFunc: func(ctx context.Context, joinCode string, userID string) (int64, error) {
+				return expectedBoardID, domain.BoardMemberAlreadyInBoardError{BoardID: expectedBoardID}
+			},
+		}
+
+		h := newTestBoardHandler(nil, bms)
+
+		req := makeJoinBoardReq(t, body)
+		w := httptest.NewRecorder()
+
+		h.JoinBoard(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data dtos.JoinBoardResponseDto `json:"data"`
+		}
+
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, expectedBoardID, resp.Data.BoardID)
+	})
+
 	t.Run("propagates service error", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/repositories/board_member_repository.go
+++ b/internal/repositories/board_member_repository.go
@@ -39,21 +39,30 @@ func (r *BoardMemberRepository) CreateBoardMember(
 	defer tx.Rollback()
 
 	var boardID int64
+	var wasInserted bool
 	err = tx.QueryRowContext(ctx,
 		`WITH board AS (
 			SELECT id FROM boards WHERE join_code = $1
+		),
+		inserted AS (
+			INSERT INTO board_members (board_id, user_id, role)
+			SELECT id, $2, 'member' FROM board
+			ON CONFLICT (board_id, user_id) DO NOTHING
+			RETURNING board_id
 		)
-		INSERT INTO board_members (board_id, user_id, role)
-		SELECT id, $2, 'member' FROM board
-		WHERE EXISTS(SELECT 1 FROM board)
-		RETURNING board_id`,
+		SELECT board.id, EXISTS (SELECT 1 FROM inserted) AS inserted
+		FROM board`,
 		joinCode, userID,
-	).Scan(&boardID)
+	).Scan(&boardID, &wasInserted)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, domain.ErrBoardInvalidJoinCode
 		}
 		return 0, handleDBError(err, resourceBoardMember)
+	}
+
+	if !wasInserted {
+		return boardID, domain.BoardMemberAlreadyInBoardError{BoardID: boardID}
 	}
 
 	if err := r.initCompetitionScoresForMember(ctx, tx, boardID, userID); err != nil {

--- a/internal/services/board_member_service_test.go
+++ b/internal/services/board_member_service_test.go
@@ -68,6 +68,29 @@ func TestBoardMemberService_JoinBoard(t *testing.T) {
 		assert.Contains(t, err.Error(), "database error")
 		assert.Empty(t, boardID)
 	})
+
+	t.Run("propagates already-in-board typed error with board id", func(t *testing.T) {
+		t.Parallel()
+
+		joinCode := "ABCD1234"
+		userID := gofakeit.UUID()
+		expectedBoardID := gofakeit.Int64()
+
+		bmr := &mocks.MockBoardMemberRepository{
+			CreateBoardMemberFunc: func(ctx context.Context, jc string, uid string) (int64, error) {
+				return expectedBoardID, domain.BoardMemberAlreadyInBoardError{BoardID: expectedBoardID}
+			},
+		}
+
+		service := newTestBoardMemberService(nil, bmr)
+
+		boardID, err := service.JoinBoard(context.Background(), joinCode, userID)
+
+		var alreadyInBoardErr domain.BoardMemberAlreadyInBoardError
+		assert.ErrorAs(t, err, &alreadyInBoardErr)
+		assert.Equal(t, expectedBoardID, alreadyInBoardErr.BoardID)
+		assert.Equal(t, expectedBoardID, boardID)
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #108

## What changed

- `POST /boards/join` is now idempotent: returns `200 { board_id }` when the user is already a member instead of 409
- Replaced bare `INSERT INTO board_members` with `ON CONFLICT (board_id, user_id) DO NOTHING`, eliminating the Postgres `duplicate key` error log
- Added `BoardMemberAlreadyInBoardError` typed error to carry the `board_id` through the error path to the handler
- New join still returns `201`; client can distinguish "already member" vs "just joined" by status code

## How to test

- [ ] `POST /boards/join` with a valid code as a new user → `201 { data: { board_id } }`
- [ ] Same request again → `200 { data: { board_id } }` (same body, no Postgres error in `docker compose logs db`)
- [ ] `POST /boards/join` with a bogus code → `401 BOARD_INVALID_JOIN_CODE`