### PR TITLE
feat: deduplicate concurrent refresh-token rotations via encrypted replay cache

### DIFF
--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fifawcp/api/internal/infrastructure/auth"
 	"github.com/fifawcp/api/internal/infrastructure/cache"
 	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/infrastructure/crypto"
 	"github.com/fifawcp/api/internal/infrastructure/db"
 	"github.com/fifawcp/api/internal/infrastructure/football"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
@@ -49,6 +50,7 @@ type Container struct {
 	syncMatchResultsJob  *jobs.SyncMatchResultsJob
 	GoogleOauthConfig    domain.OAuth2Client
 	OIDCIdentityVerifier domain.IDTokenVerifier
+	refreshReplayCipher  *crypto.Cipher
 
 	// repositories
 	userRepository             domain.UserRepository
@@ -78,9 +80,10 @@ type Container struct {
 	globalMatchCompetition  *domain.Competition
 
 	// storages
-	otpStorage        *storage.OTPStorage
-	userStorage       *storage.UserStorage
-	oauthStateStorage *storage.OAuthStorage
+	otpStorage           *storage.OTPStorage
+	userStorage          *storage.UserStorage
+	oauthStateStorage    *storage.OAuthStorage
+	refreshReplayStorage *storage.RefreshReplayStorage
 
 	// services
 	authService               services.AuthServiceInterface
@@ -185,6 +188,12 @@ func (c *Container) initCoreDeps(cfg *config.Config) error {
 	c.mailer = mailer.NewResendMailer(cfg)
 	c.Scheduler = scheduler.NewCronScheduler(c.Logger)
 
+	refreshReplayCipher, err := crypto.NewCipher(crypto.DeriveKey(cfg.JWT.Secret, "refresh-replay"))
+	if err != nil {
+		return fmt.Errorf("creating refresh replay cipher: %w", err)
+	}
+	c.refreshReplayCipher = refreshReplayCipher
+
 	googleOIDCProvider, err := oauth.NewOIDCProvider(cfg.Auth.GoogleOAuth.Issuer)
 	if err != nil {
 		c.Logger.Error(
@@ -250,12 +259,13 @@ func (c *Container) initStorages() {
 	c.otpStorage = storage.NewOTPStorage(c.redis, c.Config)
 	c.userStorage = storage.NewUserStorage(c.redis, c.Config)
 	c.oauthStateStorage = storage.NewOAuthStorage(c.redis, c.Config)
+	c.refreshReplayStorage = storage.NewRefreshReplayStorage(c.redis, c.Config, c.refreshReplayCipher)
 }
 
 func (c *Container) initServices() {
 	c.authService = services.NewAuthService(
 		c.userRepository, c.sessionRepository, c.refreshTokenRepository,
-		c.otpStorage, c.Logger, c.Config, c.Authenticator, c.mailer,
+		c.otpStorage, c.refreshReplayStorage, c.Logger, c.Config, c.Authenticator, c.mailer,
 	)
 	c.UserService = services.NewUserService(c.userRepository, c.userStorage, c.Logger)
 	c.boardService = services.NewBoardService(c.boardRepository, c.competitionRepository)

--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -21,3 +21,20 @@ type RefreshTokenRepository interface {
 	RotateRefreshToken(ctx context.Context, oldTokenHash string, newToken *RefreshToken) error
 	DeleteRotatedBefore(ctx context.Context, cutoff time.Time) (int64, error)
 }
+
+// IssuedTokens is the access/refresh pair a refresh hands back, cached briefly so
+// concurrent refreshes of the same token converge on one successor.
+type IssuedTokens struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// RefreshReplayStorage deduplicates concurrent refreshes of the same token.
+type RefreshReplayStorage interface {
+	// Claim reserves oldTokenHash for the caller. won=true means no successor was cached yet
+	// (caller should rotate); won=false returns the successor a concurrent refresh issued.
+	Claim(ctx context.Context, oldTokenHash string, tokens *IssuedTokens, ttl time.Duration) (won bool, existing *IssuedTokens, err error)
+	// Release drops a claim so a failed rotation doesn't strand losers on an unpersisted successor.
+	Release(ctx context.Context, oldTokenHash string) error
+}

--- a/internal/infrastructure/crypto/cipher.go
+++ b/internal/infrastructure/crypto/cipher.go
@@ -1,0 +1,59 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+)
+
+// Cipher does authenticated symmetric encryption (AES-256-GCM) for secrets that must be
+// recoverable in plaintext, unlike the one-way hashing used for tokens at rest.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// DeriveKey turns a shared secret into a 32-byte AES-256 key bound to a context label, so
+// the same secret yields independent keys for different uses.
+func DeriveKey(secret, context string) []byte {
+	sum := sha256.Sum256([]byte(context + ":" + secret))
+	return sum[:]
+}
+
+func NewCipher(key []byte) (*Cipher, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// Encrypt returns base64(nonce || ciphertext||tag).
+func (c *Cipher) Encrypt(plaintext []byte) (string, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := c.aead.Seal(nonce, nonce, plaintext, nil)
+	return base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+func (c *Cipher) Decrypt(ciphertext string) ([]byte, error) {
+	sealed, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := c.aead.NonceSize()
+	if len(sealed) < nonceSize {
+		return nil, errors.New("ciphertext too short")
+	}
+	nonce, body := sealed[:nonceSize], sealed[nonceSize:]
+	return c.aead.Open(nil, nonce, body, nil)
+}

--- a/internal/infrastructure/crypto/cipher_test.go
+++ b/internal/infrastructure/crypto/cipher_test.go
@@ -1,0 +1,71 @@
+package crypto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCipher(t *testing.T, secret string) *Cipher {
+	t.Helper()
+	c, err := NewCipher(DeriveKey(secret, "test"))
+	require.NoError(t, err)
+	return c
+}
+
+func TestCipher_EncryptDecryptRoundTrip(t *testing.T) {
+	c := newTestCipher(t, "super-secret")
+	plaintext := []byte(`{"refresh_token":"rt_abc123"}`)
+
+	ciphertext, err := c.Encrypt(plaintext)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(ciphertext, "rt_abc123"), "ciphertext must not leak plaintext")
+
+	decrypted, err := c.Decrypt(ciphertext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestCipher_DecryptWithWrongKeyFails(t *testing.T) {
+	a := newTestCipher(t, "secret-a")
+	b := newTestCipher(t, "secret-b")
+
+	ciphertext, err := a.Encrypt([]byte("payload"))
+	require.NoError(t, err)
+
+	_, err = b.Decrypt(ciphertext)
+	assert.Error(t, err, "a different key must not decrypt")
+}
+
+func TestCipher_DecryptTamperedCiphertextFails(t *testing.T) {
+	c := newTestCipher(t, "secret")
+
+	ciphertext, err := c.Encrypt([]byte("payload"))
+	require.NoError(t, err)
+
+	_, err = c.Decrypt(corruptFirstChar(ciphertext))
+	assert.Error(t, err, "tampered ciphertext must fail authentication")
+}
+
+func TestCipher_EncryptIsNonDeterministic(t *testing.T) {
+	c := newTestCipher(t, "secret")
+
+	first, err := c.Encrypt([]byte("payload"))
+	require.NoError(t, err)
+	second, err := c.Encrypt([]byte("payload"))
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second, "each encryption must use a fresh nonce")
+}
+
+func corruptFirstChar(s string) string {
+	b := []byte(s)
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	return string(b)
+}

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -34,6 +34,7 @@ type AuthService struct {
 	sessionRepository      domain.SessionRepository
 	refreshTokenRepository domain.RefreshTokenRepository
 	otpStorage             domain.OTPStorage
+	refreshReplayStorage   domain.RefreshReplayStorage
 	cfg                    *config.Config
 	logger                 logging.Logger
 	authenticator          auth.Authenticator
@@ -45,6 +46,7 @@ func NewAuthService(
 	sessionRepository domain.SessionRepository,
 	refreshTokenRepository domain.RefreshTokenRepository,
 	otpStorage domain.OTPStorage,
+	refreshReplayStorage domain.RefreshReplayStorage,
 	logger logging.Logger,
 	cfg *config.Config,
 	authenticator auth.Authenticator,
@@ -55,6 +57,7 @@ func NewAuthService(
 		sessionRepository:      sessionRepository,
 		refreshTokenRepository: refreshTokenRepository,
 		otpStorage:             otpStorage,
+		refreshReplayStorage:   refreshReplayStorage,
 		cfg:                    cfg,
 		logger:                 logger,
 		authenticator:          authenticator,
@@ -215,16 +218,38 @@ func (s *AuthService) RefreshToken(
 		return nil, domain.ErrRefreshTokenInvalidOrExpired
 	}
 
-	// Generate access token
 	accessTokenResult, err := s.authenticator.GenerateToken(refreshToken.UserID, auth.AccessTokenType)
 	if err != nil {
 		return nil, err
 	}
 
-	// Generate refresh token
 	refreshTokenResult, err := s.authenticator.GenerateToken(refreshToken.UserID, auth.RefreshTokenType)
 	if err != nil {
 		return nil, err
+	}
+
+	candidate := &domain.IssuedTokens{
+		AccessToken:  accessTokenResult.Token,
+		RefreshToken: refreshTokenResult.Token,
+		ExpiresAt:    refreshTokenResult.ExpiresAt,
+	}
+
+	// Collapse concurrent refreshes of one token onto a single successor: the winner rotates,
+	// losers return the token it issued. Otherwise each mints its own and the orphans log the user out.
+	won, existing, err := s.refreshReplayStorage.Claim(ctx, tokenHash, candidate, s.cfg.JWT.RefreshGraceWindow)
+	if err != nil {
+		// Fail open: a Redis blip must not block refresh (that would log everyone out). We
+		// rotate without dedup for this request only.
+		s.logger.Warn("refresh replay claim failed; rotating without dedup", logging.Error, err.Error())
+		won = true
+	}
+	if !won {
+		s.logRefreshOutcome(ctx, "deduped", tokenHash, refreshToken)
+		return &dtos.AuthData{
+			AccessToken:  existing.AccessToken,
+			RefreshToken: existing.RefreshToken,
+			ExpiresAt:    existing.ExpiresAt,
+		}, nil
 	}
 
 	// Slide the session expiry forward (bounded by SessionMaxLifetime) before rotating,
@@ -237,6 +262,7 @@ func (s *AuthService) RefreshToken(
 		s.cfg.Auth.SessionMaxLifetime,
 	)
 	if err != nil {
+		s.refreshReplayStorage.Release(ctx, tokenHash)
 		return nil, err
 	}
 
@@ -245,22 +271,22 @@ func (s *AuthService) RefreshToken(
 		refreshTokenExpiresAt = sessionExpiresAt
 	}
 
-	// Rotate refresh token
 	if err := s.refreshTokenRepository.RotateRefreshToken(ctx, refreshToken.TokenHash, &domain.RefreshToken{
 		UserID:    refreshToken.UserID,
 		SessionID: refreshToken.SessionID,
 		TokenHash: hashToken(refreshTokenResult.Token),
 		ExpiresAt: refreshTokenExpiresAt,
 	}); err != nil {
+		s.refreshReplayStorage.Release(ctx, tokenHash)
 		return nil, err
 	}
 
 	s.logRefreshOutcome(ctx, "success", tokenHash, refreshToken)
 
 	return &dtos.AuthData{
-		AccessToken:  accessTokenResult.Token,
-		RefreshToken: refreshTokenResult.Token,
-		ExpiresAt:    refreshTokenResult.ExpiresAt,
+		AccessToken:  candidate.AccessToken,
+		RefreshToken: candidate.RefreshToken,
+		ExpiresAt:    candidate.ExpiresAt,
 	}, nil
 }
 
@@ -292,8 +318,8 @@ func (s *AuthService) logRefreshOutcome(ctx context.Context, outcome, tokenHash 
 		}
 	}
 
-	// rotated_past_grace is the real anomaly (race lost past the window / reuse);
-	// success and the benign not_found_or_expired stay at info to avoid warn noise.
+	// rotated_past_grace is the real anomaly (race lost past the window / reuse); every
+	// other outcome (success, deduped, not_found_or_expired) is benign and stays at info.
 	if outcome == "rotated_past_grace" {
 		s.logger.Warn("refresh outcome", fields...)
 	} else {

--- a/internal/services/auth_service_test.go
+++ b/internal/services/auth_service_test.go
@@ -26,6 +26,7 @@ func newTestAuthService(
 	logger *mocks.MockLogger,
 	authenticator *mocks.MockAuthenticator,
 	mailer *mocks.MockMailer,
+	replay ...*mocks.MockRefreshReplayStorage,
 ) AuthServiceInterface {
 	cfg := &config.Config{
 		Env: "testing",
@@ -41,7 +42,21 @@ func newTestAuthService(
 		},
 	}
 
-	return NewAuthService(ur, sr, rtr, os, logger, cfg, authenticator, mailer)
+	// Default: the caller wins the claim and proceeds to rotate. Tests exercising the
+	// dedup path pass their own replay mock.
+	rrs := &mocks.MockRefreshReplayStorage{
+		ClaimFunc: func(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error) {
+			return true, nil, nil
+		},
+		ReleaseFunc: func(ctx context.Context, oldTokenHash string) error {
+			return nil
+		},
+	}
+	if len(replay) > 0 {
+		rrs = replay[0]
+	}
+
+	return NewAuthService(ur, sr, rtr, os, rrs, logger, cfg, authenticator, mailer)
 }
 
 // ---------------------------------------------------------------------------
@@ -1183,6 +1198,150 @@ func TestAuthService_RefreshToken(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.NotEmpty(t, result.AccessToken)
 		assert.NotEmpty(t, result.RefreshToken)
+	})
+
+	t.Run("returns the already-issued successor without rotating when a concurrent refresh won the claim", func(t *testing.T) {
+		t.Parallel()
+
+		userID := gofakeit.UUID()
+		sessionID := gofakeit.UUID()
+		cached := &domain.IssuedTokens{
+			AccessToken:  "cached_access",
+			RefreshToken: "cached_refresh",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		}
+
+		rotateCalled := false
+		rtr := &mocks.MockRefreshTokenRepository{
+			GetRefreshTokenByTokenHashFunc: func(ctx context.Context, hash string) (*domain.RefreshToken, error) {
+				return &domain.RefreshToken{UserID: userID, SessionID: sessionID}, nil
+			},
+			RotateRefreshTokenFunc: func(ctx context.Context, oldHash string, newToken *domain.RefreshToken) error {
+				rotateCalled = true
+				return nil
+			},
+		}
+
+		// Present so an unimplemented dedup path fails on assertions rather than nil-panicking.
+		sr := &mocks.MockSessionRepository{
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
+		}
+
+		authenticator := &mocks.MockAuthenticator{
+			GenerateTokenFunc: func(uid string, tokenType auth.TokenType) (*auth.TokenResult, error) {
+				return &auth.TokenResult{Token: "fresh_" + string(tokenType), ExpiresAt: time.Now().Add(time.Hour)}, nil
+			},
+		}
+
+		replay := &mocks.MockRefreshReplayStorage{
+			ClaimFunc: func(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error) {
+				return false, cached, nil
+			},
+		}
+
+		service := newTestAuthService(nil, sr, rtr, nil, &mocks.MockLogger{}, authenticator, nil, replay)
+
+		result, err := service.RefreshToken(context.Background(), "token")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "cached_access", result.AccessToken)
+		assert.Equal(t, "cached_refresh", result.RefreshToken)
+		assert.False(t, rotateCalled, "the caller that lost the claim must not rotate the token")
+	})
+
+	t.Run("releases the claim when rotation fails so concurrent refreshes are not stranded", func(t *testing.T) {
+		t.Parallel()
+
+		userID := gofakeit.UUID()
+		sessionID := gofakeit.UUID()
+
+		rtr := &mocks.MockRefreshTokenRepository{
+			GetRefreshTokenByTokenHashFunc: func(ctx context.Context, hash string) (*domain.RefreshToken, error) {
+				return &domain.RefreshToken{UserID: userID, SessionID: sessionID}, nil
+			},
+			RotateRefreshTokenFunc: func(ctx context.Context, oldHash string, newToken *domain.RefreshToken) error {
+				return errors.New("db down")
+			},
+		}
+
+		sr := &mocks.MockSessionRepository{
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
+		}
+
+		authenticator := &mocks.MockAuthenticator{
+			GenerateTokenFunc: func(uid string, tokenType auth.TokenType) (*auth.TokenResult, error) {
+				return &auth.TokenResult{Token: "fresh_" + string(tokenType), ExpiresAt: time.Now().Add(time.Hour)}, nil
+			},
+		}
+
+		releasedHash := ""
+		replay := &mocks.MockRefreshReplayStorage{
+			ClaimFunc: func(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error) {
+				return true, nil, nil
+			},
+			ReleaseFunc: func(ctx context.Context, oldTokenHash string) error {
+				releasedHash = oldTokenHash
+				return nil
+			},
+		}
+
+		service := newTestAuthService(nil, sr, rtr, nil, &mocks.MockLogger{}, authenticator, nil, replay)
+
+		result, err := service.RefreshToken(context.Background(), "token")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, hashToken("token"), releasedHash, "a failed rotation must release the claim")
+	})
+
+	t.Run("falls open and rotates when the replay claim errors so a Redis blip does not block refresh", func(t *testing.T) {
+		t.Parallel()
+
+		userID := gofakeit.UUID()
+		sessionID := gofakeit.UUID()
+
+		rotateCalled := false
+		rtr := &mocks.MockRefreshTokenRepository{
+			GetRefreshTokenByTokenHashFunc: func(ctx context.Context, hash string) (*domain.RefreshToken, error) {
+				return &domain.RefreshToken{UserID: userID, SessionID: sessionID}, nil
+			},
+			RotateRefreshTokenFunc: func(ctx context.Context, oldHash string, newToken *domain.RefreshToken) error {
+				rotateCalled = true
+				return nil
+			},
+		}
+
+		sr := &mocks.MockSessionRepository{
+			UpdateLastUsedAtFunc: func(ctx context.Context, id string, slideTo time.Time, maxLifetime time.Duration) (time.Time, error) {
+				return slideTo, nil
+			},
+		}
+
+		authenticator := &mocks.MockAuthenticator{
+			GenerateTokenFunc: func(uid string, tokenType auth.TokenType) (*auth.TokenResult, error) {
+				return &auth.TokenResult{Token: "new_" + string(tokenType), ExpiresAt: time.Now().Add(time.Hour)}, nil
+			},
+		}
+
+		replay := &mocks.MockRefreshReplayStorage{
+			ClaimFunc: func(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error) {
+				return false, nil, errors.New("redis down")
+			},
+		}
+
+		service := newTestAuthService(nil, sr, rtr, nil, &mocks.MockLogger{}, authenticator, nil, replay)
+
+		result, err := service.RefreshToken(context.Background(), "token")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotEmpty(t, result.AccessToken)
+		assert.True(t, rotateCalled, "fail-open: a claim error must not block the rotation")
 	})
 
 	t.Run("succeeds for an already-rotated token within the grace window", func(t *testing.T) {

--- a/internal/storage/refresh_replay_storage.go
+++ b/internal/storage/refresh_replay_storage.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/infrastructure/crypto"
+	"github.com/redis/go-redis/v9"
+)
+
+// RefreshReplayStorage caches the token pair issued for a just-rotated refresh token,
+// keyed by the old token's hash, so concurrent refreshes converge on one successor. The
+// payload is encrypted so raw tokens never sit in Redis in plaintext.
+type RefreshReplayStorage struct {
+	redis  *redis.Client
+	cfg    *config.Config
+	cipher *crypto.Cipher
+}
+
+func NewRefreshReplayStorage(
+	redis *redis.Client,
+	cfg *config.Config,
+	cipher *crypto.Cipher,
+) *RefreshReplayStorage {
+	return &RefreshReplayStorage{
+		redis:  redis,
+		cfg:    cfg,
+		cipher: cipher,
+	}
+}
+
+func (s *RefreshReplayStorage) Claim(
+	ctx context.Context,
+	oldTokenHash string,
+	tokens *domain.IssuedTokens,
+	ttl time.Duration,
+) (bool, *domain.IssuedTokens, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.cfg.Redis.QueryTimeout)
+	defer cancel()
+
+	payload, err := json.Marshal(tokens)
+	if err != nil {
+		return false, nil, err
+	}
+
+	ciphertext, err := s.cipher.Encrypt(payload)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// SET NX GET claims the slot and returns any successor a concurrent refresh already
+	// cached, atomically in one round trip (Redis 7.0+). redis.Nil means we won.
+	prev, err := s.redis.SetArgs(ctx, s.createKey(oldTokenHash), ciphertext, redis.SetArgs{
+		Mode: "NX",
+		TTL:  ttl,
+		Get:  true,
+	}).Result()
+	if err == redis.Nil {
+		return true, nil, nil
+	}
+	if err != nil {
+		return false, nil, err
+	}
+
+	plaintext, err := s.cipher.Decrypt(prev)
+	if err != nil {
+		return false, nil, err
+	}
+
+	var existing domain.IssuedTokens
+	if err := json.Unmarshal(plaintext, &existing); err != nil {
+		return false, nil, err
+	}
+
+	return false, &existing, nil
+}
+
+func (s *RefreshReplayStorage) Release(ctx context.Context, oldTokenHash string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.cfg.Redis.QueryTimeout)
+	defer cancel()
+
+	return s.redis.Del(ctx, s.createKey(oldTokenHash)).Err()
+}
+
+func (s *RefreshReplayStorage) createKey(oldTokenHash string) string {
+	return fmt.Sprintf("refresh:replay:%s", oldTokenHash)
+}

--- a/internal/test/mocks/refresh_replay_storage_mock.go
+++ b/internal/test/mocks/refresh_replay_storage_mock.go
@@ -1,0 +1,27 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/fifawcp/api/internal/domain"
+)
+
+type MockRefreshReplayStorage struct {
+	ClaimFunc   func(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error)
+	ReleaseFunc func(ctx context.Context, oldTokenHash string) error
+}
+
+func (m *MockRefreshReplayStorage) Claim(ctx context.Context, oldTokenHash string, tokens *domain.IssuedTokens, ttl time.Duration) (bool, *domain.IssuedTokens, error) {
+	if m.ClaimFunc != nil {
+		return m.ClaimFunc(ctx, oldTokenHash, tokens, ttl)
+	}
+	panic("Claim called unexpectedly")
+}
+
+func (m *MockRefreshReplayStorage) Release(ctx context.Context, oldTokenHash string) error {
+	if m.ReleaseFunc != nil {
+		return m.ReleaseFunc(ctx, oldTokenHash)
+	}
+	panic("Release called unexpectedly")
+}


### PR DESCRIPTION
## Related issue

Closes #122

## What changed

- Concurrent refreshes of the same token now converge on one successor via a Redis replay cache (atomic `SET NX GET`), eliminating the orphaned tokens that caused spurious logouts.
- Only the first caller rotates; the rest return the cached successor (new `deduped` log outcome). Failed rotations release the claim.
- Replay payload is AES-256-GCM encrypted (new `internal/infrastructure/crypto`), so raw tokens never sit in Redis in plaintext.
- `Claim` errors fail **open** — rotate without dedup — so a Redis blip can't log everyone out.

## How to test

- [ ] Fire several concurrent `POST /api/auth/token/refresh` with the same refresh cookie → all return 200 with the same new token, not 401.
- [ ] Logs show one `success` + `deduped` outcomes for that burst, no `rotated_past_grace`.
- [ ] Inspect Redis `refresh:replay:*` values → ciphertext, not readable JSON.
- [ ] Stop Redis, then refresh → still succeeds (fails open).
- [ ] `make test-unit` passes (new crypto + RefreshToken tests).