### PR TITLE
feat: adaptive match sync poller, real_dates seed, standings fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ db-test-migrate-down-inner:
 
 # ==================== Database Seeding ====================
 
-SCENARIOS := pre_tournament group_stage_done r32_done r16_done qf_done sf_done final_done
+SCENARIOS := pre_tournament real_dates group_stage_done r32_done r16_done qf_done sf_done final_done
 
 .PHONY: db-seed
 db-seed:

--- a/cmd/db/seed/scenario.go
+++ b/cmd/db/seed/scenario.go
@@ -32,13 +32,25 @@ type Scenario struct {
 
 	// AnchorMatchID's kickoff_at is shifted so it sits at AnchorOffset from
 	// "now" at seeder run time. All other matches receive the same delta to
-	// preserve relative spacing across the schedule
+	// preserve relative spacing across the schedule.
+	// Ignored when UseRealDates is set.
 	AnchorMatchID int64
 	AnchorOffset  time.Duration
+
+	// UseRealDates anchors the opener to its canonical 2026 kickoff instead of
+	// "now", restoring the real schedule so the live sync hits finished fixtures.
+	// Requires AnchorMatchID = 1.
+	UseRealDates bool
 }
+
+// canonicalOpenerKickoff is match 1's real kickoff from migration
+// 000006_seed_matches. Real-dates scenarios re-anchor the opener here, which —
+// because the shift is uniform — pins every other match back to its real date.
+var canonicalOpenerKickoff = time.Date(2026, 6, 11, 19, 0, 0, 0, time.UTC)
 
 const (
 	scenarioPreTournament  = "pre_tournament"
+	scenarioRealDates      = "real_dates"
 	scenarioGroupStageDone = "group_stage_done"
 	scenarioRoundOf32Done  = "r32_done"
 	scenarioRoundOf16Done  = "r16_done"
@@ -49,6 +61,7 @@ const (
 
 var ScenarioNames = []string{
 	scenarioPreTournament,
+	scenarioRealDates,
 	scenarioGroupStageDone,
 	scenarioRoundOf32Done,
 	scenarioRoundOf16Done,
@@ -63,6 +76,12 @@ var scenarios = map[string]Scenario{
 		StageGroups:   nil,
 		AnchorMatchID: 1,
 		AnchorOffset:  24 * time.Hour, // opener is 1 day from now
+	},
+	scenarioRealDates: {
+		Name:          scenarioRealDates,
+		StageGroups:   nil, // no results applied; matches sync in live from the football API
+		AnchorMatchID: 1,   // the opener
+		UseRealDates:  true,
 	},
 	scenarioGroupStageDone: {
 		Name:          scenarioGroupStageDone,

--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -138,19 +138,16 @@ func (s *Seeder) seedBoards(ctx context.Context, users []*domain.User) {
 		memberCount := boardMembersMin + mathrand.Intn(boardMembersMax-boardMembersMin+1)
 		candidates := make([]*domain.User, 0, len(users)-1)
 
-		// Get all users except the owner
 		for _, user := range users {
 			if user.ID != owner.ID {
 				candidates = append(candidates, user)
 			}
 		}
 
-		// Get a random subset of candidates
 		mathrand.Shuffle(len(candidates), func(a, b int) {
 			candidates[a], candidates[b] = candidates[b], candidates[a]
 		})
 
-		// Insert the members into the board
 		for j := 0; j < memberCount && j < len(candidates); j++ {
 			if _, err := s.boardMemberRepository.CreateBoardMember(ctx, *board.JoinCode, candidates[j].ID); err != nil {
 				s.logger.Error(
@@ -251,13 +248,10 @@ func (s *Seeder) seedMatchScoresFor(ctx context.Context, users []*domain.User, m
 		 	AND m.away_team_fifa_code IS NOT NULL
 		ON CONFLICT (user_id, match_id) DO NOTHING`
 
-	// Insert the match scores for each user
 	for _, user := range users {
 		args := make([]any, 0, len(matchIDs)*4)
 
-		// Insert the match scores for each match
 		for _, matchID := range matchIDs {
-			// Generate random scores between 0 and 5
 			args = append(args, user.ID, matchID, mathrand.Intn(6), mathrand.Intn(6))
 		}
 
@@ -422,9 +416,11 @@ func (s *Seeder) resetMatchesToCanonical(ctx context.Context) error {
 	return nil
 }
 
-// shiftKickoffDates moves every match's kickoff_at by a single offset
-// computed so the scenario's anchor match sits at its configured offset
-// from "now". This preserves relative spacing across the schedule
+// shiftKickoffDates moves every match's kickoff_at by a single offset computed
+// so the scenario's anchor match sits at its target time. The shift is uniform,
+// so anchoring one match re-pins the whole schedule while preserving spacing.
+// Normal scenarios anchor to "now + AnchorOffset"; real-dates scenarios anchor
+// the opener to its canonical absolute kickoff, restoring the real 2026 schedule.
 func (s *Seeder) shiftKickoffDates(ctx context.Context, scenario Scenario) error {
 	var currentAnchorKickoff time.Time
 	row := s.db.QueryRowContext(ctx, `SELECT kickoff_at FROM matches WHERE id = $1`, scenario.AnchorMatchID)
@@ -433,6 +429,9 @@ func (s *Seeder) shiftKickoffDates(ctx context.Context, scenario Scenario) error
 	}
 
 	targetAnchorKickoff := time.Now().UTC().Add(scenario.AnchorOffset)
+	if scenario.UseRealDates {
+		targetAnchorKickoff = canonicalOpenerKickoff
+	}
 	offset := targetAnchorKickoff.Sub(currentAnchorKickoff)
 	intervalSeconds := int64(offset.Seconds())
 	if _, err := s.db.ExecContext(ctx,

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -347,6 +347,13 @@ func (c *Container) initJobs() {
 		footballClient,
 		c.matchFairPlayRepository,
 		c.matchAPIFixtureRepository,
+		jobs.SyncTiming{
+			FirstPollOffset: c.Config.Cron.SyncMatchResultsFirstPollOffset,
+			NearEndInterval: c.Config.Cron.SyncMatchResultsNearEndInterval,
+			MaxPollInterval: c.Config.Cron.SyncMatchResultsMaxPollInterval,
+			ErrorBackoff:    c.Config.Cron.SyncMatchResultsErrorBackoff,
+			MaxPollWindow:   c.Config.Cron.SyncMatchResultsMaxPollWindow,
+		},
 		c.Logger,
 	)
 

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -103,9 +103,14 @@ type MailerConfig struct {
 }
 
 type CronConfig struct {
-	CleanupSessionsSchedule  string
-	SyncMatchResultsSchedule string
-	SyncMatchResultsEnabled  bool
+	CleanupSessionsSchedule         string
+	SyncMatchResultsSchedule        string
+	SyncMatchResultsEnabled         bool
+	SyncMatchResultsFirstPollOffset time.Duration // delay from kickoff to the first poll
+	SyncMatchResultsNearEndInterval time.Duration // tight cadence near/at full time (floor of the clamp)
+	SyncMatchResultsMaxPollInterval time.Duration // sparsest cadence far from the end (ceiling of the clamp)
+	SyncMatchResultsErrorBackoff    time.Duration // reschedule delay after a fetch error / non-200
+	SyncMatchResultsMaxPollWindow   time.Duration // hard stop: give up if now > kickoff + MaxPollWindow
 }
 
 type FootballAPIConfig struct {
@@ -185,9 +190,14 @@ func NewConfig() *Config {
 			FromAddress: env.GetString("MAILER_FROM_ADDRESS", ""),
 		},
 		Cron: CronConfig{
-			CleanupSessionsSchedule:  env.GetString("CRON_CLEANUP_SESSIONS_SCHEDULE", "0 0 * * *"),   // Every day at midnight
-			SyncMatchResultsSchedule: env.GetString("CRON_SYNC_MATCH_RESULTS_SCHEDULE", "0 0 * * *"), // Every day at midnight (planning-only run)
-			SyncMatchResultsEnabled:  env.GetBool("CRON_SYNC_MATCH_RESULTS_ENABLED", true),
+			CleanupSessionsSchedule:         env.GetString("CRON_CLEANUP_SESSIONS_SCHEDULE", "0 0 * * *"),   // Every day at midnight
+			SyncMatchResultsSchedule:        env.GetString("CRON_SYNC_MATCH_RESULTS_SCHEDULE", "0 0 * * *"), // Every day at midnight (planning-only run)
+			SyncMatchResultsEnabled:         env.GetBool("CRON_SYNC_MATCH_RESULTS_ENABLED", true),
+			SyncMatchResultsFirstPollOffset: env.GetDuration("CRON_SYNC_MATCH_RESULTS_FIRST_POLL_OFFSET", 75*time.Minute),
+			SyncMatchResultsNearEndInterval: env.GetDuration("CRON_SYNC_MATCH_RESULTS_NEAR_END_INTERVAL", 60*time.Second),
+			SyncMatchResultsMaxPollInterval: env.GetDuration("CRON_SYNC_MATCH_RESULTS_MAX_POLL_INTERVAL", 15*time.Minute),
+			SyncMatchResultsErrorBackoff:    env.GetDuration("CRON_SYNC_MATCH_RESULTS_ERROR_BACKOFF", 90*time.Second),
+			SyncMatchResultsMaxPollWindow:   env.GetDuration("CRON_SYNC_MATCH_RESULTS_MAX_POLL_WINDOW", 240*time.Minute),
 		},
 		FootballAPI: FootballAPIConfig{
 			Key:     env.GetString("FOOTBALL_API_KEY", ""),

--- a/internal/jobs/sync_match_results_cadence.go
+++ b/internal/jobs/sync_match_results_cadence.go
@@ -1,0 +1,114 @@
+package jobs
+
+import "time"
+
+// api-football live status short codes.
+// See https://www.api-football.com/documentation-v3#tag/Fixtures
+const (
+	statusNotStarted      = "NS"
+	statusTimeToBeDefined = "TBD"
+	statusFirstHalf       = "1H"
+	statusHalfTime        = "HT"
+	statusSecondHalf      = "2H"
+	statusExtraTime       = "ET"
+	statusBreakTime       = "BT"
+	statusPenaltiesLive   = "P"
+	statusSuspended       = "SUSP"
+	statusInterrupted     = "INT"
+)
+
+// terminalNotPlayedStatuses will never produce a result, so the poller gives up
+// instead of waiting out the poll window.
+var terminalNotPlayedStatuses = map[string]bool{
+	"PST":  true, // Postponed
+	"CANC": true, // Cancelled
+	"ABD":  true, // Abandoned
+	"WO":   true, // WalkOver
+	"AWD":  true, // Technical loss / awarded
+}
+
+const (
+	// In the second half, switch from a time-based estimate to the tight
+	// near-end cadence once the match is within stoppage-time range.
+	secondHalfNearEndElapsed = 80
+	firstHalfFullElapsed     = 45
+	secondHalfFullElapsed    = 90
+
+	// Coarse re-check gaps for states still far from a result.
+	firstHalfToFullTimeGap = 20 * time.Minute // ~half time (15m) + cushion to reach full time
+	halfTimeRecheck        = 10 * time.Minute
+	kickoffSlippedRecheck  = 5 * time.Minute // NS/TBD past the first poll
+	suspendedRecheck       = 5 * time.Minute // SUSP/INT
+)
+
+// pollDecision is the outcome of inspecting one live (non-final) fixture poll.
+type pollDecision struct {
+	stop  bool          // give up: terminal "not played" status
+	delay time.Duration // otherwise, wait this long before the next poll
+}
+
+// nextPollDelay decides how long to wait before re-polling a match that is not
+// yet final, from its live status and elapsed minute. It is pure (no clock, no
+// I/O) so the cadence is exhaustively unit-tested. Final statuses (FT/AET/PEN)
+// never reach here — the poller persists those before calling this.
+//
+// nearInterval and maxInterval are the clamp bounds; every estimated delay is
+// kept within [nearInterval, maxInterval].
+func nextPollDelay(short string, elapsed *int, nearInterval, maxInterval time.Duration) pollDecision {
+	if terminalNotPlayedStatuses[short] {
+		return pollDecision{stop: true}
+	}
+
+	clamp := func(delay time.Duration) time.Duration {
+		switch {
+		case delay < nearInterval:
+			return nearInterval
+		case delay > maxInterval:
+			return maxInterval
+		default:
+			return delay
+		}
+	}
+
+	switch short {
+	// Suspended/interrupted: sparse re-check; the poll window eventually ends it.
+	case statusSuspended, statusInterrupted:
+		return pollDecision{delay: clamp(suspendedRecheck)}
+
+	// Kickoff slipped (still not started past the first poll): short re-check.
+	case statusNotStarted, statusTimeToBeDefined, "":
+		return pollDecision{delay: clamp(kickoffSlippedRecheck)}
+
+	case statusHalfTime:
+		return pollDecision{delay: clamp(halfTimeRecheck)}
+
+	// End of regulation or the knockout tail (extra time / penalties): poll tight.
+	case statusExtraTime, statusBreakTime, statusPenaltiesLive:
+		return pollDecision{delay: nearInterval}
+
+	case statusSecondHalf:
+		elapsedMinute := elapsedOr(elapsed, secondHalfFullElapsed)
+		if elapsedMinute >= secondHalfNearEndElapsed {
+			return pollDecision{delay: nearInterval}
+		}
+		untilNearEnd := time.Duration(secondHalfNearEndElapsed-elapsedMinute) * time.Minute
+		return pollDecision{delay: clamp(untilNearEnd)}
+
+	case statusFirstHalf:
+		elapsedMinute := elapsedOr(elapsed, firstHalfFullElapsed)
+		untilFullTime := time.Duration(firstHalfFullElapsed-elapsedMinute)*time.Minute + firstHalfToFullTimeGap
+		return pollDecision{delay: clamp(untilFullTime)}
+
+	// Unknown/unexpected live code: poll tight so a fast finish isn't missed.
+	default:
+		return pollDecision{delay: nearInterval}
+	}
+}
+
+// elapsedOr returns the elapsed minute, or fallback when api-football omits it.
+func elapsedOr(elapsed *int, fallback int) int {
+	if elapsed == nil {
+		return fallback
+	}
+	return *elapsed
+}

--- a/internal/jobs/sync_match_results_cadence_test.go
+++ b/internal/jobs/sync_match_results_cadence_test.go
@@ -1,0 +1,67 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextPollDelay(t *testing.T) {
+	const near = 60 * time.Second
+	const max = 15 * time.Minute
+
+	intPtr := func(n int) *int { return &n }
+
+	cases := []struct {
+		name        string
+		short       string
+		elapsed     *int
+		expectStop  bool
+		expectDelay time.Duration
+	}{
+		// Second half: tight near the end, time-based estimate earlier (clamped).
+		{"2H past 80'", statusSecondHalf, intPtr(82), false, near},
+		{"2H at 80'", statusSecondHalf, intPtr(80), false, near},
+		{"2H mid", statusSecondHalf, intPtr(70), false, 10 * time.Minute},
+		{"2H early clamps to max", statusSecondHalf, intPtr(50), false, max},
+		{"2H nil elapsed assumes full time", statusSecondHalf, nil, false, near},
+
+		// Knockout tail is always tight.
+		{"extra time", statusExtraTime, intPtr(95), false, near},
+		{"break time", statusBreakTime, nil, false, near},
+		{"penalties", statusPenaltiesLive, nil, false, near},
+
+		// Mid-match coarse cadences.
+		{"half time", statusHalfTime, nil, false, halfTimeRecheck},
+		{"first half clamps to max", statusFirstHalf, intPtr(30), false, max},
+		{"first half late still clamps", statusFirstHalf, intPtr(44), false, max},
+
+		// Kickoff slipped / odd states.
+		{"not started", statusNotStarted, nil, false, kickoffSlippedRecheck},
+		{"to be defined", statusTimeToBeDefined, nil, false, kickoffSlippedRecheck},
+		{"empty status", "", nil, false, kickoffSlippedRecheck},
+		{"suspended", statusSuspended, intPtr(60), false, suspendedRecheck},
+		{"interrupted", statusInterrupted, nil, false, suspendedRecheck},
+
+		// Terminal, not played -> give up.
+		{"postponed", "PST", nil, true, 0},
+		{"cancelled", "CANC", nil, true, 0},
+		{"abandoned", "ABD", nil, true, 0},
+		{"walkover", "WO", nil, true, 0},
+		{"awarded", "AWD", nil, true, 0},
+
+		// Unknown live code -> fail fast (tight).
+		{"unknown", "XYZ", nil, false, near},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextPollDelay(tc.short, tc.elapsed, near, max)
+			if got.stop != tc.expectStop {
+				t.Fatalf("stop = %v, want %v", got.stop, tc.expectStop)
+			}
+			if !tc.expectStop && got.delay != tc.expectDelay {
+				t.Fatalf("delay = %v, want %v", got.delay, tc.expectDelay)
+			}
+		})
+	}
+}

--- a/internal/jobs/sync_match_results_job.go
+++ b/internal/jobs/sync_match_results_job.go
@@ -14,17 +14,28 @@ import (
 	"github.com/fifawcp/api/internal/services"
 )
 
-const (
-	syncInitialBuffer = 115 * time.Minute // fires after regular time + stoppage (~90 min playing + 15 min half time + 10 min buffer)
-	syncRetryInterval = 15 * time.Minute  // covers extra time and penalty shootout window
-	syncMaxRetries    = 5                 // 5 × 15 min = 75 min extra; total coverage ≈ 190 min from kickoff
-)
+// SyncTiming controls the adaptive per-match poller.
+type SyncTiming struct {
+	FirstPollOffset time.Duration // delay from kickoff to the first poll
+	NearEndInterval time.Duration // tight cadence near/at full time (floor of the clamp)
+	MaxPollInterval time.Duration // sparsest cadence far from the end (ceiling of the clamp)
+	ErrorBackoff    time.Duration // reschedule delay after a fetch error / non-200
+	MaxPollWindow   time.Duration // hard stop: give up if now > kickoff + MaxPollWindow
+}
+
+// FixtureFetcher is the slice of the football client the job needs. Defined on
+// the consumer side so the poller can be unit-tested with a mock.
+type FixtureFetcher interface {
+	GetFixture(ctx context.Context, fixtureID int64) (*football.FixtureResponse, error)
+	GetFixturesByTeam(ctx context.Context, teamAPIID int64) ([]football.FixtureResponse, error)
+}
 
 type SyncMatchResultsJob struct {
 	matchService   services.MatchServiceInterface
-	footballClient *football.FootballClient
+	fetcher        FixtureFetcher
 	fairPlayRepo   domain.MatchFairPlayRepository
 	apiFixtureRepo domain.MatchAPIFixtureRepository
+	timing         SyncTiming
 	logger         logging.Logger
 	timersMutex    sync.Mutex
 	timers         map[int64]*time.Timer
@@ -32,16 +43,18 @@ type SyncMatchResultsJob struct {
 
 func NewSyncMatchResultsJob(
 	matchService services.MatchServiceInterface,
-	footballClient *football.FootballClient,
+	fetcher FixtureFetcher,
 	fairPlayRepo domain.MatchFairPlayRepository,
 	apiFixtureRepo domain.MatchAPIFixtureRepository,
+	timing SyncTiming,
 	logger logging.Logger,
 ) *SyncMatchResultsJob {
 	return &SyncMatchResultsJob{
 		matchService:   matchService,
-		footballClient: footballClient,
+		fetcher:        fetcher,
 		fairPlayRepo:   fairPlayRepo,
 		apiFixtureRepo: apiFixtureRepo,
+		timing:         timing,
 		logger:         logger,
 		timers:         make(map[int64]*time.Timer),
 	}
@@ -54,7 +67,6 @@ func (j *SyncMatchResultsJob) Name() string {
 func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 	j.logger.Info("sync:match_results planning run started")
 
-	// Get all scheduled matches
 	matches, err := j.matchService.GetMatches(ctx, domain.MatchFilters{
 		Status: domain.MatchStatusScheduled,
 	})
@@ -64,7 +76,6 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 
 	scheduled := 0
 
-	// For each scheduled match, resolve the api-football fixture ID and schedule a timer to sync the result
 	for _, match := range matches {
 		fixtureID, err := j.resolveFixtureID(ctx, match)
 		if err != nil {
@@ -75,20 +86,15 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 			continue
 		}
 
-		syncTime := match.KickoffAt.Add(syncInitialBuffer)
-		delay := time.Until(syncTime)
-
-		// Capture the match ID for the closure
-		matchID := match.ID
-
-		// Schedule the sync if the match is in the future
-		if delay > 0 {
-			j.scheduleSync(matchID, fixtureID, delay)
-		} else {
-			// Sync the match immediately if it's in the past
-			go j.syncMatch(ctx, matchID, fixtureID, syncMaxRetries)
+		// First poll fires at kickoff + FirstPollOffset; if that moment has
+		// already passed, poll right away (startup backfill — an already-final
+		// fixture persists on the first tick).
+		delay := time.Until(match.KickoffAt.Add(j.timing.FirstPollOffset))
+		if delay < 0 {
+			delay = 0
 		}
 
+		j.schedulePoll(match.ID, fixtureID, match.KickoffAt, delay)
 		scheduled++
 	}
 
@@ -98,9 +104,10 @@ func (j *SyncMatchResultsJob) Run(ctx context.Context) error {
 	return nil
 }
 
-// scheduleSync registers a single pending sync timer per match. A re-run stops
-// the previous timer before installing the new one so timers never accumulate.
-func (j *SyncMatchResultsJob) scheduleSync(matchID, fixtureID int64, delay time.Duration) {
+// schedulePoll registers (or replaces) the single pending poll timer for a match.
+// The self-rescheduling poll re-arms through this same slot, so there is never
+// more than one live timer per match and Stop() can cancel the whole chain.
+func (j *SyncMatchResultsJob) schedulePoll(matchID, fixtureID int64, kickoffAt time.Time, delay time.Duration) {
 	j.timersMutex.Lock()
 	defer j.timersMutex.Unlock()
 
@@ -109,8 +116,20 @@ func (j *SyncMatchResultsJob) scheduleSync(matchID, fixtureID int64, delay time.
 	}
 
 	j.timers[matchID] = time.AfterFunc(delay, func() {
-		j.syncMatch(context.Background(), matchID, fixtureID, syncMaxRetries)
+		j.poll(context.Background(), matchID, fixtureID, kickoffAt)
 	})
+}
+
+// clearTimer stops and forgets a match's timer once polling is done, so Stop()
+// has nothing stale to cancel and the map does not grow unbounded.
+func (j *SyncMatchResultsJob) clearTimer(matchID int64) {
+	j.timersMutex.Lock()
+	defer j.timersMutex.Unlock()
+
+	if timer, ok := j.timers[matchID]; ok {
+		timer.Stop()
+		delete(j.timers, matchID)
+	}
 }
 
 // Stop cancels all pending sync timers. Called on shutdown so timers do not fire
@@ -125,42 +144,64 @@ func (j *SyncMatchResultsJob) Stop() {
 	}
 }
 
-func (j *SyncMatchResultsJob) syncMatch(ctx context.Context, matchID, fixtureID int64, retriesLeft int) {
-	fixture, err := j.footballClient.GetFixture(ctx, fixtureID)
-	if err != nil {
-		j.logger.Error("sync:match_results: get fixture failed",
+// poll fetches the fixture once and either persists the final result or re-arms
+// itself at an adaptive cadence. Every non-terminal outcome — including a fetch
+// error — reschedules through schedulePoll, so a transient failure never abandons
+// the match and Stop() always has a single timer to cancel.
+func (j *SyncMatchResultsJob) poll(ctx context.Context, matchID, fixtureID int64, kickoffAt time.Time) {
+	if time.Now().After(kickoffAt.Add(j.timing.MaxPollWindow)) {
+		j.clearTimer(matchID)
+		j.logger.Warn("sync:match_results: poll window exceeded, giving up",
 			"fixture_id", fixtureID,
 			"match_id", matchID,
-			"error", err,
 		)
 		return
 	}
 
-	if !fixture.IsFinished() {
-		// If the fixture is not finished, retry after the retry interval
-		if retriesLeft > 0 {
-			j.logger.Info("sync:match_results: match still in progress, will retry",
-				"fixture_id", fixtureID,
-				"match_id", matchID,
-				"status", fixture.Fixture.Status.Short,
-				"retries_left", retriesLeft,
-			)
-
-			time.AfterFunc(syncRetryInterval, func() {
-				j.syncMatch(context.Background(), matchID, fixtureID, retriesLeft-1)
-			})
-		} else {
-			// If the fixture is not finished and we've exhausted the retries, log a warning
-			j.logger.Warn("sync:match_results: max retries exhausted, giving up",
-				"fixture_id", fixtureID,
-				"match_id", matchID,
-				"status", fixture.Fixture.Status.Short,
-			)
-		}
-
+	fixture, err := j.fetcher.GetFixture(ctx, fixtureID)
+	if err != nil {
+		// Reschedule rather than abandon: a transient error or 429 must not
+		// permanently drop the match.
+		j.logger.Warn("sync:match_results: get fixture failed, will retry",
+			"fixture_id", fixtureID,
+			"match_id", matchID,
+			"error", err,
+		)
+		j.schedulePoll(matchID, fixtureID, kickoffAt, j.timing.ErrorBackoff)
 		return
 	}
 
+	if fixture.IsFinished() {
+		j.clearTimer(matchID)
+		j.finalizeMatch(ctx, matchID, fixtureID, fixture)
+		return
+	}
+
+	decision := nextPollDelay(
+		fixture.Fixture.Status.Short, fixture.Fixture.Status.Elapsed,
+		j.timing.NearEndInterval, j.timing.MaxPollInterval,
+	)
+	if decision.stop {
+		j.clearTimer(matchID)
+		j.logger.Warn("sync:match_results: terminal non-played status, giving up",
+			"fixture_id", fixtureID,
+			"match_id", matchID,
+			"status", fixture.Fixture.Status.Short,
+		)
+		return
+	}
+
+	j.logger.Info("sync:match_results: in progress, will re-poll",
+		"fixture_id", fixtureID,
+		"match_id", matchID,
+		"status", fixture.Fixture.Status.Short,
+		"next_delay", decision.delay,
+	)
+	j.schedulePoll(matchID, fixtureID, kickoffAt, decision.delay)
+}
+
+// finalizeMatch persists a finished fixture's result and fair-play cards.
+func (j *SyncMatchResultsJob) finalizeMatch(ctx context.Context, matchID, fixtureID int64, fixture *football.FixtureResponse) {
 	if err := j.persistResult(ctx, matchID, fixture); err != nil {
 		j.logger.Error("sync:match_results: persist result failed",
 			"fixture_id", fixtureID,
@@ -229,7 +270,6 @@ func (j *SyncMatchResultsJob) persistFairPlay(ctx context.Context, matchID int64
 		})
 	}
 
-	// No update needed
 	if len(records) == 0 {
 		return nil
 	}
@@ -246,17 +286,14 @@ func (j *SyncMatchResultsJob) resolveFixtureID(ctx context.Context, match *domai
 		return 0, fmt.Errorf("lookup fixture ID for match %d: %w", match.ID, err)
 	}
 
-	// Not in DB yet — only knockout matches can be in this state (group stage IDs are pre-seeded)
-	// Discover the ID via the API and persist it for future planning runs
+	// Not in DB yet — only knockout matches reach this (group-stage IDs are pre-seeded).
 	if match.Teams.Home == nil || match.Teams.Away == nil {
 		return 0, fmt.Errorf("match %d has unassigned teams", match.ID)
 	}
 
-	// Get the API team IDs from the FIFA codes
 	homeAPITeamID := football.FifaCodeToAPITeamID[match.Teams.Home.FifaCode]
 	awayAPITeamID := football.FifaCodeToAPITeamID[match.Teams.Away.FifaCode]
 
-	// Discover the fixture ID via the API and persist it for future planning runs
 	fixtureID, err = j.discoverAndPersistKnockoutFixtureID(ctx, match.ID, homeAPITeamID, awayAPITeamID)
 	if err != nil {
 		return 0, err
@@ -266,16 +303,14 @@ func (j *SyncMatchResultsJob) resolveFixtureID(ctx context.Context, match *domai
 }
 
 func (j *SyncMatchResultsJob) discoverAndPersistKnockoutFixtureID(ctx context.Context, matchID, homeAPITeamID, awayAPITeamID int64) (int64, error) {
-	fixtures, err := j.footballClient.GetFixturesByTeam(ctx, homeAPITeamID)
+	fixtures, err := j.fetcher.GetFixturesByTeam(ctx, homeAPITeamID)
 	if err != nil {
 		return 0, fmt.Errorf("get fixtures by team %d: %w", homeAPITeamID, err)
 	}
 
 	for _, fixture := range fixtures {
-		// Check if the away team is the same as the away team in the match
 		if fixture.Teams.Away.ID == awayAPITeamID {
 			fixtureID := fixture.Fixture.ID
-			// Persist the fixture ID for future planning runs
 			if err := j.apiFixtureRepo.UpsertFixtureID(ctx, matchID, fixtureID); err != nil {
 				j.logger.Warn("sync:match_results: failed to persist knockout fixture ID",
 					"match_id", matchID,

--- a/internal/jobs/sync_match_results_job_test.go
+++ b/internal/jobs/sync_match_results_job_test.go
@@ -1,24 +1,44 @@
 package jobs
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+	"github.com/fifawcp/api/internal/infrastructure/football"
+	"github.com/fifawcp/api/internal/test/mocks"
 )
 
-// TestScheduleSync_ReplacesExistingTimer verifies that re-scheduling the same
+// neverEndingTiming keeps every rescheduled timer far in the future so it cannot
+// fire during a test; assertions look at j.timers membership, not side effects.
+func neverEndingTiming() SyncTiming {
+	return SyncTiming{
+		FirstPollOffset: 75 * time.Minute,
+		NearEndInterval: time.Hour,
+		MaxPollInterval: time.Hour,
+		ErrorBackoff:    time.Hour,
+		MaxPollWindow:   4 * time.Hour,
+	}
+}
+
+// TestSchedulePoll_ReplacesExistingTimer verifies that re-scheduling the same
 // match stops the previous timer and keeps exactly one pending timer, so daily
-// re-runs do not accumulate duplicate timers.
-func TestScheduleSync_ReplacesExistingTimer(t *testing.T) {
+// re-runs and self-rescheduling polls do not accumulate duplicate timers.
+func TestSchedulePoll_ReplacesExistingTimer(t *testing.T) {
 	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
 
 	const matchID int64 = 1
 	const fixtureID int64 = 10
+	kickoff := time.Now()
 
 	// A long delay guarantees neither timer fires during the test.
-	job.scheduleSync(matchID, fixtureID, time.Hour)
+	job.schedulePoll(matchID, fixtureID, kickoff, time.Hour)
 	firstTimer := job.timers[matchID]
 
-	job.scheduleSync(matchID, fixtureID, time.Hour)
+	job.schedulePoll(matchID, fixtureID, kickoff, time.Hour)
 	secondTimer := job.timers[matchID]
 
 	if len(job.timers) != 1 {
@@ -27,7 +47,6 @@ func TestScheduleSync_ReplacesExistingTimer(t *testing.T) {
 	if firstTimer == secondTimer {
 		t.Fatal("expected the timer to be replaced on re-schedule")
 	}
-	// The first timer should already be stopped by the helper, so Stop() reports false.
 	if firstTimer.Stop() {
 		t.Fatal("expected the previous timer to have been stopped")
 	}
@@ -36,9 +55,10 @@ func TestScheduleSync_ReplacesExistingTimer(t *testing.T) {
 // TestStop_CancelsAllPendingTimers verifies shutdown cancels every pending timer.
 func TestStop_CancelsAllPendingTimers(t *testing.T) {
 	job := &SyncMatchResultsJob{timers: make(map[int64]*time.Timer)}
+	now := time.Now()
 
-	job.scheduleSync(1, 10, time.Hour)
-	job.scheduleSync(2, 20, time.Hour)
+	job.schedulePoll(1, 10, now, time.Hour)
+	job.schedulePoll(2, 20, now, time.Hour)
 	timer := job.timers[1]
 
 	job.Stop()
@@ -48,5 +68,146 @@ func TestStop_CancelsAllPendingTimers(t *testing.T) {
 	}
 	if timer.Stop() {
 		t.Fatal("expected pending timer to have been stopped")
+	}
+}
+
+// TestPoll_PersistsAndClearsTimer_WhenFinal verifies the happy path: a finished
+// fixture is persisted via UpdateMatchResult and its timer is cleared.
+func TestPoll_PersistsAndClearsTimer_WhenFinal(t *testing.T) {
+	home, away := 2, 0
+	fetcher := &mocks.MockFixtureFetcher{
+		GetFixtureFunc: func(_ context.Context, fixtureID int64) (*football.FixtureResponse, error) {
+			return &football.FixtureResponse{
+				Fixture: football.FixtureInfo{ID: fixtureID, Status: football.FixtureStatus{Short: "FT"}},
+				Goals:   football.FixtureGoals{Home: &home, Away: &away},
+			}, nil
+		},
+	}
+
+	var persistedMatchID int64
+	var persisted dtos.UpdateMatchResultDto
+	called := false
+	matchService := &mocks.MockMatchService{
+		UpdateMatchResultFunc: func(_ context.Context, matchID int64, payload dtos.UpdateMatchResultDto) (*domain.SyncGroupStageOutcomes, error) {
+			called = true
+			persistedMatchID = matchID
+			persisted = payload
+			return &domain.SyncGroupStageOutcomes{}, nil
+		},
+	}
+
+	job := &SyncMatchResultsJob{
+		matchService: matchService,
+		fetcher:      fetcher,
+		logger:       &mocks.MockLogger{},
+		timing:       neverEndingTiming(),
+		timers:       make(map[int64]*time.Timer),
+	}
+	job.schedulePoll(1, 10, time.Now(), time.Hour) // pre-arm so we can prove it gets cleared
+
+	job.poll(context.Background(), 1, 10, time.Now())
+
+	if !called {
+		t.Fatal("expected UpdateMatchResult to be called for a finished fixture")
+	}
+	if persistedMatchID != 1 || persisted.HomeScore == nil || *persisted.HomeScore != 2 || persisted.AwayScore == nil || *persisted.AwayScore != 0 {
+		t.Fatalf("unexpected persisted result: match=%d payload=%+v", persistedMatchID, persisted)
+	}
+	if _, ok := job.timers[1]; ok {
+		t.Fatal("expected timer to be cleared after the match went final")
+	}
+}
+
+// TestPoll_ReschedulesOnFetchError is the regression test for the abandon-on-error
+// bug: a transient fetch failure must re-arm the poll, not drop the match.
+func TestPoll_ReschedulesOnFetchError(t *testing.T) {
+	fetcher := &mocks.MockFixtureFetcher{
+		GetFixtureFunc: func(_ context.Context, _ int64) (*football.FixtureResponse, error) {
+			return nil, errors.New("network blip")
+		},
+	}
+
+	job := &SyncMatchResultsJob{
+		fetcher: fetcher,
+		logger:  &mocks.MockLogger{},
+		timing:  neverEndingTiming(),
+		timers:  make(map[int64]*time.Timer),
+	}
+
+	job.poll(context.Background(), 1, 10, time.Now())
+
+	if _, ok := job.timers[1]; !ok {
+		t.Fatal("expected a rescheduled timer after a fetch error (match must not be abandoned)")
+	}
+}
+
+// TestPoll_ReschedulesWhileInProgress verifies a live (non-final) fixture re-arms
+// the poll and does not persist a result.
+func TestPoll_ReschedulesWhileInProgress(t *testing.T) {
+	elapsed := 50
+	fetcher := &mocks.MockFixtureFetcher{
+		GetFixtureFunc: func(_ context.Context, fixtureID int64) (*football.FixtureResponse, error) {
+			return &football.FixtureResponse{
+				Fixture: football.FixtureInfo{ID: fixtureID, Status: football.FixtureStatus{Short: "2H", Elapsed: &elapsed}},
+			}, nil
+		},
+	}
+
+	job := &SyncMatchResultsJob{
+		matchService: &mocks.MockMatchService{}, // must NOT be called (would panic)
+		fetcher:      fetcher,
+		logger:       &mocks.MockLogger{},
+		timing:       neverEndingTiming(),
+		timers:       make(map[int64]*time.Timer),
+	}
+
+	job.poll(context.Background(), 1, 10, time.Now())
+
+	if _, ok := job.timers[1]; !ok {
+		t.Fatal("expected the poll to re-arm while the match is in progress")
+	}
+}
+
+// TestPoll_StopsOnTerminalNotPlayed verifies a postponed/cancelled match stops
+// polling and clears its timer.
+func TestPoll_StopsOnTerminalNotPlayed(t *testing.T) {
+	fetcher := &mocks.MockFixtureFetcher{
+		GetFixtureFunc: func(_ context.Context, fixtureID int64) (*football.FixtureResponse, error) {
+			return &football.FixtureResponse{
+				Fixture: football.FixtureInfo{ID: fixtureID, Status: football.FixtureStatus{Short: "CANC"}},
+			}, nil
+		},
+	}
+
+	job := &SyncMatchResultsJob{
+		fetcher: fetcher,
+		logger:  &mocks.MockLogger{},
+		timing:  neverEndingTiming(),
+		timers:  make(map[int64]*time.Timer),
+	}
+	job.schedulePoll(1, 10, time.Now(), time.Hour) // pre-arm
+
+	job.poll(context.Background(), 1, 10, time.Now())
+
+	if _, ok := job.timers[1]; ok {
+		t.Fatal("expected the timer to be cleared on a terminal non-played status")
+	}
+}
+
+// TestPoll_GivesUpAfterMaxPollWindow verifies the global guard: past the window
+// the poll gives up without even fetching.
+func TestPoll_GivesUpAfterMaxPollWindow(t *testing.T) {
+	job := &SyncMatchResultsJob{
+		fetcher: &mocks.MockFixtureFetcher{}, // GetFixture must NOT be called (would panic)
+		logger:  &mocks.MockLogger{},
+		timing:  SyncTiming{MaxPollWindow: time.Minute},
+		timers:  make(map[int64]*time.Timer),
+	}
+
+	kickoff := time.Now().Add(-2 * time.Hour) // well past kickoff + MaxPollWindow
+	job.poll(context.Background(), 1, 10, kickoff)
+
+	if _, ok := job.timers[1]; ok {
+		t.Fatal("expected no timer to be armed past the poll window")
 	}
 }

--- a/internal/services/group_standing_service.go
+++ b/internal/services/group_standing_service.go
@@ -54,6 +54,17 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 		matchesByGroup[*match.GroupCode] = append(matchesByGroup[*match.GroupCode], match)
 	}
 
+	// Every team must be ranked, including those yet to play — finished matches
+	// alone don't reveal them, so seed the roster from the group_standings table.
+	roster, err := s.groupStandingRepository.GetGroupStandings(ctx, nil, nil)
+	if err != nil {
+		return err
+	}
+	rosterByGroup := make(map[string][]domain.Team)
+	for _, standing := range roster {
+		rosterByGroup[standing.Team.GroupCode] = append(rosterByGroup[standing.Team.GroupCode], standing.Team)
+	}
+
 	groupCodes := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}
 
 	var wg sync.WaitGroup
@@ -64,7 +75,7 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 		wg.Add(1)
 		go func(groupCode string) {
 			defer wg.Done()
-			if err := s.recalculateStandingsByGroup(ctx, groupCode, matchesByGroup[groupCode]); err != nil {
+			if err := s.recalculateStandingsByGroup(ctx, groupCode, rosterByGroup[groupCode], matchesByGroup[groupCode]); err != nil {
 				mu.Lock()
 				errs = append(errs, err)
 				mu.Unlock()
@@ -80,15 +91,14 @@ func (s *GroupStandingService) RecalculateStandings(ctx context.Context) error {
 	return nil
 }
 
-func (s *GroupStandingService) recalculateStandingsByGroup(ctx context.Context, groupCode string, groupMatches []*domain.Match) error {
-	standings := rankGroup(groupMatches)
+func (s *GroupStandingService) recalculateStandingsByGroup(ctx context.Context, groupCode string, roster []domain.Team, groupMatches []*domain.Match) error {
+	standings := rankGroup(roster, groupMatches)
 
 	fairPlayTotals, err := s.fairPlayRepository.GetFairPlayTotalsByGroup(ctx, groupCode)
 	if err != nil {
 		return err
 	}
 
-	// Update the fair play score for each team
 	for _, standing := range standings {
 		standing.FairPlayScore = fairPlayTotals[standing.Team.FifaCode]
 	}
@@ -96,23 +106,26 @@ func (s *GroupStandingService) recalculateStandingsByGroup(ctx context.Context, 
 	return s.groupStandingRepository.UpdateGroupStandings(ctx, standings)
 }
 
-// rankGroup is the full FIFA Article 13 ranking pipeline
-func rankGroup(matches []*domain.Match) []*domain.GroupStanding {
-	standings := computeStandings(matches)
+// rankGroup is the full FIFA Article 13 ranking pipeline. roster is every team
+// in the group, so teams without a finished match yet are still ranked rather
+// than dropped from the table.
+func rankGroup(roster []domain.Team, matches []*domain.Match) []*domain.GroupStanding {
+	standings := computeStandings(roster, matches)
 	sortBy(standings, overallSortChain)
 	breakPointsTies(standings, matches)
 	assignPositions(standings)
 	return standings
 }
 
-// Builds a GroupStanding per team from a slice of matches
-// Reused for both the overall table and h2h mini-tables
-// The returned slice has no defined order
-func computeStandings(matches []*domain.Match) []*domain.GroupStanding {
-	// Map team FIFA code to group standing stats
+// computeStandings tallies a GroupStanding per team. roster seeds teams with no
+// match yet (empty for h2h sub-tables). The returned slice order is undefined.
+func computeStandings(roster []domain.Team, matches []*domain.Match) []*domain.GroupStanding {
 	statsByTeam := make(map[string]*domain.GroupStanding)
 
-	// For each match, update the group standing stats for the home and away teams
+	for _, team := range roster {
+		statsByTeam[team.FifaCode] = &domain.GroupStanding{Team: team}
+	}
+
 	for _, match := range matches {
 		homeTeam := match.Teams.Home.FifaCode
 		awayTeam := match.Teams.Away.FifaCode
@@ -142,11 +155,9 @@ func computeStandings(matches []*domain.Match) []*domain.GroupStanding {
 }
 
 func applyMatchToStandings(home, away *domain.GroupStanding, homeScore, awayScore int) {
-	// Update the matches played count
 	home.MatchesPlayed++
 	away.MatchesPlayed++
 
-	// Update the goals for, against counts and goal difference
 	home.GoalsFor += homeScore
 	home.GoalsAgainst += awayScore
 	home.GoalDifference = home.GoalsFor - home.GoalsAgainst
@@ -155,7 +166,6 @@ func applyMatchToStandings(home, away *domain.GroupStanding, homeScore, awayScor
 	away.GoalsAgainst += homeScore
 	away.GoalDifference = away.GoalsFor - away.GoalsAgainst
 
-	// Update the wins, draws, losses and points counts
 	switch {
 	case homeScore > awayScore:
 		home.Wins++
@@ -174,30 +184,24 @@ func applyMatchToStandings(home, away *domain.GroupStanding, homeScore, awayScor
 }
 
 // breakPointsTies finds consecutive runs of teams equal on Points and re-orders
-// each run via the FIFA Article 13 tiebreaker chain (Step 1 + Step 2 with recursion)
-// Modifies `standings` in place
+// each run via the FIFA Article 13 tiebreaker chain (Step 1 + Step 2 with
+// recursion). Modifies `standings` in place.
 func breakPointsTies(standings []*domain.GroupStanding, allMatches []*domain.Match) {
-	i := 0 // Index of the current team
+	i := 0
 
-	// Iterate over the standings
 	for i < len(standings) {
-		j := i + 1 // Index of the next team
-
-		// Iterate over the standings until the points are not equal
+		j := i + 1
 		for j < len(standings) && standings[j].Points == standings[i].Points {
-			j++ // If the next team has the same points, move to the next team
+			j++
 		}
 
-		// If there are at least two teams with the same points, rank them
 		if j-i > 1 {
 			ranked := rankTiedSubgroup(standings[i:j], allMatches)
-			// Replace the tied teams with the ranked teams
 			for k, team := range ranked {
 				standings[i+k] = team
 			}
 		}
 
-		// Move to the next group of teams with the same points
 		i = j
 	}
 }
@@ -207,18 +211,16 @@ func breakPointsTies(standings []*domain.GroupStanding, allMatches []*domain.Mat
 // criteria (Step 2, first sentence). If the entire input remains h2h-tied (no
 // separation possible), falls back to the overall sort chain (rules d, e, [f])
 func rankTiedSubgroup(tiedTeams []*domain.GroupStanding, allMatches []*domain.Match) []*domain.GroupStanding {
-	// Get the matches between the tied teams
 	h2hMatches := matchesBetween(tiedTeams, allMatches)
-	// Compute the standings for the head-to-head matches
-	h2hStandings := computeStandings(h2hMatches)
-	// Map the head-to-head standings by team FIFA code
+	// Seed every tied team so one that hasn't played the others yet is ranked
+	// (with zero h2h stats) instead of dropped.
+	h2hStandings := computeStandings(teamsOf(tiedTeams), h2hMatches)
 	h2hByTeam := make(map[string]*domain.GroupStanding, len(h2hStandings))
 
 	for _, s := range h2hStandings {
 		h2hByTeam[s.Team.FifaCode] = s
 	}
 
-	// Sort the head-to-head standings by the head-to-head sort chain (points, GD, GF)
 	sortBy(h2hStandings, headToHeadSortChain)
 
 	tiedByCode := make(map[string]*domain.GroupStanding, len(tiedTeams))
@@ -241,8 +243,6 @@ func rankTiedSubgroup(tiedTeams []*domain.GroupStanding, allMatches []*domain.Ma
 		case len(subgroup) == 1:
 			result = append(result, subgroup...)
 		case len(subgroup) < len(tiedTeams):
-			// If there are fewer teams in the subgroup than the tied teams,
-			// recursively rank the subgroup
 			result = append(result, rankTiedSubgroup(subgroup, allMatches)...)
 		default:
 			sortBy(subgroup, overallSortChain)
@@ -253,7 +253,7 @@ func rankTiedSubgroup(tiedTeams []*domain.GroupStanding, allMatches []*domain.Ma
 	return result
 }
 
-// Returns the matches in allMatches where both teams are in `teams`
+// matchesBetween returns the matches where both teams are in `teams`.
 func matchesBetween(teams []*domain.GroupStanding, allMatches []*domain.Match) []*domain.Match {
 	codes := make(map[string]bool, len(teams))
 	for _, t := range teams {
@@ -302,6 +302,15 @@ func assignPositions(standings []*domain.GroupStanding) {
 	}
 }
 
+func teamsOf(standings []*domain.GroupStanding) []domain.Team {
+	teams := make([]domain.Team, len(standings))
+	for i, standing := range standings {
+		teams[i] = standing.Team
+	}
+
+	return teams
+}
+
 // tiebreaker returns a negative value if a ranks above b, positive if b above a,
 // zero if equal on this criterion
 type tiebreaker func(a, b *domain.GroupStanding) int
@@ -346,7 +355,6 @@ var headToHeadSortChain = []tiebreaker{
 
 func sortBy(standings []*domain.GroupStanding, chain []tiebreaker) {
 	sort.SliceStable(standings, func(i, j int) bool {
-		// For each criterion in the chain, compare the standings at the current indices
 		for _, criterion := range chain {
 			if comparison := criterion(standings[i], standings[j]); comparison != 0 {
 				return comparison < 0

--- a/internal/services/group_standing_service_test.go
+++ b/internal/services/group_standing_service_test.go
@@ -20,9 +20,6 @@ func newTestGroupStandingService(
 	return NewGroupStandingService(gr, mr, fp, logger)
 }
 
-// ---------------------------------------------------------------------------
-// TestGroupStandingService_GetGroupStandings
-// ---------------------------------------------------------------------------
 func TestGroupStandingService_GetGroupStandings(t *testing.T) {
 	t.Parallel()
 
@@ -67,9 +64,6 @@ func TestGroupStandingService_GetGroupStandings(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// TestGroupStandingService_RecalculateStandings
-// ---------------------------------------------------------------------------
 func TestGroupStandingService_RecalculateStandings(t *testing.T) {
 	t.Parallel()
 
@@ -114,6 +108,13 @@ func TestGroupStandingService_RecalculateStandings(t *testing.T) {
 		}
 
 		gr := &mocks.MockGroupStandingRepository{
+			GetGroupStandingsFunc: func(_ context.Context, _ []string, _ *int64) ([]*domain.GroupStanding, error) {
+				roster := []*domain.GroupStanding{}
+				for _, code := range []string{"MEX", "RSA", "KOR", "CZE"} {
+					roster = append(roster, &domain.GroupStanding{Team: domain.Team{FifaCode: code, GroupCode: "A"}})
+				}
+				return roster, nil
+			},
 			UpdateGroupStandingsFunc: func(ctx context.Context, standings []*domain.GroupStanding) error {
 				return nil
 			},
@@ -159,6 +160,9 @@ func TestGroupStandingService_RecalculateStandings(t *testing.T) {
 		}
 
 		gr := &mocks.MockGroupStandingRepository{
+			GetGroupStandingsFunc: func(_ context.Context, _ []string, _ *int64) ([]*domain.GroupStanding, error) {
+				return []*domain.GroupStanding{}, nil
+			},
 			UpdateGroupStandingsFunc: func(ctx context.Context, standings []*domain.GroupStanding) error {
 				return errors.New("database error")
 			},
@@ -179,9 +183,6 @@ func TestGroupStandingService_RecalculateStandings(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// TestGroupStandingService_rankGroup
-// ---------------------------------------------------------------------------
 func TestGroupStandingService_rankGroup(t *testing.T) {
 	t.Parallel()
 
@@ -205,13 +206,36 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 		return matches
 	}
 
+	buildRoster := func(codes []string) []domain.Team {
+		roster := make([]domain.Team, len(codes))
+		for i, code := range codes {
+			roster[i] = domain.Team{FifaCode: code}
+		}
+
+		return roster
+	}
+
+	groupRoster := []string{"MEX", "KOR", "CZE", "RSA"}
+
 	testCases := []struct {
 		name          string
+		roster        []string
 		scores        []matchScore
 		expectedOrder []string
 	}{
 		{
-			name: "mid-tournament: tied teams haven't played each other yet",
+			// Regression: the screenshot bug. After one match only two of the four
+			// teams have played; the other two must still be ranked (not dropped).
+			name:   "early matchday: teams with no matches are still ranked",
+			roster: groupRoster,
+			scores: []matchScore{
+				{"MEX", "RSA", 2, 0},
+			},
+			expectedOrder: []string{"MEX", "KOR", "CZE", "RSA"},
+		},
+		{
+			name:   "mid-tournament: tied teams haven't played each other yet",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 1, 0},
 				{"KOR", "CZE", 1, 0},
@@ -219,7 +243,8 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 			expectedOrder: []string{"MEX", "KOR", "CZE", "RSA"},
 		},
 		{
-			name: "no ties",
+			name:   "no ties",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 0, 2},
 				{"KOR", "CZE", 1, 0},
@@ -231,7 +256,8 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 			expectedOrder: []string{"RSA", "KOR", "CZE", "MEX"},
 		},
 		{
-			name: "2 teams tied on points and goal difference",
+			name:   "2 teams tied on points and goal difference",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 0, 2},
 				{"KOR", "CZE", 0, 0},
@@ -243,7 +269,8 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 			expectedOrder: []string{"CZE", "KOR", "RSA", "MEX"},
 		},
 		{
-			name: "3 teams tied on points",
+			name:   "3 teams tied on points",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 0, 1},
 				{"KOR", "CZE", 1, 0},
@@ -255,7 +282,8 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 			expectedOrder: []string{"CZE", "KOR", "RSA", "MEX"},
 		},
 		{
-			name: "3 teams tied on points and goal difference",
+			name:   "3 teams tied on points and goal difference",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 0, 2},
 				{"KOR", "CZE", 0, 0},
@@ -267,7 +295,8 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 			expectedOrder: []string{"RSA", "KOR", "CZE", "MEX"},
 		},
 		{
-			name: "4 teams tied on points",
+			name:   "4 teams tied on points",
+			roster: groupRoster,
 			scores: []matchScore{
 				{"MEX", "RSA", 1, 1},
 				{"KOR", "CZE", 1, 1},
@@ -284,19 +313,12 @@ func TestGroupStandingService_rankGroup(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			standings := rankGroup(buildMatches(tc.scores))
+			standings := rankGroup(buildRoster(tc.roster), buildMatches(tc.scores))
 
 			actualOrder := make([]string, len(standings))
 			for i, s := range standings {
 				actualOrder[i] = s.Team.FifaCode
 			}
-
-			// ? Debug output
-			// for _, s := range standings {
-			// 	if tc.name == "no ties" {
-			// 		fmt.Printf("Team: %s, Points: %d, GD: %d, GF: %d, GA: %d\n", s.Team.FifaCode, s.Points, s.GoalDifference, s.GoalsFor, s.GoalsAgainst)
-			// 	}
-			// }
 
 			assert.Equal(t, tc.expectedOrder, actualOrder)
 		})

--- a/internal/test/mocks/fixture_fetcher_mock.go
+++ b/internal/test/mocks/fixture_fetcher_mock.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/infrastructure/football"
+)
+
+type MockFixtureFetcher struct {
+	GetFixtureFunc        func(ctx context.Context, fixtureID int64) (*football.FixtureResponse, error)
+	GetFixturesByTeamFunc func(ctx context.Context, teamAPIID int64) ([]football.FixtureResponse, error)
+}
+
+func (m *MockFixtureFetcher) GetFixture(ctx context.Context, fixtureID int64) (*football.FixtureResponse, error) {
+	if m.GetFixtureFunc != nil {
+		return m.GetFixtureFunc(ctx, fixtureID)
+	}
+	panic("GetFixture called unexpectedly")
+}
+
+func (m *MockFixtureFetcher) GetFixturesByTeam(ctx context.Context, teamAPIID int64) ([]football.FixtureResponse, error) {
+	if m.GetFixturesByTeamFunc != nil {
+		return m.GetFixturesByTeamFunc(ctx, teamAPIID)
+	}
+	panic("GetFixturesByTeam called unexpectedly")
+}

--- a/internal/test/mocks/match_service_mock.go
+++ b/internal/test/mocks/match_service_mock.go
@@ -1,0 +1,67 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/dtos"
+)
+
+type MockMatchService struct {
+	GetMatchesFunc                 func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error)
+	UpdateMatchResultFunc          func(ctx context.Context, matchID int64, payload dtos.UpdateMatchResultDto) (*domain.SyncGroupStageOutcomes, error)
+	UpdateMatchResultsBulkFunc     func(ctx context.Context, payload dtos.BulkUpdateMatchesResultDto) (*domain.SyncGroupStageOutcomes, error)
+	UpdateMatchResultsBulkSyncFunc func(ctx context.Context, payload dtos.BulkUpdateMatchesResultDto) (*domain.SyncGroupStageOutcomes, error)
+	ResetMatchResultFunc           func(ctx context.Context, matchID int64) (*domain.SyncGroupStageOutcomes, error)
+	SyncGroupStageOutcomesFunc     func(ctx context.Context) (*domain.SyncGroupStageOutcomes, error)
+	ResolveThirdPlaceConflictFunc  func(ctx context.Context, payload dtos.ResolveThirdPlaceConflictDto) (*domain.SyncGroupStageOutcomes, error)
+}
+
+func (m *MockMatchService) GetMatches(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+	if m.GetMatchesFunc != nil {
+		return m.GetMatchesFunc(ctx, filters)
+	}
+	panic("GetMatches called unexpectedly")
+}
+
+func (m *MockMatchService) UpdateMatchResult(ctx context.Context, matchID int64, payload dtos.UpdateMatchResultDto) (*domain.SyncGroupStageOutcomes, error) {
+	if m.UpdateMatchResultFunc != nil {
+		return m.UpdateMatchResultFunc(ctx, matchID, payload)
+	}
+	panic("UpdateMatchResult called unexpectedly")
+}
+
+func (m *MockMatchService) UpdateMatchResultsBulk(ctx context.Context, payload dtos.BulkUpdateMatchesResultDto) (*domain.SyncGroupStageOutcomes, error) {
+	if m.UpdateMatchResultsBulkFunc != nil {
+		return m.UpdateMatchResultsBulkFunc(ctx, payload)
+	}
+	panic("UpdateMatchResultsBulk called unexpectedly")
+}
+
+func (m *MockMatchService) UpdateMatchResultsBulkSync(ctx context.Context, payload dtos.BulkUpdateMatchesResultDto) (*domain.SyncGroupStageOutcomes, error) {
+	if m.UpdateMatchResultsBulkSyncFunc != nil {
+		return m.UpdateMatchResultsBulkSyncFunc(ctx, payload)
+	}
+	panic("UpdateMatchResultsBulkSync called unexpectedly")
+}
+
+func (m *MockMatchService) ResetMatchResult(ctx context.Context, matchID int64) (*domain.SyncGroupStageOutcomes, error) {
+	if m.ResetMatchResultFunc != nil {
+		return m.ResetMatchResultFunc(ctx, matchID)
+	}
+	panic("ResetMatchResult called unexpectedly")
+}
+
+func (m *MockMatchService) SyncGroupStageOutcomes(ctx context.Context) (*domain.SyncGroupStageOutcomes, error) {
+	if m.SyncGroupStageOutcomesFunc != nil {
+		return m.SyncGroupStageOutcomesFunc(ctx)
+	}
+	panic("SyncGroupStageOutcomes called unexpectedly")
+}
+
+func (m *MockMatchService) ResolveThirdPlaceConflict(ctx context.Context, payload dtos.ResolveThirdPlaceConflictDto) (*domain.SyncGroupStageOutcomes, error) {
+	if m.ResolveThirdPlaceConflictFunc != nil {
+		return m.ResolveThirdPlaceConflictFunc(ctx, payload)
+	}
+	panic("ResolveThirdPlaceConflict called unexpectedly")
+}


### PR DESCRIPTION
## Related issue

N/A — no linked issue.

## What changed

- Match-result sync now polls per match and tightens cadence as the game nears full time (~60s near the whistle) instead of a fixed kickoff+buffer, so results land ~1–2 min after FT — `internal/jobs/sync_match_results_job.go` + new cadence fn.
- Fixed a latent sync bug where a single fetch error abandoned the match until the next planning run; errors now reschedule with backoff. Timing is env-configurable via `CRON_SYNC_MATCH_RESULTS_*`.
- Standings now rank every group team, including teams with no match yet (were stuck at position 0); also fixes a head-to-head edge case that could drop a tied team.
- Added a `real_dates` seed scenario that keeps the canonical 2026 schedule for testing the live sync against finished fixtures.

## How to test

- [ ] `make test-unit` — cadence table, poll/reschedule (incl. error-retry), and standings roster tests pass.
- [ ] `make db-seed real_dates` then confirm match 1 kickoff is `2026-06-11T19:00Z` (canonical, unshifted).
- [ ] Restart the server with `CRON_SYNC_MATCH_RESULTS_ENABLED=true`; check logs for `sync:match_results: synced … status=FT` and that match 1 becomes `finished 2-0`.
- [ ] `GET /matches` / group standings: Group A shows `1 MEX, 2 KOR, 3 CZE, 4 RSA` (not `0,0,1,2`).