### PR TITLE
chore: release v1.3.0

### DIFF
--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -46,6 +46,7 @@ type Container struct {
 	mailer               mailer.Mailer
 	Authenticator        auth.Authenticator
 	Scheduler            scheduler.Scheduler
+	syncMatchResultsJob  *jobs.SyncMatchResultsJob
 	GoogleOauthConfig    domain.OAuth2Client
 	OIDCIdentityVerifier domain.IDTokenVerifier
 
@@ -335,8 +336,13 @@ func (c *Container) initJobs() {
 		)
 	}
 
+	if !c.Config.Cron.SyncMatchResultsEnabled {
+		c.Logger.Info("sync:match_results disabled via config")
+		return
+	}
+
 	footballClient := football.NewFootballClient(c.Config.FootballAPI)
-	syncMatchResultsJob := jobs.NewSyncMatchResultsJob(
+	c.syncMatchResultsJob = jobs.NewSyncMatchResultsJob(
 		c.matchService,
 		footballClient,
 		c.matchFairPlayRepository,
@@ -346,10 +352,10 @@ func (c *Container) initJobs() {
 
 	// Run once at startup to register timers for upcoming matches and backfill any
 	// matches whose sync window has already passed (e.g. after a server restart)
-	go syncMatchResultsJob.Run(context.Background())
+	go c.syncMatchResultsJob.Run(context.Background())
 
 	// Re-run at midnight to pick up newly-assigned knockout teams and re-register timers
-	if err := c.Scheduler.RegisterJob(c.Config.Cron.SyncMatchResultsSchedule, syncMatchResultsJob); err != nil {
+	if err := c.Scheduler.RegisterJob(c.Config.Cron.SyncMatchResultsSchedule, c.syncMatchResultsJob); err != nil {
 		c.Logger.Error(
 			"failed to register job",
 			"job", "sync:match_results",
@@ -391,7 +397,7 @@ func (c *Container) StartServer(r *chi.Mux) error {
 
 	select {
 	case err := <-serverErrors:
-		c.Scheduler.Stop()
+		c.stopJobs()
 		return fmt.Errorf("server error: %w", err)
 	case sig := <-quit:
 		c.Logger.Info("Shutting down server", "signal", sig)
@@ -399,11 +405,19 @@ func (c *Container) StartServer(r *chi.Mux) error {
 	}
 }
 
+// stopJobs halts the cron scheduler and cancels any pending match-sync timers.
+func (c *Container) stopJobs() {
+	c.Scheduler.Stop()
+	if c.syncMatchResultsJob != nil {
+		c.syncMatchResultsJob.Stop()
+	}
+}
+
 func (c *Container) ShutdownServer(server *http.Server) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Config.Server.ShutdownTimeout)
 	defer cancel()
 
-	c.Scheduler.Stop()
+	c.stopJobs()
 
 	if err := server.Shutdown(ctx); err != nil {
 		server.Close()

--- a/internal/app/routes_boards.go
+++ b/internal/app/routes_boards.go
@@ -34,6 +34,12 @@ func boardsRoutes(c *Container) chi.Router {
 					r.Patch("/role", c.BoardHandler.UpdateBoardMemberRole)
 					r.Delete("/", c.BoardHandler.RemoveBoardMember)
 					r.Post("/transfer-ownership", c.BoardHandler.TransferOwnership)
+
+					r.Group(func(r chi.Router) {
+						r.Use(middlewares.RequireTargetBoardMembership(c.BoardMemberService))
+						r.Get("/pickem", c.PickemHandler.GetMemberPickem)
+						r.Get("/awards", c.AwardHandler.GetMemberAwards)
+					})
 				})
 			})
 

--- a/internal/domain/board.go
+++ b/internal/domain/board.go
@@ -22,9 +22,10 @@ type Board struct {
 }
 
 type UserBoardListItem struct {
-	ID      int64        `json:"id" example:"1"`
-	Name    string       `json:"name" example:"My Board"`
-	Privacy BoardPrivacy `json:"privacy" example:"private"`
+	ID      int64           `json:"id" example:"1"`
+	Name    string          `json:"name" example:"My Board"`
+	Privacy BoardPrivacy    `json:"privacy" example:"private"`
+	Role    BoardMemberRole `json:"role" example:"member"`
 }
 
 type BoardDetails struct {

--- a/internal/domain/dashboard.go
+++ b/internal/domain/dashboard.go
@@ -1,11 +1,19 @@
 package domain
 
 type Dashboard struct {
-	PickedChampion *Team                `json:"picked_champion"`
-	Stats          *DashboardStats      `json:"stats"`
-	NextMatch      *Match               `json:"next_match"`
-	Progress       *DashboardProgress   `json:"progress"`
-	Leaderboard    DashboardLeaderboard `json:"leaderboard"`
+	PickedChampion     *Team                `json:"picked_champion"`
+	Stats              *DashboardStats      `json:"stats"`
+	NextMatch          *Match               `json:"next_match"`
+	Progress           *DashboardProgress   `json:"progress"`
+	Leaderboard        DashboardLeaderboard `json:"leaderboard"`
+	TitleFavorites     []*TitleFavorite     `json:"title_favorites"`
+	NextMatchScorePick *UserMatchScorePick  `json:"-"`
+}
+
+type TitleFavorite struct {
+	Team        *Team `json:"team"`
+	PickCount   int   `json:"pick_count"`
+	PickPercent int   `json:"pick_percent"`
 }
 
 type DashboardStats struct {

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -112,6 +112,9 @@ var ErrCompetitionAwardsAlreadyExists = errors.New("an awards competition alread
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
 var ErrDuplicatePickForMatch = errors.New("a pick for this match already exists on this board")
 
+// Predictions visibility (member views)
+var ErrPredictionsHidden = errors.New("member predictions are hidden until the tournament starts")
+
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")
 var ErrMatchPickLocked = errors.New("match pick is locked: match has already started")

--- a/internal/domain/pickem.go
+++ b/internal/domain/pickem.go
@@ -80,6 +80,9 @@ type PickemRepository interface {
 	GetBracketPicks(ctx context.Context, userID string) ([]*UserBracketPick, error)
 	GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*UserBracketPick, error) // for scoring
 	GetChampionPick(ctx context.Context, userID string) (*string, error)
+	// GetChampionPickCounts returns the most-picked champions (final-match winner
+	// picks) across all users, with counts + percent, ordered desc, capped at limit.
+	GetChampionPickCounts(ctx context.Context, limit int) ([]*TitleFavorite, error)
 	GetUserProgressCounts(ctx context.Context, userID string) (PickemProgressCounts, error)
 	GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error)
 	// SetGroupLocks replaces the user's set of locked groups with exactly lockedCodes

--- a/internal/dtos/match_dto.go
+++ b/internal/dtos/match_dto.go
@@ -16,3 +16,37 @@ type SaveMatchScorePickDto struct {
 	HomeScore *int `json:"home_score" validate:"required,gte=0,lte=20" example:"2"`
 	AwayScore *int `json:"away_score" validate:"required,gte=0,lte=20" example:"1"`
 }
+
+// DashboardResponseDto mirrors domain.Dashboard but serializes next_match through
+// MatchResponseDto so it carries the authenticated user's score pick.
+type DashboardResponseDto struct {
+	PickedChampion *domain.Team                `json:"picked_champion"`
+	Stats          *domain.DashboardStats      `json:"stats"`
+	NextMatch      *MatchResponseDto           `json:"next_match"`
+	Progress       *domain.DashboardProgress   `json:"progress"`
+	Leaderboard    domain.DashboardLeaderboard `json:"leaderboard"`
+	TitleFavorites []*domain.TitleFavorite     `json:"title_favorites"`
+}
+
+func NewDashboardResponse(d *domain.Dashboard) *DashboardResponseDto {
+	if d == nil {
+		return nil
+	}
+
+	var nextMatch *MatchResponseDto
+	if d.NextMatch != nil {
+		nextMatch = &MatchResponseDto{Match: d.NextMatch}
+		if pick := d.NextMatchScorePick; pick != nil {
+			nextMatch.UserScorePick = &UserScorePickDto{HomeScore: pick.HomeScore, AwayScore: pick.AwayScore}
+		}
+	}
+
+	return &DashboardResponseDto{
+		PickedChampion: d.PickedChampion,
+		Stats:          d.Stats,
+		NextMatch:      nextMatch,
+		Progress:       d.Progress,
+		Leaderboard:    d.Leaderboard,
+		TitleFavorites: d.TitleFavorites,
+	}
+}

--- a/internal/handlers/award_handler.go
+++ b/internal/handlers/award_handler.go
@@ -69,6 +69,32 @@ func (h *AwardHandler) GetUserAwards(w http.ResponseWriter, r *http.Request) {
 	httpx.RespondWithData(w, http.StatusOK, awards)
 }
 
+// GetMemberAwards returns the award picks of a specific board member.
+//
+//	@Summary		Get a board member's award picks
+//	@Description	Returns the award picks of a specific board member. Only accessible after the tournament lockout has passed.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId	path		int64				true	"Board ID"
+//	@Param			userId	path		string				true	"Member user ID (UUID)"
+//	@Success		200		{object}	domain.UserAwards	"Member's award picks state"
+//	@Failure		401		{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Failure		403		{object}	httpx.ErrorResponse	"Predictions are hidden until the tournament starts"
+//	@Failure		404		{object}	httpx.ErrorResponse	"Board or member not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/members/{userId}/awards [get]
+func (h *AwardHandler) GetMemberAwards(w http.ResponseWriter, r *http.Request) {
+	targetUserID := httpctx.GetUserID(r.Context())
+
+	awards, err := h.awardService.GetMemberAwards(r.Context(), targetUserID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, awards)
+}
+
 // GetPopularPicks godoc
 //
 //	@Summary		Get popular award picks

--- a/internal/handlers/award_handler_test.go
+++ b/internal/handlers/award_handler_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestAwardHandler(as *mocks.MockAwardService) *AwardHandler {
+	return NewAwardHandler(as, &mocks.MockLogger{}, validator.NewValidator())
+}
+
+// ---------------------------------------------------------------------------
+// TestAwardHandler_GetMemberAwards
+// ---------------------------------------------------------------------------
+func TestAwardHandler_GetMemberAwards(t *testing.T) {
+	t.Parallel()
+
+	makeReq := func(t *testing.T, targetUserID string) *http.Request {
+		t.Helper()
+		return testutils.MakeJSONRequest(
+			t, http.MethodGet, "/boards/1/members/"+targetUserID+"/awards", nil,
+			testutils.WithUserID(targetUserID),
+		)
+	}
+
+	t.Run("returns 200 with member awards on success", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				assert.Equal(t, targetUserID, userID)
+				return &domain.UserAwards{IsLocked: true}, nil
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data domain.UserAwards `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.True(t, resp.Data.IsLocked)
+	})
+
+	t.Run("returns 403 when predictions are hidden", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				return nil, domain.ErrPredictionsHidden
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "PREDICTIONS_HIDDEN", resp.Error.Code)
+	})
+
+	t.Run("returns 404 when board member not found", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		as := &mocks.MockAwardService{
+			GetMemberAwardsFunc: func(ctx context.Context, userID string) (*domain.UserAwards, error) {
+				return nil, domain.ErrBoardMemberNotFound
+			},
+		}
+
+		h := newTestAwardHandler(as)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberAwards(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "BOARD_MEMBER_NOT_FOUND", resp.Error.Code)
+	})
+}

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/fifawcp/api/internal/dtos"
 	"github.com/fifawcp/api/internal/httpctx"
 	"github.com/fifawcp/api/internal/httpx"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
@@ -33,8 +34,8 @@ func NewDashboardHandler(
 //	@Description	Guest callers receive `null` for `picked_champion`, `stats`, and `progress`.
 //	@Tags			dashboard
 //	@Produce		json
-//	@Success		200	{object}	httpx.Response{data=domain.Dashboard}	"Dashboard"
-//	@Failure		500	{object}	httpx.ErrorResponse						"Internal server error"
+//	@Success		200	{object}	httpx.Response{data=dtos.DashboardResponseDto}	"Dashboard"
+//	@Failure		500	{object}	httpx.ErrorResponse								"Internal server error"
 //	@Router			/dashboard [get]
 func (h *DashboardHandler) GetDashboard(w http.ResponseWriter, r *http.Request) {
 	user := httpctx.GetAuthenticatedUser(r.Context())
@@ -50,5 +51,5 @@ func (h *DashboardHandler) GetDashboard(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	httpx.RespondWithData(w, http.StatusOK, dashboard)
+	httpx.RespondWithData(w, http.StatusOK, dtos.NewDashboardResponse(dashboard))
 }

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -50,6 +50,7 @@ const (
 	codeBoardIsGlobal             = "BOARD_IS_GLOBAL"
 	codeCompetitionForbidden      = "COMPETITION_FORBIDDEN"
 	codeBoardManageAdminForbidden = "BOARD_MANAGE_ADMIN_FORBIDDEN"
+	codePredictionsHidden         = "PREDICTIONS_HIDDEN"
 
 	// 400 Bad Request
 	codeInvalidWinnerTeam          = "INVALID_WINNER_TEAM"
@@ -168,6 +169,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.Forbidden(w, r, codeCompetitionForbidden, domain.ErrCompetitionForbidden.Error())
 	case errors.Is(err, domain.ErrBoardManageAdminForbidden):
 		httpx.Forbidden(w, r, codeBoardManageAdminForbidden, domain.ErrBoardManageAdminForbidden.Error())
+	case errors.Is(err, domain.ErrPredictionsHidden):
+		httpx.Forbidden(w, r, codePredictionsHidden, domain.ErrPredictionsHidden.Error())
 
 	// 400 Bad Request
 	case errors.Is(err, domain.ErrInvalidWinnerTeam):

--- a/internal/handlers/pickem_handler.go
+++ b/internal/handlers/pickem_handler.go
@@ -52,6 +52,32 @@ func (h *PickemHandler) GetUserPickem(w http.ResponseWriter, r *http.Request) {
 	httpx.RespondWithData(w, http.StatusOK, pickem)
 }
 
+// GetMemberPickem returns a board member's pickem state.
+//
+//	@Summary		Get a board member's pickem
+//	@Description	Returns the pick'em predictions of a specific board member. Only accessible after the tournament lockout has passed.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId	path		int64				true	"Board ID"
+//	@Param			userId	path		string				true	"Member user ID (UUID)"
+//	@Success		200		{object}	domain.UserPickem	"Member's pickem state"
+//	@Failure		401		{object}	httpx.ErrorResponse	"Missing or invalid Bearer token"
+//	@Failure		403		{object}	httpx.ErrorResponse	"Predictions are hidden until the tournament starts"
+//	@Failure		404		{object}	httpx.ErrorResponse	"Board or member not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/members/{userId}/pickem [get]
+func (h *PickemHandler) GetMemberPickem(w http.ResponseWriter, r *http.Request) {
+	targetUserID := httpctx.GetUserID(r.Context())
+
+	pickem, err := h.pickemService.GetMemberPickem(r.Context(), targetUserID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, pickem)
+}
+
 // SaveGroupPicks saves (overwrites) the user's group order picks and syncs each group's
 // lock state from the per-group `locked` flag. Changing a group's order cascade-clears
 // best-thirds + bracket; toggling only a lock does not.

--- a/internal/handlers/pickem_handler_test.go
+++ b/internal/handlers/pickem_handler_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/validator"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/fifawcp/api/internal/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestPickemHandler(ps *mocks.MockPickemService) *PickemHandler {
+	return NewPickemHandler(ps, &mocks.MockLogger{}, validator.NewValidator())
+}
+
+// ---------------------------------------------------------------------------
+// TestPickemHandler_GetMemberPickem
+// ---------------------------------------------------------------------------
+func TestPickemHandler_GetMemberPickem(t *testing.T) {
+	t.Parallel()
+
+	makeReq := func(t *testing.T, targetUserID string) *http.Request {
+		t.Helper()
+		return testutils.MakeJSONRequest(
+			t, http.MethodGet, "/boards/1/members/"+targetUserID+"/pickem", nil,
+			testutils.WithUserID(targetUserID),
+		)
+	}
+
+	t.Run("returns 200 with member pickem on success", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				assert.Equal(t, targetUserID, userID)
+				return &domain.UserPickem{IsLocked: true}, nil
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data domain.UserPickem `json:"data"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.True(t, resp.Data.IsLocked)
+	})
+
+	t.Run("returns 403 when predictions are hidden", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				return nil, domain.ErrPredictionsHidden
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "PREDICTIONS_HIDDEN", resp.Error.Code)
+	})
+
+	t.Run("returns 404 when board member not found", func(t *testing.T) {
+		t.Parallel()
+
+		targetUserID := gofakeit.UUID()
+
+		ps := &mocks.MockPickemService{
+			GetMemberPickemFunc: func(ctx context.Context, userID string) (*domain.UserPickem, error) {
+				return nil, domain.ErrBoardMemberNotFound
+			},
+		}
+
+		h := newTestPickemHandler(ps)
+		req := makeReq(t, targetUserID)
+		w := httptest.NewRecorder()
+
+		h.GetMemberPickem(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		testutils.ParseJSONResponse(t, w, &resp)
+		assert.Equal(t, "BOARD_MEMBER_NOT_FOUND", resp.Error.Code)
+	})
+}

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -105,6 +105,7 @@ type MailerConfig struct {
 type CronConfig struct {
 	CleanupSessionsSchedule  string
 	SyncMatchResultsSchedule string
+	SyncMatchResultsEnabled  bool
 }
 
 type FootballAPIConfig struct {
@@ -186,6 +187,7 @@ func NewConfig() *Config {
 		Cron: CronConfig{
 			CleanupSessionsSchedule:  env.GetString("CRON_CLEANUP_SESSIONS_SCHEDULE", "0 0 * * *"),   // Every day at midnight
 			SyncMatchResultsSchedule: env.GetString("CRON_SYNC_MATCH_RESULTS_SCHEDULE", "0 0 * * *"), // Every day at midnight (planning-only run)
+			SyncMatchResultsEnabled:  env.GetBool("CRON_SYNC_MATCH_RESULTS_ENABLED", true),
 		},
 		FootballAPI: FootballAPIConfig{
 			Key:     env.GetString("FOOTBALL_API_KEY", ""),

--- a/internal/jobs/sync_match_results_job.go
+++ b/internal/jobs/sync_match_results_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/fifawcp/api/internal/domain"
@@ -25,6 +26,8 @@ type SyncMatchResultsJob struct {
 	fairPlayRepo   domain.MatchFairPlayRepository
 	apiFixtureRepo domain.MatchAPIFixtureRepository
 	logger         logging.Logger
+	timersMutex    sync.Mutex
+	timers         map[int64]*time.Timer
 }
 
 func NewSyncMatchResultsJob(
@@ -40,6 +43,7 @@ func NewSyncMatchResultsJob(
 		fairPlayRepo:   fairPlayRepo,
 		apiFixtureRepo: apiFixtureRepo,
 		logger:         logger,
+		timers:         make(map[int64]*time.Timer),
 	}
 }
 
@@ -79,9 +83,7 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 
 		// Schedule the sync if the match is in the future
 		if delay > 0 {
-			time.AfterFunc(delay, func() {
-				j.syncMatch(context.Background(), matchID, fixtureID, syncMaxRetries)
-			})
+			j.scheduleSync(matchID, fixtureID, delay)
 		} else {
 			// Sync the match immediately if it's in the past
 			go j.syncMatch(ctx, matchID, fixtureID, syncMaxRetries)
@@ -94,6 +96,33 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 		"matches_scheduled", scheduled,
 	)
 	return nil
+}
+
+// scheduleSync registers a single pending sync timer per match. A re-run stops
+// the previous timer before installing the new one so timers never accumulate.
+func (j *SyncMatchResultsJob) scheduleSync(matchID, fixtureID int64, delay time.Duration) {
+	j.timersMutex.Lock()
+	defer j.timersMutex.Unlock()
+
+	if existing, ok := j.timers[matchID]; ok {
+		existing.Stop()
+	}
+
+	j.timers[matchID] = time.AfterFunc(delay, func() {
+		j.syncMatch(context.Background(), matchID, fixtureID, syncMaxRetries)
+	})
+}
+
+// Stop cancels all pending sync timers. Called on shutdown so timers do not fire
+// during teardown; the next startup re-arms them from the scheduled matches.
+func (j *SyncMatchResultsJob) Stop() {
+	j.timersMutex.Lock()
+	defer j.timersMutex.Unlock()
+
+	for matchID, timer := range j.timers {
+		timer.Stop()
+		delete(j.timers, matchID)
+	}
 }
 
 func (j *SyncMatchResultsJob) syncMatch(ctx context.Context, matchID, fixtureID int64, retriesLeft int) {

--- a/internal/jobs/sync_match_results_job_test.go
+++ b/internal/jobs/sync_match_results_job_test.go
@@ -1,0 +1,52 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScheduleSync_ReplacesExistingTimer verifies that re-scheduling the same
+// match stops the previous timer and keeps exactly one pending timer, so daily
+// re-runs do not accumulate duplicate timers.
+func TestScheduleSync_ReplacesExistingTimer(t *testing.T) {
+	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
+
+	const matchID int64 = 1
+	const fixtureID int64 = 10
+
+	// A long delay guarantees neither timer fires during the test.
+	job.scheduleSync(matchID, fixtureID, time.Hour)
+	firstTimer := job.timers[matchID]
+
+	job.scheduleSync(matchID, fixtureID, time.Hour)
+	secondTimer := job.timers[matchID]
+
+	if len(job.timers) != 1 {
+		t.Fatalf("expected exactly 1 pending timer, got %d", len(job.timers))
+	}
+	if firstTimer == secondTimer {
+		t.Fatal("expected the timer to be replaced on re-schedule")
+	}
+	// The first timer should already be stopped by the helper, so Stop() reports false.
+	if firstTimer.Stop() {
+		t.Fatal("expected the previous timer to have been stopped")
+	}
+}
+
+// TestStop_CancelsAllPendingTimers verifies shutdown cancels every pending timer.
+func TestStop_CancelsAllPendingTimers(t *testing.T) {
+	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
+
+	job.scheduleSync(1, 10, time.Hour)
+	job.scheduleSync(2, 20, time.Hour)
+	timer := job.timers[1]
+
+	job.Stop()
+
+	if len(job.timers) != 0 {
+		t.Fatalf("expected all timers cleared, got %d", len(job.timers))
+	}
+	if timer.Stop() {
+		t.Fatal("expected pending timer to have been stopped")
+	}
+}

--- a/internal/middlewares/errors.go
+++ b/internal/middlewares/errors.go
@@ -17,7 +17,8 @@ const (
 	codeForbidden      = "FORBIDDEN"
 
 	// 404 Not Found
-	codeBoardNotFound = "BOARD_NOT_FOUND"
+	codeBoardNotFound        = "BOARD_NOT_FOUND"
+	codeBoardMemberNotFound  = "BOARD_MEMBER_NOT_FOUND"
 
 	// 400 Bad Request
 	codeReturnToRequired   = "RETURN_TO_REQUIRED"

--- a/internal/middlewares/require_target_board_membership.go
+++ b/internal/middlewares/require_target_board_membership.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/httpctx"
+	"github.com/fifawcp/api/internal/httpx"
+	"github.com/fifawcp/api/internal/services"
+)
+
+func RequireTargetBoardMembership(boardMemberService services.BoardMemberServiceInterface) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			boardID := httpctx.GetBoardID(r.Context())
+			targetUserID := httpctx.GetUserID(r.Context())
+
+			if boardID == 0 || targetUserID == "" {
+				httpx.InternalServerError(w, r, codeInternalServer, ErrInternalServer.Error())
+				return
+			}
+
+			_, err := boardMemberService.GetBoardMember(r.Context(), boardID, targetUserID)
+			if err != nil {
+				switch {
+				case errors.Is(err, domain.ErrBoardMemberNotFound):
+					httpx.NotFound(w, r, codeBoardMemberNotFound, domain.ErrBoardMemberNotFound.Error())
+				default:
+					httpx.InternalServerError(w, r, codeInternalServer, ErrInternalServer.Error())
+				}
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/repositories/board_repository.go
+++ b/internal/repositories/board_repository.go
@@ -63,7 +63,7 @@ func (r *BoardRepository) GetUserBoards(ctx context.Context, userID string) ([]*
 	defer cancel()
 
 	query := `
-		SELECT b.id, b.name, b.privacy
+		SELECT b.id, b.name, b.privacy, bm.role
 		FROM boards b
 		INNER JOIN board_members bm ON bm.board_id = b.id
 		WHERE bm.user_id = $1
@@ -79,7 +79,7 @@ func (r *BoardRepository) GetUserBoards(ctx context.Context, userID string) ([]*
 	boards := []*domain.UserBoardListItem{}
 	for rows.Next() {
 		var board domain.UserBoardListItem
-		if err := rows.Scan(&board.ID, &board.Name, &board.Privacy); err != nil {
+		if err := rows.Scan(&board.ID, &board.Name, &board.Privacy, &board.Role); err != nil {
 			return nil, handleDBError(err, resourceBoard)
 		}
 

--- a/internal/repositories/pickem_repository.go
+++ b/internal/repositories/pickem_repository.go
@@ -343,6 +343,56 @@ func (r *PickemRepository) GetChampionPick(ctx context.Context, userID string) (
 	return &fifaCode, nil
 }
 
+func (r *PickemRepository) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	// Count final-match winner picks per team and express each as a share of all
+	// users who picked a final winner. Aggregate by fifa_code FIRST (a varchar —
+	// groupable), then join team_localized; grouping by the team's json
+	// name_translations directly errors ("no equality operator for type json").
+	query := `
+		WITH final_picks AS (
+			SELECT team_fifa_code
+			FROM user_bracket_picks
+			WHERE match_id = (SELECT id FROM matches WHERE stage_code = 'final')
+		),
+		total AS (SELECT COUNT(*) AS n FROM final_picks),
+		counts AS (
+			SELECT team_fifa_code, COUNT(*)::int AS pick_count
+			FROM final_picks
+			GROUP BY team_fifa_code
+		)
+		SELECT t.fifa_code, t.name_translations, t.flag_url, t.group_code,
+			c.pick_count,
+			(CASE WHEN (SELECT n FROM total) > 0
+				THEN ROUND(100.0 * c.pick_count / (SELECT n FROM total))
+				ELSE 0 END)::int AS pick_percent
+		FROM counts c
+		INNER JOIN team_localized t ON t.fifa_code = c.team_fifa_code
+		ORDER BY c.pick_count DESC, t.fifa_code
+		LIMIT $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, handleDBError(err, resourcePickem)
+	}
+	defer rows.Close()
+
+	favorites := []*domain.TitleFavorite{}
+	for rows.Next() {
+		var team domain.Team
+		fav := &domain.TitleFavorite{Team: &team}
+		if err := rows.Scan(&team.FifaCode, &team.Name, &team.FlagURL, &team.GroupCode, &fav.PickCount, &fav.PickPercent); err != nil {
+			return nil, handleDBError(err, resourcePickem)
+		}
+		favorites = append(favorites, fav)
+	}
+
+	return favorites, rows.Err()
+}
+
 func (r *PickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()

--- a/internal/services/award_service.go
+++ b/internal/services/award_service.go
@@ -15,6 +15,7 @@ const YoungPlayerMaxAge = 21
 
 type AwardServiceInterface interface {
 	GetUserAwards(ctx context.Context, userID string) (*domain.UserAwards, error)
+	GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error)
 	SaveAwardPicks(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
 	GetPopularPicks(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
 	RecordWinners(ctx context.Context, winners []*domain.AwardWinner) error
@@ -54,6 +55,14 @@ func (s *AwardService) GetUserAwards(ctx context.Context, userID string) (*domai
 	}
 
 	return s.buildUserAwards(ctx, picks)
+}
+
+func (s *AwardService) GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {
+	if !s.isLocked() {
+		return nil, domain.ErrPredictionsHidden
+	}
+
+	return s.GetUserAwards(ctx, userID)
 }
 
 func (s *AwardService) SaveAwardPicks(

--- a/internal/services/award_service_test.go
+++ b/internal/services/award_service_test.go
@@ -449,6 +449,37 @@ func TestAwardService_RecordWinners_SurfacesPersistenceFailureSynchronously(t *t
 	assert.ErrorIs(t, err, persistenceErr)
 }
 
+// ---------------------------------------------------------------------------
+// GetMemberAwards
+// ---------------------------------------------------------------------------
+func TestAwardService_GetMemberAwards_HiddenBeforeLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestAwardService(&mocks.MockAwardPickRepository{}, &mocks.MockPlayerRepository{}, nil, futureLock())
+
+	result, err := service.GetMemberAwards(context.Background(), gofakeit.UUID())
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, domain.ErrPredictionsHidden)
+}
+
+func TestAwardService_GetMemberAwards_ReturnsAwardsAfterLock(t *testing.T) {
+	t.Parallel()
+
+	awardRepo := &mocks.MockAwardPickRepository{
+		GetAwardPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserAwardPick, error) {
+			return []*domain.UserAwardPick{}, nil
+		},
+	}
+	service := newTestAwardService(awardRepo, &mocks.MockPlayerRepository{}, nil, pastLock())
+
+	result, err := service.GetMemberAwards(context.Background(), gofakeit.UUID())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsLocked)
+}
+
 func assertSignaledWithin(t *testing.T, ch <-chan struct{}, timeout time.Duration, msg string) {
 	t.Helper()
 	select {

--- a/internal/services/dashboard_service.go
+++ b/internal/services/dashboard_service.go
@@ -44,15 +44,16 @@ func NewDashboardService(
 func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*domain.Dashboard, error) {
 	var (
 		// public — always fetched
-		nextMatch  *domain.Match
-		pickemPage *domain.CompetitionLeaderboardPage
-		matchPage  *domain.CompetitionLeaderboardPage
+		nextMatch      *domain.Match
+		pickemPage     *domain.CompetitionLeaderboardPage
+		matchPage      *domain.CompetitionLeaderboardPage
+		titleFavorites []*domain.TitleFavorite
 
 		// per-user — fetched only when authenticated
 		champion       *domain.Team
 		pickemStats    domain.CompetitionUserStats
 		matchStats     domain.CompetitionUserStats
-		matchPicksMade int
+		userMatchPicks []*domain.UserMatchScorePick
 		pickemProgress *domain.PickemProgress
 		userAwards     *domain.UserAwards
 	)
@@ -65,12 +66,19 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 		return
 	})
 	eg.Go(func() (err error) {
-		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 5, "", "", "")
+		pickemPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalPickemCompetition.ID, 1, 10, "", "", "")
 		return
 	})
 	eg.Go(func() (err error) {
-		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 5, "", "", "")
+		matchPage, err = s.competitionScoreRepo.GetLeaderboard(egCtx, s.globalMatchCompetition.ID, 1, 10, "", "", "")
 		return
+	})
+	eg.Go(func() error {
+		// Decorative data — never fail the whole dashboard over it.
+		if favs, err := s.pickemService.GetChampionPickCounts(egCtx, 5); err == nil {
+			titleFavorites = favs
+		}
+		return nil
 	})
 
 	// per-user data: only fan out for authenticated callers
@@ -88,7 +96,9 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 			return
 		})
 		eg.Go(func() (err error) {
-			matchPicksMade, err = s.matchScorePickRepository.CountMatchScorePicksByUser(egCtx, userID)
+			// Fetches the user's picks once: powers both the match-picks count and
+			// the score pick attached to next_match below.
+			userMatchPicks, err = s.matchScorePickRepository.GetMatchScorePicksByUser(egCtx, userID)
 			return
 		})
 		eg.Go(func() (err error) {
@@ -106,7 +116,8 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 	}
 
 	dashboard := &domain.Dashboard{
-		NextMatch: nextMatch,
+		NextMatch:      nextMatch,
+		TitleFavorites: titleFavorites,
 		Leaderboard: domain.DashboardLeaderboard{
 			Pickem: domain.CompetitionTop{
 				CompetitionID:   s.globalPickemCompetition.ID,
@@ -130,9 +141,19 @@ func (s *DashboardService) GetDashboard(ctx context.Context, userID string) (*do
 			Match:  matchStats,
 		}
 		dashboard.Progress = &domain.DashboardProgress{
-			MatchPicks: stepProgress(matchPicksMade, 104),
+			MatchPicks: stepProgress(len(userMatchPicks), 104),
 			Pickem:     *pickemProgress,
 			Awards:     userAwards.Progress,
+		}
+		// Attach the user's pick for the featured next match (if any) so the
+		// dashboard's "up next" card reflects it.
+		if nextMatch != nil {
+			for _, pick := range userMatchPicks {
+				if pick.MatchID == nextMatch.ID {
+					dashboard.NextMatchScorePick = pick
+					break
+				}
+			}
 		}
 	}
 

--- a/internal/services/dashboard_service_test.go
+++ b/internal/services/dashboard_service_test.go
@@ -57,6 +57,12 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			GetChampionPickFunc: func(ctx context.Context, userID string) (*domain.Team, error) {
 				return argentina, nil
 			},
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{
+					{Team: &domain.Team{FifaCode: "BRA"}, PickCount: 40, PickPercent: 40},
+					{Team: &domain.Team{FifaCode: "ARG"}, PickCount: 30, PickPercent: 30},
+				}, nil
+			},
 			GetUserPickemProgressFunc: func(ctx context.Context, userID string) (*domain.PickemProgress, error) {
 				return &domain.PickemProgress{
 					Groups:     domain.StepProgress{Completed: 12, Total: 12},
@@ -75,7 +81,7 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 			},
 			GetLeaderboardFunc: func(ctx context.Context, competitionID int64, page, limit int, q, sort, dir string) (*domain.CompetitionLeaderboardPage, error) {
 				assert.Equal(t, 1, page)
-				assert.Equal(t, 5, limit)
+				assert.Equal(t, 10, limit)
 				if competitionID == 11 {
 					return &domain.CompetitionLeaderboardPage{
 						Members: []*domain.CompetitionLeaderboardEntry{
@@ -107,8 +113,14 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		}
 
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{
-			CountMatchScorePicksByUserFunc: func(ctx context.Context, userID string) (int, error) {
-				return 12, nil
+			GetMatchScorePicksByUserFunc: func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error) {
+				picks := make([]*domain.UserMatchScorePick, 0, 12)
+				// One of the picks is for the featured next match (id 1).
+				picks = append(picks, &domain.UserMatchScorePick{UserID: userID, MatchID: 1, HomeScore: 2, AwayScore: 1})
+				for i := 0; i < 11; i++ {
+					picks = append(picks, &domain.UserMatchScorePick{UserID: userID, MatchID: int64(100 + i), HomeScore: 1, AwayScore: 0})
+				}
+				return picks, nil
 			},
 		}
 
@@ -140,6 +152,12 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		assert.Equal(t, kickoffTime, dashboard.NextMatch.KickoffAt)
 		assert.Equal(t, 12, dashboard.Progress.MatchPicks.Completed)
 		assert.Equal(t, 104, dashboard.Progress.MatchPicks.Total)
+		assert.NotNil(t, dashboard.NextMatchScorePick)
+		assert.Equal(t, 2, dashboard.NextMatchScorePick.HomeScore)
+		assert.Equal(t, 1, dashboard.NextMatchScorePick.AwayScore)
+		assert.Len(t, dashboard.TitleFavorites, 2)
+		assert.Equal(t, "BRA", dashboard.TitleFavorites[0].Team.FifaCode)
+		assert.Equal(t, 40, dashboard.TitleFavorites[0].PickPercent)
 		assert.True(t, dashboard.Progress.Pickem.Groups.IsComplete())
 		assert.True(t, dashboard.Progress.Pickem.BestThirds.IsComplete())
 		assert.True(t, dashboard.Progress.Pickem.Bracket.IsComplete())
@@ -160,6 +178,9 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		pickemSvc := &mocks.MockPickemService{
 			GetChampionPickFunc: func(ctx context.Context, userID string) (*domain.Team, error) {
 				return nil, nil
+			},
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{}, nil
 			},
 			GetUserPickemProgressFunc: func(ctx context.Context, userID string) (*domain.PickemProgress, error) {
 				return &domain.PickemProgress{
@@ -189,8 +210,8 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		}
 
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{
-			CountMatchScorePicksByUserFunc: func(ctx context.Context, userID string) (int, error) {
-				return 0, nil
+			GetMatchScorePicksByUserFunc: func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error) {
+				return []*domain.UserMatchScorePick{}, nil
 			},
 		}
 
@@ -229,8 +250,13 @@ func TestDashboardService_GetDashboard(t *testing.T) {
 		t.Parallel()
 
 		// Per-user mock funcs are left unset — they panic if called, proving the
-		// service does not fan out user-specific queries for guests.
-		pickemSvc := &mocks.MockPickemService{}
+		// service does not fan out user-specific queries for guests. Champion-pick
+		// counts are public, so that one is provided.
+		pickemSvc := &mocks.MockPickemService{
+			GetChampionPickCountsFunc: func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+				return []*domain.TitleFavorite{{Team: &domain.Team{FifaCode: "BRA"}, PickCount: 10, PickPercent: 100}}, nil
+			},
+		}
 		matchScorePickRepo := &mocks.MockMatchScorePickRepository{}
 		awardSvc := &mocks.MockAwardService{}
 

--- a/internal/services/pickem_service.go
+++ b/internal/services/pickem_service.go
@@ -16,6 +16,7 @@ var allKnockoutMatchIDs = []int64{73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84
 
 type PickemServiceInterface interface {
 	GetUserPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
+	GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPick(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
@@ -95,6 +96,14 @@ func (s *PickemService) GetUserPickem(ctx context.Context, userID string) (*doma
 		},
 		IsLocked: s.isPickemLocked(),
 	}, nil
+}
+
+func (s *PickemService) GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error) {
+	if !s.isPickemLocked() {
+		return nil, domain.ErrPredictionsHidden
+	}
+
+	return s.GetUserPickem(ctx, userID)
 }
 
 func (s *PickemService) GetChampionPick(ctx context.Context, userID string) (*domain.Team, error) {

--- a/internal/services/pickem_service.go
+++ b/internal/services/pickem_service.go
@@ -18,6 +18,7 @@ type PickemServiceInterface interface {
 	GetUserPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPick(ctx context.Context, userID string) (*domain.Team, error)
+	GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
 	SaveBestThirds(ctx context.Context, userID string, teamFifaCodes []string) error
@@ -113,6 +114,10 @@ func (s *PickemService) GetChampionPick(ctx context.Context, userID string) (*do
 	}
 
 	return s.teamLookup[*fifaCode], nil
+}
+
+func (s *PickemService) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	return s.pickemRepo.GetChampionPickCounts(ctx, limit)
 }
 
 func (s *PickemService) GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error) {

--- a/internal/services/pickem_service_test.go
+++ b/internal/services/pickem_service_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestPickemService(repo *mocks.MockPickemRepository, lockTime time.Time) PickemServiceInterface {
+	cfg := &config.Config{}
+	logger := &mocks.MockLogger{}
+	return NewPickemService(repo, nil, lockTime, cfg, logger)
+}
+
+// repoWithEmptyPicks returns a MockPickemRepository whose four parallel-fetch
+// methods all return empty slices — sufficient to let GetUserPickem succeed.
+func repoWithEmptyPicks() *mocks.MockPickemRepository {
+	return &mocks.MockPickemRepository{
+		GetGroupPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error) {
+			return nil, nil
+		},
+		GetBestThirdPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error) {
+			return nil, nil
+		},
+		GetBracketPicksFunc: func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error) {
+			return nil, nil
+		},
+		GetLockedGroupCodesFunc: func(ctx context.Context, userID string) ([]string, error) {
+			return nil, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetMemberPickem
+// ---------------------------------------------------------------------------
+func TestPickemService_GetMemberPickem_HiddenBeforeLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestPickemService(&mocks.MockPickemRepository{}, time.Now().UTC().Add(24*time.Hour))
+
+	result, err := service.GetMemberPickem(context.Background(), gofakeit.UUID())
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, domain.ErrPredictionsHidden)
+}
+
+func TestPickemService_GetMemberPickem_ReturnsPickemAfterLock(t *testing.T) {
+	t.Parallel()
+
+	service := newTestPickemService(repoWithEmptyPicks(), time.Now().UTC().Add(-24*time.Hour))
+
+	result, err := service.GetMemberPickem(context.Background(), gofakeit.UUID())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsLocked)
+}

--- a/internal/test/mocks/award_service_mock.go
+++ b/internal/test/mocks/award_service_mock.go
@@ -8,6 +8,7 @@ import (
 
 type MockAwardService struct {
 	GetUserAwardsFunc   func(ctx context.Context, userID string) (*domain.UserAwards, error)
+	GetMemberAwardsFunc func(ctx context.Context, userID string) (*domain.UserAwards, error)
 	SaveAwardPicksFunc  func(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error)
 	GetPopularPicksFunc func(ctx context.Context, limit int) (domain.PopularPicksByAward, error)
 	RecordWinnersFunc   func(ctx context.Context, winners []*domain.AwardWinner) error
@@ -18,6 +19,13 @@ func (m *MockAwardService) GetUserAwards(ctx context.Context, userID string) (*d
 		return m.GetUserAwardsFunc(ctx, userID)
 	}
 	panic("GetUserAwards called unexpectedly")
+}
+
+func (m *MockAwardService) GetMemberAwards(ctx context.Context, userID string) (*domain.UserAwards, error) {
+	if m.GetMemberAwardsFunc != nil {
+		return m.GetMemberAwardsFunc(ctx, userID)
+	}
+	panic("GetMemberAwards called unexpectedly")
 }
 
 func (m *MockAwardService) SaveAwardPicks(ctx context.Context, userID string, picks []*domain.UserAwardPick) (*domain.UserAwards, error) {

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -1,0 +1,114 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockPickemRepository struct {
+	UpsertGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	GetGroupPicksFunc           func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
+	GetGroupPicksByGroupFunc    func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
+	UpsertBestThirdsFunc        func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
+	GetBestThirdPicksFunc       func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
+	GetBestThirdPicksByTeamsFunc func(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error)
+	UpsertBracketPicksFunc      func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
+	GetBracketPicksFunc         func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
+	GetBracketPicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
+	GetChampionPickFunc         func(ctx context.Context, userID string) (*string, error)
+	GetUserProgressCountsFunc   func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
+	GetLockedGroupCodesFunc     func(ctx context.Context, userID string) ([]string, error)
+	SetGroupLocksFunc           func(ctx context.Context, userID string, lockedCodes []string) error
+}
+
+func (m *MockPickemRepository) UpsertGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick) error {
+	if m.UpsertGroupPicksFunc != nil {
+		return m.UpsertGroupPicksFunc(ctx, userID, picks)
+	}
+	panic("UpsertGroupPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetGroupPicks(ctx context.Context, userID string) ([]*domain.UserGroupPick, error) {
+	if m.GetGroupPicksFunc != nil {
+		return m.GetGroupPicksFunc(ctx, userID)
+	}
+	panic("GetGroupPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetGroupPicksByGroup(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error) {
+	if m.GetGroupPicksByGroupFunc != nil {
+		return m.GetGroupPicksByGroupFunc(ctx, groupCode)
+	}
+	panic("GetGroupPicksByGroup called unexpectedly")
+}
+
+func (m *MockPickemRepository) UpsertBestThirds(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error {
+	if m.UpsertBestThirdsFunc != nil {
+		return m.UpsertBestThirdsFunc(ctx, userID, bestThirds)
+	}
+	panic("UpsertBestThirds called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBestThirdPicks(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error) {
+	if m.GetBestThirdPicksFunc != nil {
+		return m.GetBestThirdPicksFunc(ctx, userID)
+	}
+	panic("GetBestThirdPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBestThirdPicksByTeams(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error) {
+	if m.GetBestThirdPicksByTeamsFunc != nil {
+		return m.GetBestThirdPicksByTeamsFunc(ctx, teamFifaCodes)
+	}
+	panic("GetBestThirdPicksByTeams called unexpectedly")
+}
+
+func (m *MockPickemRepository) UpsertBracketPicks(ctx context.Context, userID string, picks []*domain.UserBracketPick) error {
+	if m.UpsertBracketPicksFunc != nil {
+		return m.UpsertBracketPicksFunc(ctx, userID, picks)
+	}
+	panic("UpsertBracketPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBracketPicks(ctx context.Context, userID string) ([]*domain.UserBracketPick, error) {
+	if m.GetBracketPicksFunc != nil {
+		return m.GetBracketPicksFunc(ctx, userID)
+	}
+	panic("GetBracketPicks called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error) {
+	if m.GetBracketPicksByMatchFunc != nil {
+		return m.GetBracketPicksByMatchFunc(ctx, matchID)
+	}
+	panic("GetBracketPicksByMatch called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetChampionPick(ctx context.Context, userID string) (*string, error) {
+	if m.GetChampionPickFunc != nil {
+		return m.GetChampionPickFunc(ctx, userID)
+	}
+	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {
+	if m.GetUserProgressCountsFunc != nil {
+		return m.GetUserProgressCountsFunc(ctx, userID)
+	}
+	panic("GetUserProgressCounts called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error) {
+	if m.GetLockedGroupCodesFunc != nil {
+		return m.GetLockedGroupCodesFunc(ctx, userID)
+	}
+	panic("GetLockedGroupCodes called unexpectedly")
+}
+
+func (m *MockPickemRepository) SetGroupLocks(ctx context.Context, userID string, lockedCodes []string) error {
+	if m.SetGroupLocksFunc != nil {
+		return m.SetGroupLocksFunc(ctx, userID, lockedCodes)
+	}
+	panic("SetGroupLocks called unexpectedly")
+}

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -17,6 +17,7 @@ type MockPickemRepository struct {
 	GetBracketPicksFunc         func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
 	GetBracketPicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
 	GetChampionPickFunc         func(ctx context.Context, userID string) (*string, error)
+	GetChampionPickCountsFunc   func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserProgressCountsFunc   func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
 	GetLockedGroupCodesFunc     func(ctx context.Context, userID string) ([]string, error)
 	SetGroupLocksFunc           func(ctx context.Context, userID string, lockedCodes []string) error
@@ -90,6 +91,13 @@ func (m *MockPickemRepository) GetChampionPick(ctx context.Context, userID strin
 		return m.GetChampionPickFunc(ctx, userID)
 	}
 	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemRepository) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	if m.GetChampionPickCountsFunc != nil {
+		return m.GetChampionPickCountsFunc(ctx, limit)
+	}
+	panic("GetChampionPickCounts called unexpectedly")
 }
 
 func (m *MockPickemRepository) GetUserProgressCounts(ctx context.Context, userID string) (domain.PickemProgressCounts, error) {

--- a/internal/test/mocks/pickem_service_mock.go
+++ b/internal/test/mocks/pickem_service_mock.go
@@ -10,6 +10,7 @@ type MockPickemService struct {
 	GetUserPickemFunc         func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetMemberPickemFunc       func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPickFunc       func(ctx context.Context, userID string) (*domain.Team, error)
+	GetChampionPickCountsFunc func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
 	GetUserPickemProgressFunc func(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
 	SaveBestThirdsFunc        func(ctx context.Context, userID string, teamFifaCodes []string) error
@@ -35,6 +36,13 @@ func (m *MockPickemService) GetChampionPick(ctx context.Context, userID string) 
 		return m.GetChampionPickFunc(ctx, userID)
 	}
 	panic("GetChampionPick called unexpectedly")
+}
+
+func (m *MockPickemService) GetChampionPickCounts(ctx context.Context, limit int) ([]*domain.TitleFavorite, error) {
+	if m.GetChampionPickCountsFunc != nil {
+		return m.GetChampionPickCountsFunc(ctx, limit)
+	}
+	panic("GetChampionPickCounts called unexpectedly")
 }
 
 func (m *MockPickemService) GetUserPickemProgress(ctx context.Context, userID string) (*domain.PickemProgress, error) {

--- a/internal/test/mocks/pickem_service_mock.go
+++ b/internal/test/mocks/pickem_service_mock.go
@@ -8,6 +8,7 @@ import (
 
 type MockPickemService struct {
 	GetUserPickemFunc         func(ctx context.Context, userID string) (*domain.UserPickem, error)
+	GetMemberPickemFunc       func(ctx context.Context, userID string) (*domain.UserPickem, error)
 	GetChampionPickFunc       func(ctx context.Context, userID string) (*domain.Team, error)
 	GetUserPickemProgressFunc func(ctx context.Context, userID string) (*domain.PickemProgress, error)
 	SaveGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick, lockedCodes []string) error
@@ -20,6 +21,13 @@ func (m *MockPickemService) GetUserPickem(ctx context.Context, userID string) (*
 		return m.GetUserPickemFunc(ctx, userID)
 	}
 	panic("GetUserPickem called unexpectedly")
+}
+
+func (m *MockPickemService) GetMemberPickem(ctx context.Context, userID string) (*domain.UserPickem, error) {
+	if m.GetMemberPickemFunc != nil {
+		return m.GetMemberPickemFunc(ctx, userID)
+	}
+	panic("GetMemberPickem called unexpectedly")
 }
 
 func (m *MockPickemService) GetChampionPick(ctx context.Context, userID string) (*domain.Team, error) {


### PR DESCRIPTION
## Release v1.3.0

Adds member-facing board features and a sync-job toggle, building on the v1.2.x board endpoints.

### Highlights
- **Dashboard:** title favorites and a next-match pick surfaced on the board dashboard (#114)
- **Boards:** member pick'em and awards endpoints (#111)
- **Ops:** enable/disable toggle for the match-results sync job (#107)