### PR TITLE
feat: add member pick'em and awards endpoints for boards

### DIFF
--- a/internal/app/routes_boards.go
+++ b/internal/app/routes_boards.go
@@ -34,6 +34,12 @@ func boardsRoutes(c *Container) chi.Router {
 					r.Patch("/role", c.BoardHandler.UpdateBoardMemberRole)
 					r.Delete("/", c.BoardHandler.RemoveBoardMember)
 					r.Post("/transfer-ownership", c.BoardHandler.TransferOwnership)
+
+					r.Group(func(r chi.Router) {
+						r.Use(middlewares.RequireTargetBoardMembership(c.BoardMemberService))
+						r.Get("/pickem", c.PickemHandler.GetMemberPickem)
+						r.Get("/awards", c.AwardHandler.GetMemberAwards)
+					})
 				})
 			})
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -112,6 +112,9 @@ var ErrCompetitionAwardsAlreadyExists = errors.New("an awards competition alread
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
 var ErrDuplicatePickForMatch = errors.New("a pick for this match already exists on this board")
 
+// Predictions visibility (member views)
+var ErrPredictionsHidden = errors.New("member predictions are hidden until the tournament starts")
+
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")
 var ErrMatchPickLocked = errors.New("match pick is locked: match has already started")

--- a/internal/handlers/award_handler.go
+++ b/internal/handlers/award_handler.go
@@ -69,6 +69,32 @@ func (h *AwardHandler) GetUserAwards(w http.ResponseWriter, r *http.Request) {
 	httpx.RespondWithData(w, http.StatusOK, awards)
 }
 
+// GetMemberAwards returns the award picks of a specific board member.
+//
+//	@Summary		Get a board member's award picks
+//	@Description	Returns the award picks of a specific board member. Only accessible after the tournament lockout has passed.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId	path		int64				true	"Board ID"
+//	@Param			userId	path		string				true	"Member user ID (UUID)"
+//	@Success		200		{object}	domain.UserAwards	"Member's award picks state"
+//	@Failure		401		{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Failure		403		{object}	httpx.ErrorResponse	"Predictions are hidden until the tournament starts"
+//	@Failure		404		{object}	httpx.ErrorResponse	"Board or member not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/members/{userId}/awards [get]
+func (h *AwardHandler) GetMemberAwards(w http.ResponseWriter, r *http.Request) {
+	targetUserID := httpctx.GetUserID(r.Context())
+
+	awards, err := h.awardService.GetMemberAwards(r.Context(), targetUserID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, awards)
+}
+
 // GetPopularPicks godoc
 //
 //	@Summary		Get popular award picks

--- a/internal/handlers/award_handler_test.go
+++ b/internal/handlers/award_handler_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestAwardHandler(as *mocks.MockAwardService) *AwardHandler {
+	return NewAwardHandler(as, &mocks.MockLogger{}, validator.NewValidator())
+}
+
+// ---------------------------------------------------------------------------
+// TestAwardHandler_GetMemberAwards
+// ---------------------------------------------------------------------------
+func TestAwardHandler_GetMemberAwards(t *testing.T) {
+	t.Parallel()
+
+	makeReq := func(t *testing.T, targetUserID string) *http.Request {
+		t.Helper()
+		return testutils.MakeJSONRequest(
+			t, http.MethodGet, "/boards/1/members/"+targetUserID+"/awards", nil,
+			testutils.WithUserID(targetUserID),
+		)
+	}
+
+	t.Run("returns 200 with member awards on success", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				assert.Equal(t, targetUserID, userID)
+				return &domain.UserAwards{IsLocked: true}, nil
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data domain.UserAwards `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.True(t, resp.Data.IsLocked)
+	})
+
+	t.Run("returns 403 when predictions are hidden", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				return nil, domain.ErrPredictionsHidden
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "PREDICTIONS_HIDDEN", resp.Error.Code)
+	})
+
+	t.Run("returns 404 when board member not found", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				return nil, domain.ErrBoardMemberNotFound
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "BOARD_MEMBER_NOT_FOUND", resp.Error.Code)
+	})
+}

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -50,6 +50,7 @@ const (
 	codeBoardIsGlobal             = "BOARD_IS_GLOBAL"
 	codeCompetitionForbidden      = "COMPETITION_FORBIDDEN"
 	codeBoardManageAdminForbidden = "BOARD_MANAGE_ADMIN_FORBIDDEN"
+	codePredictionsHidden         = "PREDICTIONS_HIDDEN"
 
 	// 400 Bad Request
 	codeInvalidWinnerTeam          = "INVALID_WINNER_TEAM"
@@ -168,6 +169,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.Forbidden(w, r, codeCompetitionForbidden, domain.ErrCompetitionForbidden.Error())
 	case errors.Is(err, domain.ErrBoardManageAdminForbidden):
 		httpx.Forbidden(w, r, codeBoardManageAdminForbidden, domain.ErrBoardManageAdminForbidden.Error())
+	case errors.Is(err, domain.ErrPredictionsHidden):
+		httpx.Forbidden(w, r, codePredictionsHidden, domain.ErrPredictionsHidden.Error())
 
 	// 400 Bad Request
 	case errors.Is(err, domain.ErrInvalidWinnerTeam):

--- a/internal/handlers/pickem_handler.go
+++ b/internal/handlers/pickem_handler.go
@@ -52,6 +52,32 @@ func (h *PickemHandler) GetUserPickem(w http.ResponseWriter, r *http.Request) {
 	httpx.RespondWithData(w, http.StatusOK, pickem)
 }
 
+// GetMemberPickem returns a board member's pickem state.
+//
+//	@Summary		Get a board member's pickem
+//	@Description	Returns the pick'em predictions of a specific board member. Only accessible after the tournament lockout has passed.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId	path		int64				true	"Board ID"
+//	@Param			userId	path		string				true	"Member user ID (UUID)"
+//	@Success		200		{object}	domain.UserPickem	"Member's pickem state"
+//	@Failure		401		{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Failure		403		{object}	httpx.ErrorResponse	"Predictions are hidden until the tournament starts"
+//	@Failure		404		{object}	httpx.ErrorResponse	"Board or member not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/members/{userId}/pickem [get]
+func (h *PickemHandler) GetMemberPickem(w http.ResponseWriter, r *http.Request) {
+	targetUserID := httpctx.GetUserID(r.Context())
+
+	pickem, err := h.pickemService.GetMemberPickem(r.Context(), targetUserID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, pickem)
+}
+
 // SaveGroupPicks saves (overwrites) the user's group order picks and syncs each group's
 // lock state from the per-group `locked` flag. Changing a group's order cascade-clears
 // best-thirds + bracket; toggling only a lock does not.

--- a/internal/handlers/pickem_handler_test.go
+++ b/internal/handlers/pickem_handler_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestPickemHandler(ps *mocks.MockPickemService) *PickemHandler {
+	return NewPickemHandler(ps, &mocks.MockLogger{}, validator.NewValidator())
+}
+
+// ---------------------------------------------------------------------------
+// TestPickemHandler_GetMemberPickem
+// ---------------------------------------------------------------------------
+func TestPickemHandler_GetMemberPickem(t *testing.T) {
+	t.Parallel()
+
+	makeReq := func(t *testing.T, targetUserID string) *http.Request {
+		t.Helper()
+		return testutils.MakeJSONRequest(
+			t, http.MethodGet, "/boards/1/members/"+targetUserID+"/pickem", nil,
+			testutils.WithUserID(targetUserID),
+		)
+	}
+
+	t.Run("returns 200 with member pickem on success", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				assert.Equal(t, targetUserID, userID)
+				return &domain.UserPickem{IsLocked: true}, nil
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data domain.UserPickem `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.True(t, resp.Data.IsLocked)
+	})
+
+	t.Run("returns 403 when predictions are hidden", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				return nil, domain.ErrPredictionsHidden
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "PREDICTIONS_HIDDEN", resp.Error.Code)
+	})
+
+	t.Run("returns 404 when board member not found", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				return nil, domain.ErrBoardMemberNotFound
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "BOARD_MEMBER_NOT_FOUND", resp.Error.Code)
+	})
+}

