### PR TITLE
feat: add dashboard title favorites and next-match pick

### DIFF
--- a/internal/domain/board.go
+++ b/internal/domain/board.go
@@ -22,9 +22,10 @@ type Board struct {
 }
 
 type UserBoardListItem struct {
-	ID      int64        `json:"id" example:"1"`
-	Name    string       `json:"name" example:"My Board"`
-	Privacy BoardPrivacy `json:"privacy" example:"private"`
+	ID      int64           `json:"id" example:"1"`
+	Name    string          `json:"name" example:"My Board"`
+	Privacy BoardPrivacy    `json:"privacy" example:"private"`
+	Role    BoardMemberRole `json:"role" example:"member"`
 }
 
 type BoardDetails struct {

--- a/internal/domain/dashboard.go
+++ b/internal/domain/dashboard.go
@@ -1,11 +1,19 @@
 package domain
 
 type Dashboard struct {
-	PickedChampion *Team                `json:"picked_champion"`
-	Stats          *DashboardStats      `json:"stats"`
-	NextMatch      *Match               `json:"next_match"`
-	Progress       *DashboardProgress   `json:"progress"`
-	Leaderboard    DashboardLeaderboard `json:"leaderboard"`
+	PickedChampion     *Team                `json:"picked_champion"`
+	Stats              *DashboardStats      `json:"stats"`
+	NextMatch          *Match               `json:"next_match"`
+	Progress           *DashboardProgress   `json:"progress"`
+	Leaderboard        DashboardLeaderboard `json:"leaderboard"`
+	TitleFavorites     []*TitleFavorite     `json:"title_favorites"`
+	NextMatchScorePick *UserMatchScorePick  `json:"-"`
+}
+
+type TitleFavorite struct {
+	Team        *Team `json:"team"`
+	PickCount   int   `json:"pick_count"`
+	PickPercent int   `json:"pick_percent"`
 }
 
 type DashboardStats struct {

--- a/internal/domain/pickem.go
+++ b/internal/domain/pickem.go
@@ -80,6 +80,9 @@ type PickemRepository interface {
 	GetBracketPicks(ctx context.Context, userID string) ([]*UserBracketPick, error)
 	GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*UserBracketPick, error) // for scoring
 	GetChampionPick(ctx context.Context, userID string) (*string, error)
+	// GetChampionPickCounts returns the most-picked champions (final-match winner
+	// picks) across all users, with counts + percent, ordered desc, capped at limit.
+	GetChampionPickCounts(ctx context.Context, limit int) ([]*TitleFavorite, error)
 	GetUserProgressCounts(ctx context.Context, userID string) (PickemProgressCounts, error)
 	GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error)
 	// SetGroupLocks replaces the user's set of locked groups with exactly lockedCodes

--- a/internal/dtos/match_dto.go
+++ b/internal/dtos/match_dto.go
@@ -16,3 +16,37 @@ type SaveMatchScorePickDto struct {
 	HomeScore *int `json:"home_score" validate:"required,gte=0,lte=20" example:"2"`
 	AwayScore *int `json:"away_score" validate:"required,gte=0,lte=20" example:"1"`
 }
+
+// DashboardResponseDto mirrors domain.Dashboard but serializes next_match through
+// MatchResponseDto so it carries the authenticated user's score pick.
+type DashboardResponseDto struct {
+	PickedChampion *domain.Team                `json:"picked_champion"`
+	Stats          *domain.DashboardStats      `json:"stats"`
+	NextMatch      *MatchResponseDto           `json:"next_match"`
+	Progress       *domain.DashboardProgress   `json:"progress"`
+	Leaderboard    domain.DashboardLeaderboard `json:"leaderboard"`
+	TitleFavorites []*domain.TitleFavorite     `json:"title_favorites"`
+}
+
+func NewDashboardResponse(d *domain.Dashboard) *DashboardResponseDto {
+	if d == nil {
+		return nil
+	}
+
+	var nextMatch *MatchResponseDto
+	if d.NextMatch != nil {
+		nextMatch = &MatchResponseDto{Match: d.NextMatch}
+		if pick := d.NextMatchScorePick; pick != nil {
+			nextMatch.UserScorePick = &UserScorePickDto{HomeScore: pick.HomeScore, AwayScore: pick.AwayScore}
+		}
+	}
+
+	return &DashboardResponseDto{
+		PickedChampion: d.PickedChampion,
+		Stats:          d.Stats,
+		NextMatch:      nextMatch,
+		Progress:       d.Progress,
+		Leaderboard:    d.Leaderboard,
+		TitleFavorites: d.TitleFavorites,
+	}
+}

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/httpctx"
 	"github.com/fifawcp/api/internal/httpx"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
@@ -33,8 +34,8 @@ func NewDashboardHandler(
 //	@Description	Guest callers receive `null` for `picked_champion`, `stats`, and `progress`.
 //	@Tags			dashboard
 //	@Produce		json
-//	@Success		200	{object}	httpx.Response{data=domain.Dashboard}	"Dashboard"
-//	@Failure		500	{object}	httpx.ErrorResponse						"Internal server error"
+//	@Success		200	{object}	httpx.Response{data=dtos.DashboardResponseDto}	"Dashboard"
+//	@Failure		500	{object}	httpx.ErrorResponse								"Internal server error"
 //	@Router			/dashboard [get]
 func (h *DashboardHandler) GetDashboard(w http.ResponseWriter, r *http.Request) {
 	user := httpctx.GetAuthenticatedUser(r.Context())
@@ -50,5 +51,5 @@ func (h *DashboardHandler) GetDashboard(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	httpx.RespondWithData(w, http.StatusOK, dashboard)
+	httpx.RespondWithData(w, http.StatusOK, dtos.NewDashboardResponse(dashboard))
 }

--- a/internal/repositories/board_repository.go
+++ b/internal/repositories/board_repository.go
@@ -63,7 +63,7 @@ func (r *BoardRepository) GetUserBoards(ctx context.Context, userID string) ([]*
 	defer cancel()
 
 	query := `
-		SELECT b.id, b.name, b.privacy
+		SELECT b.id, b.name, b.privacy, bm.role
 		FROM boards b
 		INNER JOIN board_members bm ON bm.board_id = b.id
 		WHERE bm.user_id = $1
@@ -79,7 +79,7 @@ func (r *BoardRepository) GetUserBoards(ctx context.Context, userID string) ([]*
 	boards := []*domain.UserBoardListItem{}
 	for rows.Next() {
 		var board domain.UserBoardListItem
-		if err := rows.Scan(&board.ID, &board.Name, &board.Privacy); err != nil {
+		if err := rows.Scan(&board.ID, &board.Name, &board.Privacy, &board.Role); err != nil {
 			return nil, handleDBError(err, resourceBoard)
 		}
 

--- a/internal/repositories/pickem_repository.go
+++ b/internal/repositories/pickem_repository.go
@@ -343,6 +343,56 @@ func (r *PickemRepository) GetChampionPick(ctx context.Context, userID string) (
 	return &fifaCode, nil
 }
 
+func (r *PickemRepository) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	// Count final-match winner picks per team and express each as a share of all
+	// users who picked a final winner. Aggregate by fifa_code FIRST (a varchar —
+	// groupable), then join team_localized; grouping by the team's json
+	// name_translations directly errors ("no equality operator for type json").
+	query := `
+		WITH final_picks AS (
+			SELECT team_fifa_code
+			FROM user_bracket_picks
+			WHERE match_id = (SELECT id FROM matches WHERE stage_code = 'final')
+		),
+		total AS (SELECT COUNT(*) AS n FROM final_picks),
+		counts AS (
+			SELECT team_fifa_code, COUNT(*)::int AS pick_count
+			FROM final_picks
+			GROUP BY team_fifa_code
+		)
+		SELECT t.fifa_code, t.name_translations, t.flag_url, t.group_code,
+			c.pick_count,
+			(CASE WHEN (SELECT n FROM total) > 0
+				THEN ROUND(100.0 * c.pick_count / (SELECT n FROM total))
+				ELSE 0 END)::int AS pick_percent
+		FROM counts c
+		INNER JOIN team_localized t ON t.fifa_code = c.team_fifa_code
+		ORDER BY c.pick_count DESC, t.fifa_code
+		LIMIT $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, handleDBError(err, resourcePickem)
+	}
+	defer rows.Close()
+
+	favorites := []*domain.TitleFavorite{}
+	for rows.Next() {
+		var team domain.Team
+		fav := &domain.TitleFavorite{Team: &team}
+		if err := rows.Scan(&team.FifaCode, &team.Name, &team.FlagURL, &team.GroupCode, &fav.PickCount, &fav.PickPercent); err != nil {
+			return nil, handleDBError(err, resourcePickem)
+		}
+		favorites = append(favorites, fav)
+	}
+
+	return favorites, rows.Err()
+}
+
 func (r *PickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()

--- a/internal/services/dashboard_service.go
+++ b/internal/services/dashboard_service.go
@@ -44,15 +44,16 @@ func NewDashboardService(
 func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*domain.Dashboard, error) {
 	var (
 		// public — always fetched
-		nextMatch  *domain.Match
-		pickemPage *domain.CompetitionLeaderboardPage
-		matchPage  *domain.CompetitionLeaderboardPage
+		nextMatch      *domain.Match
+		pickemPage     *domain.CompetitionLeaderboardPage
+		matchPage      *domain.CompetitionLeaderboardPage
+		titleFavorites []*domain.TitleFavorite
 
 		// per-user — fetched only when authenticated
 		champion       *domain.Team
 		pickemStats    domain.CompetitionUserStats
 		matchStats     domain.CompetitionUserStats
-		matchPicksMade int
+		userMatchPicks []*domain.UserMatchScorePick
 		pickemProgress *domain.PickemProgress
 		userAwards     *domain.UserAwards
 	)
@@ -65,12 +66,19 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 		return
 	})
 	eg.Go(func() (err error) {
-		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 5, "", "", "")
+		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 10, "", "", "")
 		return
 	})
 	eg.Go(func() (err error) {
-		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 5, "", "", "")
+		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 10, "", "", "")
 		return
