### PR TITLE
feat: board match-prediction reveal endpoints and pick ranking

### DIFF
--- a/cmd/db/seed/competition_templates.go
+++ b/cmd/db/seed/competition_templates.go
@@ -67,3 +67,36 @@ var competitionTemplates = func() []dtos.CreateCompetitionDto {
 
 	return templates
 }()
+
+// pickCompetitionTemplates are single-match ("pick") competitions pointing at
+// marquee group-stage fixtures. Group-stage matches always carry their teams and
+// finish from the group_stage_done scenario onward, so their picks reveal with a
+// scored result. Each board draws a couple at random in seedCompetitions.
+var pickCompetitionTemplates = func() []dtos.CreateCompetitionDto {
+	fixtures := []struct {
+		matchID int64
+		name    string
+	}{
+		{6, "BRA vs MAR"},
+		{9, "GER vs CUW"},
+		{10, "NED vs JPN"},
+		{13, "ESP vs CPV"},
+		{14, "BEL vs EGY"},
+		{15, "KSA vs URU"},
+		{17, "ARG vs ALG"},
+		{18, "FRA vs SEN"},
+		{20, "POR vs COD"},
+		{21, "ENG vs CRO"},
+	}
+
+	templates := make([]dtos.CreateCompetitionDto, len(fixtures))
+	for i, fixture := range fixtures {
+		matchID := fixture.matchID
+		templates[i] = dtos.CreateCompetitionDto{
+			Type:    domain.CompetitionTypePick,
+			Name:    fixture.name,
+			MatchID: &matchID,
+		}
+	}
+	return templates
+}()

--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -450,29 +450,39 @@ func (s *Seeder) shiftKickoffDates(ctx context.Context, scenario Scenario) error
 	return nil
 }
 
-// seedCompetitions creates 1-3 random competitions on every non-Global
-// seeded board, drawing from competitionTemplates
+// seedCompetitions creates 1-3 random custom (match) competitions plus 1-2
+// single-match (pick) competitions on every non-Global seeded board, drawing
+// from competitionTemplates and pickCompetitionTemplates respectively
 func (s *Seeder) seedCompetitions(ctx context.Context) error {
 	for boardID, ownerID := range s.boardOwners {
-		templateCount := 1 + mathrand.Intn(3)
-		shuffled := make([]dtos.CreateCompetitionDto, len(competitionTemplates))
-		copy(shuffled, competitionTemplates)
-		mathrand.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+		matchCount := 1 + mathrand.Intn(3)
+		s.seedCompetitionsFrom(ctx, boardID, ownerID, competitionTemplates, matchCount)
 
-		for i := 0; i < templateCount && i < len(shuffled); i++ {
-			template := shuffled[i]
-
-			if _, err := s.competitionService.CreateCompetition(ctx, boardID, ownerID, domain.BoardMemberRoleOwner, template); err != nil {
-				s.logger.Error("Error seeding competition",
-					logging.Error, err.Error(),
-					"board_id", boardID,
-					"name", template.Name,
-				)
-			}
-		}
+		pickCount := 1 + mathrand.Intn(2)
+		s.seedCompetitionsFrom(ctx, boardID, ownerID, pickCompetitionTemplates, pickCount)
 	}
 
 	return nil
+}
+
+// seedCompetitionsFrom creates `count` competitions on a board, drawn at random
+// (no repeats) from the given templates.
+func (s *Seeder) seedCompetitionsFrom(ctx context.Context, boardID int64, ownerID string, templates []dtos.CreateCompetitionDto, count int) {
+	shuffled := make([]dtos.CreateCompetitionDto, len(templates))
+	copy(shuffled, templates)
+	mathrand.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+
+	for i := 0; i < count && i < len(shuffled); i++ {
+		template := shuffled[i]
+
+		if _, err := s.competitionService.CreateCompetition(ctx, boardID, ownerID, domain.BoardMemberRoleOwner, template); err != nil {
+			s.logger.Error("Error seeding competition",
+				logging.Error, err.Error(),
+				"board_id", boardID,
+				"name", template.Name,
+			)
+		}
+	}
 }
 
 var knockoutStages = [][]int64{

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -275,7 +275,7 @@ func (c *Container) initServices() {
 		c.pickemRepository, c.teams, c.firstKickoff, c.Config, c.Logger,
 	)
 	c.matchScorePickService = services.NewMatchScorePickService(
-		c.matchScorePickRepository, c.matchRepository,
+		c.matchScorePickRepository, c.matchRepository, c.competitionRepository,
 	)
 
 	c.competitionScoringService = services.NewCompetitionScoringService(

--- a/internal/app/routes_boards.go
+++ b/internal/app/routes_boards.go
@@ -45,6 +45,11 @@ func boardsRoutes(c *Container) chi.Router {
 
 			r.Get("/summary", c.CompetitionHandler.GetBoardSummary)
 
+			r.Route("/matches/{id}", func(r chi.Router) {
+				r.Use(middlewares.ParseMatchID)
+				r.Get("/picks", c.MatchHandler.GetBoardMatchPicks)
+			})
+
 			r.Route("/competitions", func(r chi.Router) {
 				r.Get("/", c.CompetitionHandler.GetBoardCompetitions)
 				r.Post("/", c.CompetitionHandler.CreateCompetition)
@@ -53,6 +58,12 @@ func boardsRoutes(c *Container) chi.Router {
 					r.Use(middlewares.ParseCompetitionID)
 					r.Delete("/", c.CompetitionHandler.DeleteCompetition)
 					r.Get("/leaderboard", c.CompetitionHandler.GetLeaderboard)
+
+					r.Route("/members/{userId}", func(r chi.Router) {
+						r.Use(middlewares.ParseUserID)
+						r.Use(middlewares.RequireTargetBoardMembership(c.BoardMemberService))
+						r.Get("/picks", c.MatchHandler.GetMemberCompetitionPicks)
+					})
 				})
 			})
 		})