--- a/internal/middlewares/errors.go
+++ b/internal/middlewares/errors.go
@@ -17,7 +17,8 @@ const (
 	codeForbidden      = "FORBIDDEN"
 
 	// 404 Not Found
-	codeBoardNotFound = "BOARD_NOT_FOUND"
+	codeBoardNotFound        = "BOARD_NOT_FOUND"
+	codeBoardMemberNotFound  = "BOARD_MEMBER_NOT_FOUND"
 
 	// 400 Bad Request
 	codeReturnToRequired   = "RETURN_TO_REQUIRED"

--- a/internal/middlewares/require_target_board_membership.go
+++ b/internal/middlewares/require_target_board_membership.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/httpctx"
+	"github.com/fifawcp/api/internal/httpx"
+	"github.com/fifawcp/api/internal/services"
+)
+
+func RequireTargetBoardMembership(boardMemberService services.BoardMemberServiceInterface) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			boardID := httpctx.GetBoardID(r.Context())
+			targetUserID := httpctx.GetUserID(r.Context())
+
+			if boardID == 0 || targetUserID == "" {
+				httpx.InternalServerError(w, r, codeInternalServer, ErrInternalServer.Error())
+				return
+			}
+
+			_, err := boardMemberService.GetBoardMember(r.Context(), boardID, targetUserID)
+			if err != nil {
+				switch {
+				case errors.Is(err, domain.ErrBoardMemberNotFound):
+					httpx.NotFound(w, r, codeBoardMemberNotFound, domain.ErrBoardMemberNotFound.Error())
+				default:
+					httpx.InternalServerError(w, r, codeInternalServer, ErrInternalServer.Error())
+				}
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/services/award_service.go
+++ b/internal/services/award_service.go
@@ -15,6 +15,7 @@ const YoungPlayerMaxAge = 21
 
 type AwardServiceInterface interface {
 	GetUserAwards(ctx context.Context, userID string) (*domain.UserAwards, error)
+	GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error)
 	SaveAwardPicks(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
 	GetPopularPicks(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
 	RecordWinners(ctx context.Context, winners []*domain.AwardWinner) error
@@ -54,6 +55,14 @@ func (s *AwardService) GetUserAwards(ctx context.Context, userID string) (*domai
 	}
 
 	return s.buildUserAwards(ctx, picks)
+}
+
+func (s *AwardService) GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {
+	if !s.isLocked() {
+		return nil, domain.ErrPredictionsHidden
+	}
+
+	return s.GetUserAwards(ctx, userID)
 }
 
 func (s *AwardService) SaveAwardPicks(

--- a/internal/services/award_service_test.go
+++ b/internal/services/award_service_test.go
@@ -449,6 +449,37 @@ func TestAwardService_RecordWinners_SurfacesPersistenceFailureSynchronously(t *t
 	assert.ErrorIs(t, err, persistenceErr)
 }
 
+// ---------------------------------------------------------------------------
+// GetMemberAwards
+// ---------------------------------------------------------------------------
+func TestAwardService_GetMemberAwards_HiddenBeforeLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, futureLock())
+
+	result, err := service.GetMemberAwards(context.Background(), gofakeit.UUID())
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, domain.ErrPredictionsHidden)
+}
+
+func TestAwardService_GetMemberAwards_ReturnsAwardsAfterLock(t *testing.T) {
+	t.Parallel()
+
+	awardRepo := &mocks.MockAwardPickRepository{
+		GetAwardPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserAwardPick, error) {
+			return []*domain.UserAwardPick{}, nil
+		},
+	}
+	service := newTestAwardService(awardRepo, &mocks.MockPlayerRepository{}, nil, pastLock())
+
+	result, err := service.GetMemberAwards(context.Background(), gofakeit.UUID())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsLocked)
+}
+
 func assertSignaledWithin(t *testing.T, ch <-chan struct{}, timeout time.Duration, msg string) {
 	t.Helper()
 	select {

--- a/internal/services/pickem_service.go
+++ b/internal/services/pickem_service.go
@@ -16,6 +16,7 @@ var allKnockoutMatchIDs = []int64{73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
 
 type PickemServiceInterface interface {
 	GetUserPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
+	GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPick(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
@@ -95,6 +96,14 @@ func (s *PickemService) GetUserPickem(ctx context.Context, userID string) (*doma
 		},
 		IsLocked: s.isPickemLocked(),
 	}, nil
+}
+
+func (s *PickemService) GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error) {
+	if !s.isPickemLocked() {
+		return nil, domain.ErrPredictionsHidden
+	}
+
+	return s.GetUserPickem(ctx, userID)
 }
 
 func (s *PickemService) GetChampionPick(ctx context.Context, userID string) (*domain.Team, error) {

--- a/internal/services/pickem_service_test.go
+++ b/internal/services/pickem_service_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestPickemService(repo *mocks.MockPickemRepository, lockTime time.Time) PickemServiceInterface {
+	cfg := &config.Config{}
+	logger := &mocks.MockLogger{}
+	return NewPickemService(repo, nil, lockTime, cfg, logger)
+}
+
+// repoWithEmptyPicks returns a MockPickemRepository whose four parallel-fetch
+// methods all return empty slices — sufficient to let GetUserPickem succeed.
+func repoWithEmptyPicks() *mocks.MockPickemRepository {
+	return &mocks.MockPickemRepository{
+		GetGroupPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error) {
+			return nil, nil
+		},
+		GetBestThirdPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error) {
+			return nil, nil
+		},
+		GetBracketPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error) {
+			return nil, nil
+		},
+		GetLockedGroupCodesFunc: func(ctx context.Context, userID string) ([]string, error) {
+			return nil, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetMemberPickem
+// ---------------------------------------------------------------------------
+func TestPickemService_GetMemberPickem_HiddenBeforeLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestPickemService(&mocks.MockPickemRepository{}, time.Now().UTC().Add(24*time.Hour))
+
+	result, err := service.GetMemberPickem(context.Background(), gofakeit.UUID())
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, domain.ErrPredictionsHidden)
+}
+
+func TestPickemService_GetMemberPickem_ReturnsPickemAfterLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestPickemService(repoWithEmptyPicks(), time.Now().UTC().Add(-24*time.Hour))
+
+	result, err := service.GetMemberPickem(context.Background(), gofakeit.UUID())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsLocked)
+}

