### PR TITLE
fix: send login OTP to account email when logging in by username

### DIFF
--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -75,7 +75,8 @@ func (s *AuthService) RequestOtp(
 	}
 
 	// Verify user exists for the given purpose
-	if _, err := s.validateUserForPurpose(ctx, payload.Identifier, *payload.Purpose); err != nil {
+	user, err := s.validateUserForPurpose(ctx, payload.Identifier, *payload.Purpose)
+	if err != nil {
 		return err
 	}
 
@@ -85,9 +86,15 @@ func (s *AuthService) RequestOtp(
 		return err
 	}
 
+	// If identifier is an email, use it as the recipient email. Otherwise, use the user's email.
+	recipientEmail := payload.Identifier
+	if user != nil {
+		recipientEmail = user.Email
+	}
+
 	if err := s.mailer.SendOTPEmail(
 		ctx,
-		payload.Identifier,
+		recipientEmail,
 		plainOtp,
 		*payload.Purpose,
 	); err != nil {

--- a/internal/services/auth_service_test.go
+++ b/internal/services/auth_service_test.go
@@ -73,7 +73,7 @@ func TestAuthService_RequestOtp(t *testing.T) {
 		ur := &mocks.MockUserRepository{
 			GetUserByIdentifierFunc: func(ctx context.Context, id string) (*domain.User, error) {
 				assert.Equal(t, identifier, id)
-				return &domain.User{ID: gofakeit.UUID()}, nil
+				return &domain.User{ID: gofakeit.UUID(), Email: identifier}, nil
 			},
 		}
 
@@ -92,6 +92,48 @@ func TestAuthService_RequestOtp(t *testing.T) {
 
 		err := service.RequestOtp(context.Background(), &dtos.RequestOtpDto{
 			Identifier: identifier,
+			Purpose:    &loginPurpose,
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("sends OTP to the resolved account email when logging in by username", func(t *testing.T) {
+		t.Parallel()
+
+		username := gofakeit.Username()
+		accountEmail := gofakeit.Email()
+
+		os := &mocks.MockOTPStorage{
+			GetOTPFunc: func(ctx context.Context, id string, purpose domain.OTPPurpose) (*domain.OTP, error) {
+				return nil, errors.New("otp not found")
+			},
+			SetOTPFunc: func(ctx context.Context, otp *domain.OTP, ttl time.Duration) error {
+				// OTP stays keyed by the identifier the user typed, not the email.
+				assert.Equal(t, username, otp.Identifier)
+				return nil
+			},
+		}
+
+		ur := &mocks.MockUserRepository{
+			GetUserByIdentifierFunc: func(ctx context.Context, id string) (*domain.User, error) {
+				assert.Equal(t, username, id)
+				return &domain.User{ID: gofakeit.UUID(), Email: accountEmail}, nil
+			},
+		}
+
+		mailer := &mocks.MockMailer{
+			SendOTPEmailFunc: func(ctx context.Context, to, otp string, purpose domain.OTPPurpose) error {
+				// Must address the user's real email, never the raw username.
+				assert.Equal(t, accountEmail, to)
+				return nil
+			},
+		}
+
+		service := newTestAuthService(ur, nil, nil, os, &mocks.MockLogger{}, &mocks.MockAuthenticator{}, mailer)
+
+		err := service.RequestOtp(context.Background(), &dtos.RequestOtpDto{
+			Identifier: username,
 			Purpose:    &loginPurpose,
 		})
 


### PR DESCRIPTION
## What changed

- Resolve the OTP recipient from the looked-up account: login by username now emails the user's real address instead of the raw username, which Resend rejected as an invalid `to` field (surfacing as a 500 on `/auth/otp/request`).
- Registration is unchanged — no user exists yet, so the identifier (the email) stays the recipient.
- Add a test for the username-login path; fix the login-success test that had encoded the old behavior.

## How to test

- [ ] `POST /api/auth/otp/request` with a **username** identifier + `purpose: login` → 204, OTP lands in the account's email.
- [ ] Same with an **email** identifier + `purpose: login` → 204 (unchanged).
- [ ] `POST /api/auth/otp/request` with an email + `purpose: registration` → 204, OTP to that email.
- [ ] Confirm prod logs stop showing `Invalid \`to\` field` errors on `/auth/otp/request`.