--- a/internal/domain/competition.go
+++ b/internal/domain/competition.go
@@ -108,4 +108,5 @@ type CompetitionRepository interface {
 	DeleteCompetition(ctx context.Context, boardID, competitionID int64) error
 	FindMatchCompetitionsByMatches(ctx context.Context, matchIDs []int64) ([]int64, error)
 	GetGlobalCompetitions(ctx context.Context) (pickem *Competition, match *Competition, err error)
+	GetScopeMatchIDs(ctx context.Context, competitionID int64) ([]int64, error)
 }

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -111,6 +111,7 @@ var ErrCompetitionPickemAlreadyExists = errors.New("a tournament pick'em competi
 var ErrCompetitionAwardsAlreadyExists = errors.New("an awards competition already exists on this board")
 var ErrCompetitionNameAlreadyExists = errors.New("a competition with this name already exists on this board")
 var ErrDuplicatePickForMatch = errors.New("a pick for this match already exists on this board")
+var ErrCompetitionNotMatchBased = errors.New("competition has no match score picks")
 
 // Predictions visibility (member views)
 var ErrPredictionsHidden = errors.New("member predictions are hidden until the tournament starts")
@@ -118,6 +119,7 @@ var ErrPredictionsHidden = errors.New("member predictions are hidden until the t
 // Pickem
 var ErrPickemLocked = errors.New("pickem is locked: tournament has started")
 var ErrMatchPickLocked = errors.New("match pick is locked: match has already started")
+var ErrMatchPicksHidden = errors.New("match predictions are hidden until the match starts")
 var ErrInvalidGroupPicks = errors.New("invalid group picks: each group must have exactly 4 distinct teams in positions 1-4")
 var ErrInvalidBestThirdTeam = errors.New("each best-third team must be in position 3 within submitted group picks")
 var ErrInvalidBracketPickTeam = errors.New("picked team is not a projected participant for this bracket match")

--- a/internal/domain/match_score_pick.go
+++ b/internal/domain/match_score_pick.go
@@ -9,9 +9,19 @@ type UserMatchScorePick struct {
 	AwayScore int    `json:"away_score"`
 }
 
+// BoardMemberMatchPick pairs a board member with their (possibly absent) score pick for a match.
+// HomeScore and AwayScore are nil when the member has not submitted a pick.
+type BoardMemberMatchPick struct {
+	Member    CompetitionLeaderboardMember
+	HomeScore *int
+	AwayScore *int
+}
+
 type MatchScorePickRepository interface {
 	UpsertMatchScorePick(ctx context.Context, pick *UserMatchScorePick) error
 	GetMatchScorePicksByUser(ctx context.Context, userID string) ([]*UserMatchScorePick, error)
+	GetMatchScorePicksByUserAndMatches(ctx context.Context, userID string, matchIDs []int64) ([]*UserMatchScorePick, error)
 	GetMatchScorePicksByMatch(ctx context.Context, matchID int64) ([]*UserMatchScorePick, error)
 	CountMatchScorePicksByUser(ctx context.Context, userID string) (int, error)
+	GetBoardMembersMatchPicks(ctx context.Context, boardID, matchID int64) ([]*BoardMemberMatchPick, error)
 }

--- a/internal/dtos/match_dto.go
+++ b/internal/dtos/match_dto.go
@@ -16,3 +16,15 @@ type SaveMatchScorePickDto struct {
 	HomeScore *int `json:"home_score" validate:"required,gte=0,lte=20" example:"2"`
 	AwayScore *int `json:"away_score" validate:"required,gte=0,lte=20" example:"1"`
 }
+
+// MemberPickDto represents one board member alongside their (possibly nil) score pick.
+type MemberPickDto struct {
+	Member domain.CompetitionLeaderboardMember `json:"member"`
+	Pick   *UserScorePickDto                   `json:"pick"`
+}
+
+// MatchMemberPicksDto is the response for viewing all board members' picks for a single match.
+type MatchMemberPicksDto struct {
+	Match *domain.Match   `json:"match"`
+	Picks []MemberPickDto `json:"picks"`
+}

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -51,6 +51,7 @@ const (
 	codeCompetitionForbidden      = "COMPETITION_FORBIDDEN"
 	codeBoardManageAdminForbidden = "BOARD_MANAGE_ADMIN_FORBIDDEN"
 	codePredictionsHidden         = "PREDICTIONS_HIDDEN"
+	codeMatchPicksHidden          = "MATCH_PICKS_HIDDEN"
 
 	// 400 Bad Request
 	codeInvalidWinnerTeam          = "INVALID_WINNER_TEAM"
@@ -84,6 +85,7 @@ const (
 	codeAwardPlayerIneligible      = "AWARD_PLAYER_INELIGIBLE"
 	codeAwardWinnersIncomplete     = "AWARD_WINNERS_INCOMPLETE"
 	codePlayerNotFound             = "PLAYER_NOT_FOUND"
+	codeCompetitionNotMatchBased   = "COMPETITION_NOT_MATCH_BASED"
 
 	// 502 Bad Gateway
 	codeMissingIDToken = "MISSING_ID_TOKEN"
@@ -171,6 +173,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.Forbidden(w, r, codeBoardManageAdminForbidden, domain.ErrBoardManageAdminForbidden.Error())
 	case errors.Is(err, domain.ErrPredictionsHidden):
 		httpx.Forbidden(w, r, codePredictionsHidden, domain.ErrPredictionsHidden.Error())
+	case errors.Is(err, domain.ErrMatchPicksHidden):
+		httpx.Forbidden(w, r, codeMatchPicksHidden, domain.ErrMatchPicksHidden.Error())
 
 	// 400 Bad Request
 	case errors.Is(err, domain.ErrInvalidWinnerTeam):
@@ -197,6 +201,8 @@ func handleServiceError(w http.ResponseWriter, r *http.Request, err error, logge
 		httpx.BadRequest(w, r, codeInvalidDateRange, domain.ErrInvalidDateRange.Error())
 	case errors.Is(err, domain.ErrInvalidQueryParam):
 		httpx.BadRequest(w, r, codeInvalidQueryParam, err.Error())
+	case errors.Is(err, domain.ErrCompetitionNotMatchBased):
+		httpx.BadRequest(w, r, codeCompetitionNotMatchBased, domain.ErrCompetitionNotMatchBased.Error())
 	case errors.Is(err, domain.ErrPickemLocked):
 		httpx.BadRequest(w, r, codePickemLocked, domain.ErrPickemLocked.Error())
 	case errors.Is(err, domain.ErrMatchPickLocked):

--- a/internal/handlers/match_handler.go
+++ b/internal/handlers/match_handler.go
@@ -137,6 +137,64 @@ func (h *MatchHandler) SaveMatchScorePick(w http.ResponseWriter, r *http.Request
 	httpx.RespondWithData(w, http.StatusNoContent, nil)
 }
 
+// GetMemberCompetitionPicks returns a board member's match score picks for a competition.
+//
+//	@Summary		Get a board member's match picks for a competition
+//	@Description	Returns the locked match score picks of a specific board member for the given competition.
+//	@Description	Only picks for matches that have already started (locked) are returned.
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId			path		int64											true	"Board ID"
+//	@Param			competitionId	path		int64											true	"Competition ID"
+//	@Param			userId			path		string											true	"Member user ID (UUID)"
+//	@Success		200				{object}	httpx.Response{data=[]dtos.MatchResponseDto}	"Member's match picks"
+//	@Failure		400				{object}	httpx.ErrorResponse								"Competition is not match-based"
+//	@Failure		401				{object}	httpx.ErrorResponse								"Missing or invalid Bearer token"
+//	@Failure		404				{object}	httpx.ErrorResponse								"Board, competition, or member not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/competitions/{competitionId}/members/{userId}/picks [get]
+func (h *MatchHandler) GetMemberCompetitionPicks(w http.ResponseWriter, r *http.Request) {
+	boardID := httpctx.GetBoardID(r.Context())
+	competitionID := httpctx.GetCompetitionID(r.Context())
+	targetUserID := httpctx.GetUserID(r.Context())
+
+	matches, picks, err := h.matchScorePickService.GetMemberCompetitionPicks(r.Context(), boardID, competitionID, targetUserID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, buildMatchResponse(matches, picks))
+}
+
+// GetBoardMatchPicks returns all board members' score picks for a specific match.
+//
+//	@Summary		Get all board members' picks for a match
+//	@Description	Returns every board member alongside their predicted score for a specific match.
+//	@Description	Only available after the match has started (is locked).
+//	@Tags			boards
+//	@Produce		json
+//	@Param			boardId	path		int64											true	"Board ID"
+//	@Param			id		path		int64											true	"Match ID"
+//	@Success		200		{object}	httpx.Response{data=dtos.MatchMemberPicksDto}	"All members' picks for the match"
+//	@Failure		401		{object}	httpx.ErrorResponse								"Missing or invalid Bearer token"
+//	@Failure		403		{object}	httpx.ErrorResponse								"Match predictions not yet revealed"
+//	@Failure		404		{object}	httpx.ErrorResponse								"Board or match not found"
+//	@Security		BearerAuth
+//	@Router			/boards/{boardId}/matches/{id}/picks [get]
+func (h *MatchHandler) GetBoardMatchPicks(w http.ResponseWriter, r *http.Request) {
+	boardID := httpctx.GetBoardID(r.Context())
+	matchID := httpctx.GetMatchID(r.Context())
+
+	match, memberPicks, err := h.matchScorePickService.GetBoardMatchPicks(r.Context(), boardID, matchID)
+	if err != nil {
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	httpx.RespondWithData(w, http.StatusOK, buildMatchMemberPicksResponse(match, memberPicks))
+}
+
 func buildMatchResponse(
 	matches []*domain.Match,
 	picks []*domain.UserMatchScorePick,
@@ -163,6 +221,25 @@ func buildMatchResponse(
 	}
 
 	return response
+}
+
+func buildMatchMemberPicksResponse(
+	match *domain.Match,
+	memberPicks []*domain.BoardMemberMatchPick,
+) dtos.MatchMemberPicksDto {
+	picks := make([]dtos.MemberPickDto, len(memberPicks))
+	for index, memberPick := range memberPicks {
+		entry := dtos.MemberPickDto{Member: memberPick.Member}
+		// HomeScore and AwayScore are always co-present (both NOT NULL in the picks table)
+		if memberPick.HomeScore != nil {
+			entry.Pick = &dtos.UserScorePickDto{
+				HomeScore: *memberPick.HomeScore,
+				AwayScore: *memberPick.AwayScore,
+			}
+		}
+		picks[index] = entry
+	}
+	return dtos.MatchMemberPicksDto{Match: match, Picks: picks}
 }
 
 func parseMatchFilters(r *http.Request) (domain.MatchFilters, error) {

--- a/internal/middlewares/errors.go
+++ b/internal/middlewares/errors.go
@@ -17,8 +17,8 @@ const (
 	codeForbidden      = "FORBIDDEN"
 
 	// 404 Not Found
-	codeBoardNotFound        = "BOARD_NOT_FOUND"
-	codeBoardMemberNotFound  = "BOARD_MEMBER_NOT_FOUND"
+	codeBoardNotFound       = "BOARD_NOT_FOUND"
+	codeBoardMemberNotFound = "BOARD_MEMBER_NOT_FOUND"
 
 	// 400 Bad Request
 	codeReturnToRequired   = "RETURN_TO_REQUIRED"

--- a/internal/repositories/competition_repository.go
+++ b/internal/repositories/competition_repository.go
@@ -226,6 +226,8 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 			WHERE bc.type = 'pickem'
 		),
 		match_ranked AS (
+			-- For 'pick' competitions, members who made a prediction rank above those who
+			-- didn't within a points tie (match_id IS NOT NULL gates it to single-match picks).
 			SELECT
 				cms.competition_id,
 				cms.user_id,
@@ -236,12 +238,14 @@ func (r *CompetitionRepository) GetBoardCompetitions(
 						cms.total_points     DESC,
 						cms.exact_hits       DESC,
 						cms.correct_outcomes DESC,
+						(CASE WHEN bc.match_id IS NOT NULL AND ump.match_id IS NULL THEN 1 ELSE 0 END) ASC,
 						bm.created_at ASC,
 						cms.user_id ASC
 				) AS rank
 			FROM competition_match_scores cms
 			INNER JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = cms.user_id
-			WHERE cms.competition_id IN (SELECT id FROM board_competitions)
+			INNER JOIN board_competitions bc ON bc.id = cms.competition_id
+			LEFT JOIN user_match_score_picks ump ON ump.user_id = cms.user_id AND ump.match_id = bc.match_id
 		),
 		awards_ranked AS (
 			SELECT
@@ -529,6 +533,49 @@ func (r *CompetitionRepository) GetGlobalCompetitions(
 	}
 
 	return pickemCompetition, matchCompetition, nil
+}
+
+// GetScopeMatchIDs returns the IDs of all matches in scope for a match-type competition,
+// applying the same stage + optional team filters used when seeding scores.
+func (r *CompetitionRepository) GetScopeMatchIDs(ctx context.Context, competitionID int64) ([]int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		SELECT m.id
+		FROM matches m
+		INNER JOIN competition_scope_stages css
+			ON css.competition_id = $1 AND css.stage = m.stage_code
+		WHERE (
+			NOT EXISTS (SELECT 1 FROM competition_scope_teams cst WHERE cst.competition_id = $1)
+			OR EXISTS (
+				SELECT 1 FROM competition_scope_teams cst
+				WHERE cst.competition_id = $1
+				  AND cst.team_fifa_code IN (m.home_team_fifa_code, m.away_team_fifa_code)
+			)
+		)
+		ORDER BY m.kickoff_at ASC`
+
+	rows, err := r.db.QueryContext(ctx, query, competitionID)
+	if err != nil {
+		return nil, handleDBError(err, resourceCompetition)
+	}
+	defer rows.Close()
+
+	matchIDs := []int64{}
+	for rows.Next() {
+		var matchID int64
+		if err := rows.Scan(&matchID); err != nil {
+			return nil, handleDBError(err, resourceCompetition)
+		}
+		matchIDs = append(matchIDs, matchID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, handleDBError(err, resourceCompetition)
+	}
+
+	return matchIDs, nil
 }
 
 // FindMatchCompetitionsByMatches returns competition IDs whose scope

--- a/internal/repositories/competition_score_repository.go
+++ b/internal/repositories/competition_score_repository.go
@@ -556,7 +556,7 @@ func (r *CompetitionScoreRepository) GetBoardCompetitionPreviews(
 
 	query := `
 		WITH bc AS (
-			SELECT id, type FROM competitions WHERE board_id = $1
+			SELECT id, type, match_id FROM competitions WHERE board_id = $1
 		),
 		pickem AS (
 			SELECT c.id AS competition_id, bm.user_id, agg.total_points,
@@ -591,14 +591,19 @@ func (r *CompetitionScoreRepository) GetBoardCompetitionPreviews(
 			WHERE c.type = 'awards'
 		),
 		matchpick AS (
+			-- For 'pick' competitions, members who made a prediction rank above those who
+			-- didn't within a points tie (match_id IS NOT NULL gates it to single-match picks).
 			SELECT cms.competition_id, cms.user_id, cms.total_points,
 				RANK() OVER (
 					PARTITION BY cms.competition_id
-					ORDER BY cms.total_points DESC, cms.exact_hits DESC, cms.correct_outcomes DESC, bm.created_at ASC, cms.user_id ASC
+					ORDER BY cms.total_points DESC, cms.exact_hits DESC, cms.correct_outcomes DESC,
+						(CASE WHEN c.match_id IS NOT NULL AND ump.match_id IS NULL THEN 1 ELSE 0 END) ASC,
+						bm.created_at ASC, cms.user_id ASC
 				) AS rank
 			FROM competition_match_scores cms
 			JOIN bc c ON c.id = cms.competition_id
 			JOIN board_members bm ON bm.board_id = $1 AND bm.user_id = cms.user_id
+			LEFT JOIN user_match_score_picks ump ON ump.user_id = cms.user_id AND ump.match_id = c.match_id
 			WHERE c.type IN ('match', 'pick')
 		),
 		unioned AS (
@@ -932,6 +937,7 @@ func (r *CompetitionScoreRepository) getMatchLeaderboard(
 						cms.total_points     DESC,
 						cms.exact_hits       DESC,
 						cms.correct_outcomes DESC,
+						(CASE WHEN comp.match_id IS NOT NULL AND ump.match_id IS NULL THEN 1 ELSE 0 END) ASC,
 						bm.created_at ASC,
 						cms.user_id ASC
 				) AS rank
@@ -939,6 +945,7 @@ func (r *CompetitionScoreRepository) getMatchLeaderboard(
 			INNER JOIN competitions comp ON comp.id = cms.competition_id
 			INNER JOIN users u           ON u.id = cms.user_id
 			INNER JOIN board_members bm  ON bm.board_id = comp.board_id AND bm.user_id = cms.user_id
+			LEFT JOIN user_match_score_picks ump ON ump.user_id = cms.user_id AND ump.match_id = comp.match_id
 			WHERE cms.competition_id = $1
 		),
 		filtered AS (

--- a/internal/repositories/match_score_pick_repository.go
+++ b/internal/repositories/match_score_pick_repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/lib/pq"
 )
 
 type MatchScorePickRepository struct {
@@ -101,6 +102,37 @@ func (r *MatchScorePickRepository) CountMatchScorePicksByUser(ctx context.Contex
 	return count, nil
 }
 
+func (r *MatchScorePickRepository) GetMatchScorePicksByUserAndMatches(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `SELECT
+		user_id,
+		match_id,
+		home_score,
+		away_score
+	FROM user_match_score_picks
+	WHERE user_id = $1 AND match_id = ANY($2)
+	ORDER BY match_id`
+
+	rows, err := r.db.QueryContext(ctx, query, userID, pq.Array(matchIDs))
+	if err != nil {
+		return nil, handleDBError(err, resourceMatchScorePick)
+	}
+	defer rows.Close()
+
+	picks := []*domain.UserMatchScorePick{}
+	for rows.Next() {
+		var pick domain.UserMatchScorePick
+		if err := rows.Scan(&pick.UserID, &pick.MatchID, &pick.HomeScore, &pick.AwayScore); err != nil {
+			return nil, handleDBError(err, resourceMatchScorePick)
+		}
+		picks = append(picks, &pick)
+	}
+
+	return picks, rows.Err()
+}
+
 func (r *MatchScorePickRepository) GetMatchScorePicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserMatchScorePick, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
@@ -129,4 +161,68 @@ func (r *MatchScorePickRepository) GetMatchScorePicksByMatch(ctx context.Context
 	}
 
 	return picks, rows.Err()
+}
+
+func (r *MatchScorePickRepository) GetBoardMembersMatchPicks(ctx context.Context, boardID, matchID int64) ([]*domain.BoardMemberMatchPick, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
+	defer cancel()
+
+	query := `
+		SELECT
+			bm.user_id,
+			u.username,
+			u.first_name,
+			u.last_name,
+			bm.role,
+			bm.created_at,
+			p.home_score,
+			p.away_score
+		FROM board_members bm
+		JOIN users u ON u.id = bm.user_id
+		LEFT JOIN user_match_score_picks p
+			ON p.user_id = bm.user_id AND p.match_id = $2
+		WHERE bm.board_id = $1
+		ORDER BY bm.created_at ASC`
+
+	rows, err := r.db.QueryContext(ctx, query, boardID, matchID)
+	if err != nil {
+		return nil, handleDBError(err, resourceMatchScorePick)
+	}
+	defer rows.Close()
+
+	memberPicks := []*domain.BoardMemberMatchPick{}
+	for rows.Next() {
+		var memberPick domain.BoardMemberMatchPick
+		var homeScore, awayScore sql.NullInt64
+
+		if err := rows.Scan(
+			&memberPick.Member.UserID,
+			&memberPick.Member.UserName,
+			&memberPick.Member.FirstName,
+			&memberPick.Member.LastName,
+			&memberPick.Member.Role,
+			&memberPick.Member.JoinedAt,
+			&homeScore,
+			&awayScore,
+		); err != nil {
+			return nil, handleDBError(err, resourceMatchScorePick)
+		}
+
+		if homeScore.Valid {
+			score := int(homeScore.Int64)
+			memberPick.HomeScore = &score
+		}
+		if awayScore.Valid {
+			score := int(awayScore.Int64)
+			memberPick.AwayScore = &score
+		}
+
+		memberPicks = append(memberPicks, &memberPick)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, handleDBError(err, resourceMatchScorePick)
+	}
+
+	return memberPicks, nil
 }

--- a/internal/services/match_score_pick_service.go
+++ b/internal/services/match_score_pick_service.go
@@ -10,20 +10,25 @@ import (
 type MatchScorePickServiceInterface interface {
 	GetMatchScorePicksByUser(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error)
 	SaveMatchScorePick(ctx context.Context, userID string, matchID int64, homeScore, awayScore int) error
+	GetMemberCompetitionPicks(ctx context.Context, boardID, competitionID int64, userID string) ([]*domain.Match, []*domain.UserMatchScorePick, error)
+	GetBoardMatchPicks(ctx context.Context, boardID, matchID int64) (*domain.Match, []*domain.BoardMemberMatchPick, error)
 }
 
 type MatchScorePickService struct {
 	matchScorePickRepository domain.MatchScorePickRepository
 	matchRepository          domain.MatchRepository
+	competitionRepository    domain.CompetitionRepository
 }
 
 func NewMatchScorePickService(
 	matchScorePickRepository domain.MatchScorePickRepository,
 	matchRepository domain.MatchRepository,
+	competitionRepository domain.CompetitionRepository,
 ) *MatchScorePickService {
 	return &MatchScorePickService{
 		matchScorePickRepository: matchScorePickRepository,
 		matchRepository:          matchRepository,
+		competitionRepository:    competitionRepository,
 	}
 }
 
@@ -54,6 +59,90 @@ func (s *MatchScorePickService) SaveMatchScorePick(ctx context.Context, userID s
 		HomeScore: homeScore,
 		AwayScore: awayScore,
 	})
+}
+
+func (s *MatchScorePickService) GetMemberCompetitionPicks(
+	ctx context.Context,
+	boardID, competitionID int64,
+	userID string,
+) ([]*domain.Match, []*domain.UserMatchScorePick, error) {
+	competition, err := s.competitionRepository.GetCompetitionByID(ctx, boardID, competitionID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var matchIDs []int64
+	switch competition.Type {
+	case domain.CompetitionTypePick:
+		if competition.PickMatchID == nil {
+			return nil, nil, domain.ErrCompetitionNotMatchBased
+		}
+		matchIDs = []int64{*competition.PickMatchID}
+	case domain.CompetitionTypeMatch:
+		matchIDs, err = s.competitionRepository.GetScopeMatchIDs(ctx, competitionID)
+		if err != nil {
+			return nil, nil, err
+		}
+	default:
+		return nil, nil, domain.ErrCompetitionNotMatchBased
+	}
+
+	if len(matchIDs) == 0 {
+		return []*domain.Match{}, []*domain.UserMatchScorePick{}, nil
+	}
+
+	matches, err := s.matchRepository.GetMatches(ctx, domain.MatchFilters{MatchIDs: matchIDs})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var lockedMatches []*domain.Match
+	for _, match := range matches {
+		if isMatchPickLocked(match) {
+			lockedMatches = append(lockedMatches, match)
+		}
+	}
+
+	if len(lockedMatches) == 0 {
+		return []*domain.Match{}, []*domain.UserMatchScorePick{}, nil
+	}
+
+	lockedIDs := make([]int64, len(lockedMatches))
+	for index, match := range lockedMatches {
+		lockedIDs[index] = match.ID
+	}
+
+	picks, err := s.matchScorePickRepository.GetMatchScorePicksByUserAndMatches(ctx, userID, lockedIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return lockedMatches, picks, nil
+}
+
+func (s *MatchScorePickService) GetBoardMatchPicks(
+	ctx context.Context,
+	boardID, matchID int64,
+) (*domain.Match, []*domain.BoardMemberMatchPick, error) {
+	matches, err := s.matchRepository.GetMatches(ctx, domain.MatchFilters{MatchIDs: []int64{matchID}})
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(matches) == 0 {
+		return nil, nil, domain.ErrMatchNotFound
+	}
+
+	match := matches[0]
+	if !isMatchPickLocked(match) {
+		return nil, nil, domain.ErrMatchPicksHidden
+	}
+
+	memberPicks, err := s.matchScorePickRepository.GetBoardMembersMatchPicks(ctx, boardID, matchID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return match, memberPicks, nil
 }
 
 func isMatchPickLocked(match *domain.Match) bool {

--- a/internal/services/match_score_pick_service_test.go
+++ b/internal/services/match_score_pick_service_test.go
@@ -1,0 +1,336 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMatchScorePickService(
+	pickRepo *mocks.MockMatchScorePickRepository,
+	matchRepo *mocks.MockMatchRepository,
+	competitionRepo *mocks.MockCompetitionRepository,
+) MatchScorePickServiceInterface {
+	return NewMatchScorePickService(pickRepo, matchRepo, competitionRepo)
+}
+
+func int64Ptr(value int64) *int64 { return &value }
+func intPtr(value int) *int       { return &value }
+
+func lockedMatch(id int64) *domain.Match {
+	return &domain.Match{
+		ID:        id,
+		Status:    domain.MatchStatusScheduled,
+		KickoffAt: time.Now().UTC().Add(-1 * time.Hour),
+	}
+}
+
+func unlockedMatch(id int64) *domain.Match {
+	return &domain.Match{
+		ID:        id,
+		Status:    domain.MatchStatusScheduled,
+		KickoffAt: time.Now().UTC().Add(1 * time.Hour),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetMemberCompetitionPicks
+// ---------------------------------------------------------------------------
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_PickTypeReturnsSingleLockedMatch(t *testing.T) {
+	t.Parallel()
+
+	match := lockedMatch(42)
+	pick := &domain.UserMatchScorePick{UserID: "user-1", MatchID: 42, HomeScore: 2, AwayScore: 1}
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:          competitionID,
+				BoardID:     boardID,
+				Type:        domain.CompetitionTypePick,
+				PickMatchID: int64Ptr(42),
+			}, nil
+		},
+	}
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{match}, nil
+		},
+	}
+	pickRepo := &mocks.MockMatchScorePickRepository{
+		GetMatchScorePicksByUserAndMatchesFunc: func(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error) {
+			return []*domain.UserMatchScorePick{pick}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(pickRepo, matchRepo, competitionRepo)
+
+	matches, picks, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, int64(42), matches[0].ID)
+	assert.Len(t, picks, 1)
+	assert.Equal(t, int64(42), picks[0].MatchID)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_MatchTypeReturnsOnlyLockedMatches(t *testing.T) {
+	t.Parallel()
+
+	locked := lockedMatch(10)
+	unlocked := unlockedMatch(11)
+	pick := &domain.UserMatchScorePick{UserID: "user-1", MatchID: 10, HomeScore: 1, AwayScore: 0}
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:      competitionID,
+				BoardID: boardID,
+				Type:    domain.CompetitionTypeMatch,
+			}, nil
+		},
+		GetScopeMatchIDsFunc: func(ctx context.Context, competitionID int64) ([]int64, error) {
+			return []int64{10, 11}, nil
+		},
+	}
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{locked, unlocked}, nil
+		},
+	}
+	pickRepo := &mocks.MockMatchScorePickRepository{
+		GetMatchScorePicksByUserAndMatchesFunc: func(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error) {
+			return []*domain.UserMatchScorePick{pick}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(pickRepo, matchRepo, competitionRepo)
+
+	matches, picks, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, int64(10), matches[0].ID)
+	assert.Len(t, picks, 1)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_UnlockedScopeMatchExcluded(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:      competitionID,
+				BoardID: boardID,
+				Type:    domain.CompetitionTypeMatch,
+			}, nil
+		},
+		GetScopeMatchIDsFunc: func(ctx context.Context, competitionID int64) ([]int64, error) {
+			return []int64{20}, nil
+		},
+	}
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{unlockedMatch(20)}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, matchRepo, competitionRepo)
+
+	matches, picks, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+	assert.Empty(t, picks)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_LockedMatchWithNoMemberPick(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:          competitionID,
+				BoardID:     boardID,
+				Type:        domain.CompetitionTypePick,
+				PickMatchID: int64Ptr(30),
+			}, nil
+		},
+	}
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{lockedMatch(30)}, nil
+		},
+	}
+	pickRepo := &mocks.MockMatchScorePickRepository{
+		GetMatchScorePicksByUserAndMatchesFunc: func(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error) {
+			return []*domain.UserMatchScorePick{}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(pickRepo, matchRepo, competitionRepo)
+
+	matches, picks, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, int64(30), matches[0].ID)
+	assert.Empty(t, picks)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_PickemType_ReturnsErrCompetitionNotMatchBased(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:      competitionID,
+				BoardID: boardID,
+				Type:    domain.CompetitionTypePickem,
+			}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, &mocks.MockMatchRepository{}, competitionRepo)
+
+	_, _, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.ErrorIs(t, err, domain.ErrCompetitionNotMatchBased)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_AwardsType_ReturnsErrCompetitionNotMatchBased(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:      competitionID,
+				BoardID: boardID,
+				Type:    domain.CompetitionTypeAwards,
+			}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, &mocks.MockMatchRepository{}, competitionRepo)
+
+	_, _, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.ErrorIs(t, err, domain.ErrCompetitionNotMatchBased)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_UnknownCompetition_PropagatesErrCompetitionNotFound(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return nil, domain.ErrCompetitionNotFound
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, &mocks.MockMatchRepository{}, competitionRepo)
+
+	_, _, err := service.GetMemberCompetitionPicks(context.Background(), 1, 99, "user-1")
+
+	require.ErrorIs(t, err, domain.ErrCompetitionNotFound)
+}
+
+func TestMatchScorePickService_GetMemberCompetitionPicks_PickTypeWithNilPickMatchID_ReturnsErrCompetitionNotMatchBased(t *testing.T) {
+	t.Parallel()
+
+	competitionRepo := &mocks.MockCompetitionRepository{
+		GetCompetitionByIDFunc: func(ctx context.Context, boardID, competitionID int64) (*domain.Competition, error) {
+			return &domain.Competition{
+				ID:          competitionID,
+				BoardID:     boardID,
+				Type:        domain.CompetitionTypePick,
+				PickMatchID: nil,
+			}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, &mocks.MockMatchRepository{}, competitionRepo)
+
+	_, _, err := service.GetMemberCompetitionPicks(context.Background(), 1, 10, "user-1")
+
+	require.ErrorIs(t, err, domain.ErrCompetitionNotMatchBased)
+}
+
+// ---------------------------------------------------------------------------
+// GetBoardMatchPicks
+// ---------------------------------------------------------------------------
+
+func TestMatchScorePickService_GetBoardMatchPicks_UnknownMatch_ReturnsErrMatchNotFound(t *testing.T) {
+	t.Parallel()
+
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, matchRepo, &mocks.MockCompetitionRepository{})
+
+	_, _, err := service.GetBoardMatchPicks(context.Background(), 1, 999)
+
+	require.ErrorIs(t, err, domain.ErrMatchNotFound)
+}
+
+func TestMatchScorePickService_GetBoardMatchPicks_FutureScheduledMatch_ReturnsErrMatchPicksHidden(t *testing.T) {
+	t.Parallel()
+
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{unlockedMatch(5)}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(&mocks.MockMatchScorePickRepository{}, matchRepo, &mocks.MockCompetitionRepository{})
+
+	_, _, err := service.GetBoardMatchPicks(context.Background(), 1, 5)
+
+	require.ErrorIs(t, err, domain.ErrMatchPicksHidden)
+}
+
+func TestMatchScorePickService_GetBoardMatchPicks_LockedMatch_ReturnsAllMembersWithNilScoreForNonPickers(t *testing.T) {
+	t.Parallel()
+
+	match := lockedMatch(7)
+	memberWithPick := domain.CompetitionLeaderboardMember{UserID: "user-1", UserName: "alice"}
+	memberWithoutPick := domain.CompetitionLeaderboardMember{UserID: "user-2", UserName: "bob"}
+
+	matchRepo := &mocks.MockMatchRepository{
+		GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+			return []*domain.Match{match}, nil
+		},
+	}
+	pickRepo := &mocks.MockMatchScorePickRepository{
+		GetBoardMembersMatchPicksFunc: func(ctx context.Context, boardID, matchID int64) ([]*domain.BoardMemberMatchPick, error) {
+			return []*domain.BoardMemberMatchPick{
+				{Member: memberWithPick, HomeScore: intPtr(2), AwayScore: intPtr(1)},
+				{Member: memberWithoutPick, HomeScore: nil, AwayScore: nil},
+			}, nil
+		},
+	}
+
+	service := newTestMatchScorePickService(pickRepo, matchRepo, &mocks.MockCompetitionRepository{})
+
+	returnedMatch, memberPicks, err := service.GetBoardMatchPicks(context.Background(), 1, 7)
+
+	require.NoError(t, err)
+	assert.Equal(t, match, returnedMatch)
+	assert.Len(t, memberPicks, 2)
+
+	assert.Equal(t, "user-1", memberPicks[0].Member.UserID)
+	assert.NotNil(t, memberPicks[0].HomeScore)
+	assert.NotNil(t, memberPicks[0].AwayScore)
+
+	assert.Equal(t, "user-2", memberPicks[1].Member.UserID)
+	assert.Nil(t, memberPicks[1].HomeScore)
+	assert.Nil(t, memberPicks[1].AwayScore)
+}