--- a/internal/test/mocks/award_service_mock.go
+++ b/internal/test/mocks/award_service_mock.go
@@ -8,6 +8,7 @@ import (
 
 type MockAwardService struct {
 	GetUserAwardsFunc   func(ctx context.Context, userID string) (*domain.UserAwards, error)
+	GetMemberAwardsFunc func(ctx context.Context, userID string) (*domain.UserAwards, error)
 	SaveAwardPicksFunc  func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
 	GetPopularPicksFunc func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
 	RecordWinnersFunc   func(ctx context.Context, winners []*domain.AwardWinner) error
@@ -18,6 +19,13 @@ func (m *MockAwardService) GetUserAwards(ctx context.Context, userID string) (*d
 		return m.GetUserAwardsFunc(ctx, userID)
 	}
 	panic("GetUserAwards called unexpectedly")
+}
+
+func (m *MockAwardService) GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {
+	if m.GetMemberAwardsFunc != nil {
+		return m.GetMemberAwardsFunc(ctx, userID)
+	}
+	panic("GetMemberAwards called unexpectedly")
 }
 
 func (m *MockAwardService) SaveAwardPicks(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error) {

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -1,0 +1,114 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockPickemRepository struct {
+	UpsertGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	GetGroupPicksFunc           func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
+	GetGroupPicksByGroupFunc    func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
+	UpsertBestThirdsFunc        func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
+	GetBestThirdPicksFunc       func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
+	GetBestThirdPicksByTeamsFunc func(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error)
+	UpsertBracketPicksFunc      func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
+	GetBracketPicksFunc         func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
+	GetBracketPicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
+	GetChampionPickFunc         func(ctx context.Context, userID string) (*string, error)
+	GetUserProgressCountsFunc   func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
+	GetLockedGroupCodesFunc     func(ctx context.Context, userID string) ([]string, error)
+	SetGroupLocksFunc           func(ctx context.Context, userID string, lockedCodes []string) error
+}
+
+func (m *MockPickemRepository) UpsertGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick) error {
+	if m.UpsertGroupPicksFunc != nil {
+		return m.UpsertGroupPicksFunc(ctx, userID, picks)
+	}
+	panic("UpsertGroupPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetGroupPicks(ctx context.Context, userID string) ([]*domain.UserGroupPick, error) {
+	if m.GetGroupPicksFunc != nil {
+		return m.GetGroupPicksFunc(ctx, userID)
+	}
+	panic("GetGroupPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetGroupPicksByGroup(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error) {
+	if m.GetGroupPicksByGroupFunc != nil {
+		return m.GetGroupPicksByGroupFunc(ctx, groupCode)
+	}
+	panic("GetGroupPicksByGroup called unexpectedly")
+}
+
+func (m *MockPickemRepository) UpsertBestThirds(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error {
+	if m.UpsertBestThirdsFunc != nil {
+		return m.UpsertBestThirdsFunc(ctx, userID, bestThirds)
+	}
+	panic("UpsertBestThirds called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBestThirdPicks(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error) {
+	if m.GetBestThirdPicksFunc != nil {
+		return m.GetBestThirdPicksFunc(ctx, userID)
+	}
+	panic("GetBestThirdPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBestThirdPicksByTeams(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error) {
+	if m.GetBestThirdPicksByTeamsFunc != nil {
+		return m.GetBestThirdPicksByTeamsFunc(ctx, teamFifaCodes)
+	}
+	panic("GetBestThirdPicksByTeams called unexpectedly")
+}
+
+func (m *MockPickemRepository) UpsertBracketPicks(ctx context.Context, userID string, picks []*domain.UserBracketPick) error {
+	if m.UpsertBracketPicksFunc != nil {
+		return m.UpsertBracketPicksFunc(ctx, userID, picks)
+	}
+	panic("UpsertBracketPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBracketPicks(ctx context.Context, userID string) ([]*domain.UserBracketPick, error) {
+	if m.GetBracketPicksFunc != nil {
+		return m.GetBracketPicksFunc(ctx, userID)
+	}
+	panic("GetBracketPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error) {
+	if m.GetBracketPicksByMatchFunc != nil {
+		return m.GetBracketPicksByMatchFunc(ctx, matchID)
+	}
+	panic("GetBracketPicksByMatch called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetChampionPick(ctx context.Context, userID string) (*string, error) {
+	if m.GetChampionPickFunc != nil {
+		return m.GetChampionPickFunc(ctx, userID)
+	}
+	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {
+	if m.GetUserProgressCountsFunc != nil {
+		return m.GetUserProgressCountsFunc(ctx, userID)
+	}
+	panic("GetUserProgressCounts called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error) {
+	if m.GetLockedGroupCodesFunc != nil {
+		return m.GetLockedGroupCodesFunc(ctx, userID)
+	}
+	panic("GetLockedGroupCodes called unexpectedly")
+}
+
+func (m *MockPickemRepository) SetGroupLocks(ctx context.Context, userID string, lockedCodes []string) error {
+	if m.SetGroupLocksFunc != nil {
+		return m.SetGroupLocksFunc(ctx, userID, lockedCodes)
+	}
+	panic("SetGroupLocks called unexpectedly")
+}

--- a/internal/test/mocks/pickem_service_mock.go
+++ b/internal/test/mocks/pickem_service_mock.go
@@ -8,6 +8,7 @@ import (
 
 type MockPickemService struct {
 	GetUserPickemFunc         func(ctx context.Context, userID string) (*domain.UserPickem, error)
+	GetMemberPickemFunc       func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPickFunc       func(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgressFunc func(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
@@ -20,6 +21,13 @@ func (m *MockPickemService) GetUserPickem(ctx context.Context, userID string) (*
 		return m.GetUserPickemFunc(ctx, userID)
 	}
 	panic("GetUserPickem called unexpectedly")
+}
+
+func (m *MockPickemService) GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error) {
+	if m.GetMemberPickemFunc != nil {
+		return m.GetMemberPickemFunc(ctx, userID)
+	}
+	panic("GetMemberPickem called unexpectedly")
 }
 
 func (m *MockPickemService) GetChampionPick(ctx context.Context, userID string) (*domain.Team, error) {


### PR DESCRIPTION
## Related issue

Closes #110

## What changed

- Add `GET /boards/{boardId}/members/{userId}/pickem` and `.../awards` — board members can view another member's full pick'em predictions and award picks after the tournament lockout
- Gate visibility with `GetMemberPickem`/`GetMemberAwards` on each service — returns `403 PREDICTIONS_HIDDEN` when `now < firstKickoff`
- Add `RequireTargetBoardMembership` middleware — validates the `{userId}` path param is actually a member of the board (404 otherwise), closing a UUID-guessing gap
- Picks are the same `domain.UserPickem` / `domain.UserAwards` payloads as the self-view endpoints; no new DTOs

## How to test

- [ ] Before tournament start: `GET /api/boards/{boardId}/members/{userId}/pickem` → `403 PREDICTIONS_HIDDEN`
- [ ] After lockout (set a past `kickoff_at` in dev DB, restart): same request → `200` with the member's picks
- [ ] Non-member `userId`: `GET /api/boards/{boardId}/members/{nonMemberId}/pickem` → `404 BOARD_MEMBER_NOT_FOUND`
- [ ] Repeat both tests for `.../awards`