+	})
+	eg.Go(func() error {
+		// Decorative data — never fail the whole dashboard over it.
+		if favs, err := s.pickemService.GetChampionPickCounts(egCtx, 5); err == nil {
+			titleFavorites = favs
+		}
+		return nil
 	})
 
 	// per-user data: only fan out for authenticated callers
@@ -88,7 +96,9 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 			return
 		})
 		eg.Go(func() (err error) {
-			matchPicksMade, err = s.matchScorePickRepository.CountMatchScorePicksByUser(egCtx, userID)
+			// Fetches the user's picks once: powers both the match-picks count and
+			// the score pick attached to next_match below.
+			userMatchPicks, err = s.matchScorePickRepository.GetMatchScorePicksByUser(egCtx, userID)
 			return
 		})
 		eg.Go(func() (err error) {
@@ -106,7 +116,8 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 	}
 
 	dashboard := &domain.Dashboard{
-		NextMatch: nextMatch,
+		NextMatch:      nextMatch,
+		TitleFavorites: titleFavorites,
 		Leaderboard: domain.DashboardLeaderboard{
 			Pickem: domain.CompetitionTop{
 				CompetitionID:   s.globalPickemCompetition.ID,
@@ -130,9 +141,19 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 			Match:  matchStats,
 		}
 		dashboard.Progress = &domain.DashboardProgress{
-			MatchPicks: stepProgress(matchPicksMade, 104),
+			MatchPicks: stepProgress(len(userMatchPicks), 104),
 			Pickem:     *pickemProgress,
 			Awards:     userAwards.Progress,
+		}
+		// Attach the user's pick for the featured next match (if any) so the
+		// dashboard's "up next" card reflects it.
+		if nextMatch != nil {
+			for _, pick := range userMatchPicks {
+				if pick.MatchID == nextMatch.ID {
+					dashboard.NextMatchScorePick = pick
+					break
+				}
+			}
 		}
 	}
 

--- a/internal/services/dashboard_service_test.go
+++ b/internal/services/dashboard_service_test.go
@@ -57,6 +57,12 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			GetChampionPickFunc: func(ctx context.Context, userID string) (*domain.Team, error) {
 				return argentina, nil
 			},
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{
+					{Team: &domain.Team{FifaCode: "BRA"}, PickCount: 40, PickPercent: 40},
+					{Team: &domain.Team{FifaCode: "ARG"}, PickCount: 30, PickPercent: 30},
+				}, nil
+			},
 			GetUserPickemProgressFunc: func(ctx context.Context, userID string) (*domain.PickemProgress, error) {
 				return &domain.PickemProgress{
 					Groups:     domain.StepProgress{Completed: 12, Total: 12},
@@ -75,7 +81,7 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			},
 			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 				assert.Equal(t, 1, page)
-				assert.Equal(t, 5, limit)
+				assert.Equal(t, 10, limit)
 				if competitionID == 11 {
 					return &domain.CompetitionLeaderboardPage{
 						Members: []*domain.CompetitionLeaderboardEntry{
@@ -107,8 +113,14 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		}
 
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{
-			CountMatchScorePicksByUserFunc: func(ctx context.Context, userID string) (int, error) {
-				return 12, nil
+			GetMatchScorePicksByUserFunc: func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error) {
+				picks := make([]*domain.UserMatchScorePick, 0, 12)
+				// One of the picks is for the featured next match (id 1).
+				picks = append(picks, &domain.UserMatchScorePick{UserID: userID, MatchID: 1, HomeScore: 2, AwayScore: 1})
+				for i := 0; i < 11; i++ {
+					picks = append(picks, &domain.UserMatchScorePick{UserID: userID, MatchID: int64(100 + i), HomeScore: 1, AwayScore: 0})
+				}
+				return picks, nil
 			},
 		}
 
@@ -140,6 +152,12 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		assert.Equal(t, kickoffTime, dashboard.NextMatch.KickoffAt)
 		assert.Equal(t, 12, dashboard.Progress.MatchPicks.Completed)
 		assert.Equal(t, 104, dashboard.Progress.MatchPicks.Total)
+		assert.NotNil(t, dashboard.NextMatchScorePick)
+		assert.Equal(t, 2, dashboard.NextMatchScorePick.HomeScore)
+		assert.Equal(t, 1, dashboard.NextMatchScorePick.AwayScore)
+		assert.Len(t, dashboard.TitleFavorites, 2)
+		assert.Equal(t, "BRA", dashboard.TitleFavorites[0].Team.FifaCode)
+		assert.Equal(t, 40, dashboard.TitleFavorites[0].PickPercent)
 		assert.True(t, dashboard.Progress.Pickem.Groups.IsComplete())
 		assert.True(t, dashboard.Progress.Pickem.BestThirds.IsComplete())
 		assert.True(t, dashboard.Progress.Pickem.Bracket.IsComplete())
@@ -160,6 +178,9 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		pickemSvc := &mocks.MockPickemService{
 			GetChampionPickFunc: func(ctx context.Context, userID string) (*domain.Team, error) {
 				return nil, nil
+			},
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{}, nil
 			},
 			GetUserPickemProgressFunc: func(ctx context.Context, userID string) (*domain.PickemProgress, error) {
 				return &domain.PickemProgress{
@@ -189,8 +210,8 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		}
 
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{
-			CountMatchScorePicksByUserFunc: func(ctx context.Context, userID string) (int, error) {
-				return 0, nil
+			GetMatchScorePicksByUserFunc: func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error) {
+				return []*domain.UserMatchScorePick{}, nil
 			},
 		}
 
@@ -229,8 +250,13 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		t.Parallel()
 
 		// Per-user mock funcs are left unset — they panic if called, proving the
-		// service does not fan out user-specific queries for guests.
-		pickemSvc := &mocks.MockPickemService{}
+		// service does not fan out user-specific queries for guests. Champion-pick
+		// counts are public, so that one is provided.
+		pickemSvc := &mocks.MockPickemService{
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{{Team: &domain.Team{FifaCode: "BRA"}, PickCount: 10, PickPercent: 100}}, nil
+			},
+		}
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{}
 		awardSvc := &mocks.MockAwardService{}
 

--- a/internal/services/pickem_service.go
+++ b/internal/services/pickem_service.go
@@ -18,6 +18,7 @@ type PickemServiceInterface interface {
 	GetUserPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPick(ctx context.Context, userID string) (*domain.Team, error)
+	GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
 	SaveBestThirds(ctx context.Context, userID string, teamFifaCodes []string) error
@@ -113,6 +114,10 @@ func (s *PickemService) GetChampionPick(ctx context.Context, userID string) (*do
 	}
 
 	return s.teamLookup[*fifaCode], nil
+}
+
+func (s *PickemService) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	return s.pickemRepo.GetChampionPickCounts(ctx, limit)
 }
 
 func (s *PickemService) GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error) {

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -17,6 +17,7 @@ type MockPickemRepository struct {
 	GetBracketPicksFunc         func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
 	GetBracketPicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
 	GetChampionPickFunc         func(ctx context.Context, userID string) (*string, error)
+	GetChampionPickCountsFunc   func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserProgressCountsFunc   func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
 	GetLockedGroupCodesFunc     func(ctx context.Context, userID string) ([]string, error)
 	SetGroupLocksFunc           func(ctx context.Context, userID string, lockedCodes []string) error
@@ -90,6 +91,13 @@ func (m *MockPickemRepository) GetChampionPick(ctx context.Context, userID strin
 		return m.GetChampionPickFunc(ctx, userID)
 	}
 	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	if m.GetChampionPickCountsFunc != nil {
+		return m.GetChampionPickCountsFunc(ctx, limit)
+	}
+	panic("GetChampionPickCounts called unexpectedly")
 }
 
 func (m *MockPickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {

--- a/internal/test/mocks/pickem_service_mock.go
+++ b/internal/test/mocks/pickem_service_mock.go
@@ -10,6 +10,7 @@ type MockPickemService struct {
 	GetUserPickemFunc         func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetMemberPickemFunc       func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPickFunc       func(ctx context.Context, userID string) (*domain.Team, error)
+	GetChampionPickCountsFunc func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserPickemProgressFunc func(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
 	SaveBestThirdsFunc        func(ctx context.Context, userID string, teamFifaCodes []string) error
@@ -35,6 +36,13 @@ func (m *MockPickemService) GetChampionPick(ctx context.Context, userID string) 
 		return m.GetChampionPickFunc(ctx, userID)
 	}
 	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemService) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	if m.GetChampionPickCountsFunc != nil {
+		return m.GetChampionPickCountsFunc(ctx, limit)
+	}
+	panic("GetChampionPickCounts called unexpectedly")
 }
 
 func (m *MockPickemService) GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error) {


### PR DESCRIPTION
## Related issue

Closes #113

## What changed

- Add `title_favorites` to the dashboard — most-picked champions aggregated from final-match bracket picks
- Attach `user_score_pick` to `next_match` so the client can render the user's existing prediction
- Return member `role` on the boards list
- Fix the champion-pick query: aggregate by team code before joining `team_localized` (avoids GROUP BY on a json column)
- Champion-picks fetch is non-fatal — a failure leaves it empty instead of 500-ing the dashboard

## How to test

- [ ] `go build ./... && go vet ./... && go test ./internal/...` all pass
- [ ] `GET /api/dashboard` (authed) returns `title_favorites` with team / pick_count / pick_percent
- [ ] `next_match.user_score_pick` is populated when the user has a pick for that match
- [ ] Boards list response includes `role` per board