--- a/internal/test/mocks/competition_repository_mock.go
+++ b/internal/test/mocks/competition_repository_mock.go
@@ -13,6 +13,7 @@ type MockCompetitionRepository struct {
 	DeleteCompetitionFunc              func(ctx context.Context, boardID, competitionID int64) error
 	FindMatchCompetitionsByMatchesFunc func(ctx context.Context, matchIDs []int64) ([]int64, error)
 	GetGlobalCompetitionsFunc          func(ctx context.Context) (*domain.Competition, *domain.Competition, error)
+	GetScopeMatchIDsFunc               func(ctx context.Context, competitionID int64) ([]int64, error)
 }
 
 func (m *MockCompetitionRepository) CreateCompetition(ctx context.Context, competition *domain.Competition) error {
@@ -55,4 +56,11 @@ func (m *MockCompetitionRepository) GetGlobalCompetitions(ctx context.Context) (
 		return m.GetGlobalCompetitionsFunc(ctx)
 	}
 	panic("GetGlobalCompetitions called unexpectedly")
+}
+
+func (m *MockCompetitionRepository) GetScopeMatchIDs(ctx context.Context, competitionID int64) ([]int64, error) {
+	if m.GetScopeMatchIDsFunc != nil {
+		return m.GetScopeMatchIDsFunc(ctx, competitionID)
+	}
+	panic("GetScopeMatchIDs called unexpectedly")
 }

--- a/internal/test/mocks/match_score_pick_repository_mock.go
+++ b/internal/test/mocks/match_score_pick_repository_mock.go
@@ -7,10 +7,12 @@ import (
 )
 
 type MockMatchScorePickRepository struct {
-	UpsertMatchScorePickFunc       func(ctx context.Context, pick *domain.UserMatchScorePick) error
-	GetMatchScorePicksByUserFunc   func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error)
-	GetMatchScorePicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserMatchScorePick, error)
-	CountMatchScorePicksByUserFunc func(ctx context.Context, userID string) (int, error)
+	UpsertMatchScorePickFunc               func(ctx context.Context, pick *domain.UserMatchScorePick) error
+	GetMatchScorePicksByUserFunc           func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error)
+	GetMatchScorePicksByUserAndMatchesFunc func(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error)
+	GetMatchScorePicksByMatchFunc          func(ctx context.Context, matchID int64) ([]*domain.UserMatchScorePick, error)
+	CountMatchScorePicksByUserFunc         func(ctx context.Context, userID string) (int, error)
+	GetBoardMembersMatchPicksFunc          func(ctx context.Context, boardID, matchID int64) ([]*domain.BoardMemberMatchPick, error)
 }
 
 func (m *MockMatchScorePickRepository) UpsertMatchScorePick(ctx context.Context, pick *domain.UserMatchScorePick) error {
@@ -27,6 +29,13 @@ func (m *MockMatchScorePickRepository) GetMatchScorePicksByUser(ctx context.Cont
 	panic("GetMatchScorePicksByUser called unexpectedly")
 }
 
+func (m *MockMatchScorePickRepository) GetMatchScorePicksByUserAndMatches(ctx context.Context, userID string, matchIDs []int64) ([]*domain.UserMatchScorePick, error) {
+	if m.GetMatchScorePicksByUserAndMatchesFunc != nil {
+		return m.GetMatchScorePicksByUserAndMatchesFunc(ctx, userID, matchIDs)
+	}
+	panic("GetMatchScorePicksByUserAndMatches called unexpectedly")
+}
+
 func (m *MockMatchScorePickRepository) GetMatchScorePicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserMatchScorePick, error) {
 	if m.GetMatchScorePicksByMatchFunc != nil {
 		return m.GetMatchScorePicksByMatchFunc(ctx, matchID)
@@ -39,4 +48,11 @@ func (m *MockMatchScorePickRepository) CountMatchScorePicksByUser(ctx context.Co
 		return m.CountMatchScorePicksByUserFunc(ctx, userID)
 	}
 	panic("CountMatchScorePicksByUser called unexpectedly")
+}
+
+func (m *MockMatchScorePickRepository) GetBoardMembersMatchPicks(ctx context.Context, boardID, matchID int64) ([]*domain.BoardMemberMatchPick, error) {
+	if m.GetBoardMembersMatchPicksFunc != nil {
+		return m.GetBoardMembersMatchPicksFunc(ctx, boardID, matchID)
+	}
+	panic("GetBoardMembersMatchPicks called unexpectedly")
 }

--- a/internal/test/mocks/match_score_pick_service_mock.go
+++ b/internal/test/mocks/match_score_pick_service_mock.go
@@ -1,0 +1,42 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockMatchScorePickService struct {
+	GetMatchScorePicksByUserFunc  func(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error)
+	SaveMatchScorePickFunc        func(ctx context.Context, userID string, matchID int64, homeScore, awayScore int) error
+	GetMemberCompetitionPicksFunc func(ctx context.Context, boardID, competitionID int64, userID string) ([]*domain.Match, []*domain.UserMatchScorePick, error)
+	GetBoardMatchPicksFunc        func(ctx context.Context, boardID, matchID int64) (*domain.Match, []*domain.BoardMemberMatchPick, error)
+}
+
+func (m *MockMatchScorePickService) GetMatchScorePicksByUser(ctx context.Context, userID string) ([]*domain.UserMatchScorePick, error) {
+	if m.GetMatchScorePicksByUserFunc != nil {
+		return m.GetMatchScorePicksByUserFunc(ctx, userID)
+	}
+	panic("GetMatchScorePicksByUser called unexpectedly")
+}
+
+func (m *MockMatchScorePickService) SaveMatchScorePick(ctx context.Context, userID string, matchID int64, homeScore, awayScore int) error {
+	if m.SaveMatchScorePickFunc != nil {
+		return m.SaveMatchScorePickFunc(ctx, userID, matchID, homeScore, awayScore)
+	}
+	panic("SaveMatchScorePick called unexpectedly")
+}
+
+func (m *MockMatchScorePickService) GetMemberCompetitionPicks(ctx context.Context, boardID, competitionID int64, userID string) ([]*domain.Match, []*domain.UserMatchScorePick, error) {
+	if m.GetMemberCompetitionPicksFunc != nil {
+		return m.GetMemberCompetitionPicksFunc(ctx, boardID, competitionID, userID)
+	}
+	panic("GetMemberCompetitionPicks called unexpectedly")
+}
+
+func (m *MockMatchScorePickService) GetBoardMatchPicks(ctx context.Context, boardID, matchID int64) (*domain.Match, []*domain.BoardMemberMatchPick, error) {
+	if m.GetBoardMatchPicksFunc != nil {
+		return m.GetBoardMatchPicksFunc(ctx, boardID, matchID)
+	}
+	panic("GetBoardMatchPicks called unexpectedly")
+}

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -7,19 +7,19 @@ import (
 )
 
 type MockPickemRepository struct {
-	UpsertGroupPicksFunc        func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
-	GetGroupPicksFunc           func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
-	GetGroupPicksByGroupFunc    func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
-	UpsertBestThirdsFunc        func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
-	GetBestThirdPicksFunc       func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
+	UpsertGroupPicksFunc         func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	GetGroupPicksFunc            func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
+	GetGroupPicksByGroupFunc     func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
+	UpsertBestThirdsFunc         func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
+	GetBestThirdPicksFunc        func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
 	GetBestThirdPicksByTeamsFunc func(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error)
-	UpsertBracketPicksFunc      func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
-	GetBracketPicksFunc         func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
-	GetBracketPicksByMatchFunc  func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
-	GetChampionPickFunc         func(ctx context.Context, userID string) (*string, error)
-	GetUserProgressCountsFunc   func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
-	GetLockedGroupCodesFunc     func(ctx context.Context, userID string) ([]string, error)
-	SetGroupLocksFunc           func(ctx context.Context, userID string, lockedCodes []string) error
+	UpsertBracketPicksFunc       func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
+	GetBracketPicksFunc          func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
+	GetBracketPicksByMatchFunc   func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
+	GetChampionPickFunc          func(ctx context.Context, userID string) (*string, error)
+	GetUserProgressCountsFunc    func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
+	GetLockedGroupCodesFunc      func(ctx context.Context, userID string) ([]string, error)
+	SetGroupLocksFunc            func(ctx context.Context, userID string, lockedCodes []string) error
 }
 
 func (m *MockPickemRepository) UpsertGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick) error {


### PR DESCRIPTION
## Related issue

Closes #112

## What changed

- New read endpoints powering the reveal: `GET /boards/{id}/matches/{matchId}/picks` (whole board's picks for a match) and `GET /boards/{id}/competitions/{cid}/members/{uid}/picks` (a member's picks across a competition) — both gated to locked matches (403 before kickoff).
- Single-match `pick` competition ranking now places members who made a pick above non-predictors within a points tie — applied consistently to the viewer rank, list/preview, and full leaderboard queries.
- Seeded single-match `pick` competition templates so boards get polla-style competitions.

## How to test

- [ ] `go build ./... && go test ./...` pass.
- [ ] `GET /boards/{id}/matches/{matchId}/picks` → 403 before kickoff, board members' picks after.
- [ ] `GET /boards/{id}/competitions/{cid}/members/{uid}/picks` → only that member's locked-match picks.
- [ ] In a pick competition tie, a member who picked outranks one who didn't — same order in viewer rank, list preview, and leaderboard.
- [ ] Re-seed → boards get single-match pick competitions.