### PR TITLE
feat: set-based bracket scoring (credit advancers regardless of slot)

### DIFF
--- a/internal/domain/pickem.go
+++ b/internal/domain/pickem.go
@@ -78,14 +78,10 @@ type PickemRepository interface {
 	GetBestThirdPicksByTeams(ctx context.Context, teamFifaCodes []string) ([]*UserBestThirdPick, error) // for ScoreBestThirds
 	UpsertBracketPicks(ctx context.Context, userID string, picks []*UserBracketPick) error
 	GetBracketPicks(ctx context.Context, userID string) ([]*UserBracketPick, error)
-	GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*UserBracketPick, error) // for scoring
+	GetBracketPickUserIDsByTeamAndStage(ctx context.Context, teamFifaCode string, stage MatchStageCode) ([]string, error)
 	GetChampionPick(ctx context.Context, userID string) (*string, error)
-	// GetChampionPickCounts returns the most-picked champions (final-match winner
-	// picks) across all users, with counts + percent, ordered desc, capped at limit.
 	GetChampionPickCounts(ctx context.Context, limit int) ([]*TitleFavorite, error)
 	GetUserProgressCounts(ctx context.Context, userID string) (PickemProgressCounts, error)
 	GetLockedGroupCodes(ctx context.Context, userID string) ([]string, error)
-	// SetGroupLocks replaces the user's set of locked groups with exactly lockedCodes
-	// (groups not listed are unlocked). Lock state is sent declaratively with each group save.
 	SetGroupLocks(ctx context.Context, userID string, lockedCodes []string) error
 }

--- a/internal/repositories/pickem_repository.go
+++ b/internal/repositories/pickem_repository.go
@@ -476,31 +476,30 @@ func (r *PickemRepository) SetGroupLocks(ctx context.Context, userID string, loc
 	return tx.Commit()
 }
 
-func (r *PickemRepository) GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error) {
+func (r *PickemRepository) GetBracketPickUserIDsByTeamAndStage(ctx context.Context, teamFifaCode string, stage domain.MatchStageCode) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.DB.QueryTimeout)
 	defer cancel()
 
-	query := `SELECT
-		user_id,
-		match_id,
-		team_fifa_code
-	FROM user_bracket_picks WHERE match_id = $1`
+	query := `SELECT DISTINCT bp.user_id
+		FROM user_bracket_picks bp
+		INNER JOIN matches m ON m.id = bp.match_id
+		WHERE bp.team_fifa_code = $1 AND m.stage_code = $2`
 
-	rows, err := r.db.QueryContext(ctx, query, matchID)
+	rows, err := r.db.QueryContext(ctx, query, teamFifaCode, string(stage))
 	if err != nil {
 		return nil, handleDBError(err, resourcePickem)
 	}
 	defer rows.Close()
 
-	picks := []*domain.UserBracketPick{}
+	userIDs := []string{}
 	for rows.Next() {
-		var p domain.UserBracketPick
-		if err := rows.Scan(&p.UserID, &p.MatchID, &p.TeamFifaCode); err != nil {
+		var userID string
+		if err := rows.Scan(&userID); err != nil {
 			return nil, handleDBError(err, resourcePickem)
 		}
 
-		picks = append(picks, &p)
+		userIDs = append(userIDs, userID)
 	}
 
-	return picks, rows.Err()
+	return userIDs, rows.Err()
 }

--- a/internal/services/scoring_service.go
+++ b/internal/services/scoring_service.go
@@ -395,32 +395,38 @@ func (s *ScoringService) scoreGroupStandingPicks(ctx context.Context, groupCode 
 	return groupEvents, affectedUserIDs, nil
 }
 
+// scoreBracketPicks awards points set-based: every user who picked the match's
+// winner to advance at this stage scores, regardless of which slot they placed it
+// in. The team's actual match determines the points, so source_ref stays the match
+// ID — a unique, idempotent key (each match has exactly one winner per user).
 func (s *ScoringService) scoreBracketPicks(ctx context.Context, match *domain.Match) ([]*domain.ScoreEvent, map[string]struct{}, error) {
-	bracketPicks, err := s.pickemRepository.GetBracketPicksByMatch(ctx, match.ID)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	points := bracketPointsForStage(match.StageCode, &s.cfg.Scoring)
 	if points <= 0 {
 		return nil, nil, nil
 	}
 
-	bracketEvents := make([]*domain.ScoreEvent, 0, len(bracketPicks))
-	affectedUserIDs := make(map[string]struct{}, len(bracketPicks))
+	if match.Result == nil || match.Result.WinnerTeamFifaCode == nil {
+		return nil, nil, nil
+	}
+	winner := *match.Result.WinnerTeamFifaCode
 
-	for _, pick := range bracketPicks {
-		// If the picked team is the winner, points awarded
-		if pick.TeamFifaCode == *match.Result.WinnerTeamFifaCode {
-			bracketEvents = append(bracketEvents, &domain.ScoreEvent{
-				UserID:     pick.UserID,
-				SourceType: domain.ScoreSourceBracketPick,
-				SourceRef:  strconv.FormatInt(match.ID, 10),
-				Points:     points,
-			})
+	userIDs, err := s.pickemRepository.GetBracketPickUserIDsByTeamAndStage(ctx, winner, match.StageCode)
+	if err != nil {
+		return nil, nil, err
+	}
 
-			affectedUserIDs[pick.UserID] = struct{}{}
-		}
+	bracketEvents := make([]*domain.ScoreEvent, 0, len(userIDs))
+	affectedUserIDs := make(map[string]struct{}, len(userIDs))
+
+	for _, userID := range userIDs {
+		bracketEvents = append(bracketEvents, &domain.ScoreEvent{
+			UserID:     userID,
+			SourceType: domain.ScoreSourceBracketPick,
+			SourceRef:  strconv.FormatInt(match.ID, 10),
+			Points:     points,
+		})
+
+		affectedUserIDs[userID] = struct{}{}
 	}
 
 	return bracketEvents, affectedUserIDs, nil

--- a/internal/services/scoring_service_test.go
+++ b/internal/services/scoring_service_test.go
@@ -1,0 +1,189 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/fifawcp/api/internal/domain"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bracketScoringConfig() *config.Config {
+	return &config.Config{Scoring: config.ScoringConfig{
+		RoundOf32:     4,
+		RoundOf16:     6,
+		Quarterfinals: 8,
+		Semifinals:    12,
+		ThirdPlace:    16,
+		Final:         20,
+	}}
+}
+
+func knockoutMatch(id int64, stage domain.MatchStageCode, winner string) *domain.Match {
+	return &domain.Match{
+		ID:        id,
+		StageCode: stage,
+		Status:    domain.MatchStatusFinished,
+		Result:    &domain.MatchResult{WinnerTeamFifaCode: &winner},
+	}
+}
+
+// scoreBracketPicks awards points to every user who backed the winning team to
+// advance at the match's stage — looked up by team + stage, not by match slot.
+func TestScoringService_scoreBracketPicks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("awards stage points to every user who picked the winner at that stage", func(t *testing.T) {
+		t.Parallel()
+
+		var gotTeam string
+		var gotStage domain.MatchStageCode
+		pickemRepo := &mocks.MockPickemRepository{
+			GetBracketPickUserIDsByTeamAndStageFunc: func(ctx context.Context, team string, stage domain.MatchStageCode) ([]string, error) {
+				gotTeam, gotStage = team, stage
+				return []string{"user-1", "user-2"}, nil
+			},
+		}
+		service := &ScoringService{pickemRepository: pickemRepo, cfg: bracketScoringConfig()}
+
+		events, affected, err := service.scoreBracketPicks(context.Background(), knockoutMatch(73, domain.MatchStageCodeRoundOf32, "KOR"))
+
+		require.NoError(t, err)
+		// Looked up by the winning team + stage, never by match slot.
+		assert.Equal(t, "KOR", gotTeam)
+		assert.Equal(t, domain.MatchStageCodeRoundOf32, gotStage)
+
+		require.Len(t, events, 2)
+		for _, event := range events {
+			assert.Equal(t, domain.ScoreSourceBracketPick, event.SourceType)
+			assert.Equal(t, "73", event.SourceRef) // stays the match ID
+			assert.Equal(t, 4, event.Points)       // round_of_32
+		}
+		assert.Equal(t, map[string]struct{}{"user-1": {}, "user-2": {}}, affected)
+	})
+
+	t.Run("uses the stage's point value", func(t *testing.T) {
+		t.Parallel()
+
+		pickemRepo := &mocks.MockPickemRepository{
+			GetBracketPickUserIDsByTeamAndStageFunc: func(ctx context.Context, team string, stage domain.MatchStageCode) ([]string, error) {
+				return []string{"user-1"}, nil
+			},
+		}
+		service := &ScoringService{pickemRepository: pickemRepo, cfg: bracketScoringConfig()}
+
+		events, _, err := service.scoreBracketPicks(context.Background(), knockoutMatch(104, domain.MatchStageCodeFinal, "ARG"))
+
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+		assert.Equal(t, 20, events[0].Points) // final
+		assert.Equal(t, "104", events[0].SourceRef)
+	})
+
+	t.Run("no winning team picked yields no events", func(t *testing.T) {
+		t.Parallel()
+
+		pickemRepo := &mocks.MockPickemRepository{
+			GetBracketPickUserIDsByTeamAndStageFunc: func(ctx context.Context, team string, stage domain.MatchStageCode) ([]string, error) {
+				return nil, nil
+			},
+		}
+		service := &ScoringService{pickemRepository: pickemRepo, cfg: bracketScoringConfig()}
+
+		events, affected, err := service.scoreBracketPicks(context.Background(), knockoutMatch(73, domain.MatchStageCodeRoundOf32, "KOR"))
+
+		require.NoError(t, err)
+		assert.Empty(t, events)
+		assert.Empty(t, affected)
+	})
+
+	t.Run("nil winner is skipped without querying picks", func(t *testing.T) {
+		t.Parallel()
+
+		// GetBracketPickUserIDsByTeamAndStageFunc unset → panics if called.
+		service := &ScoringService{pickemRepository: &mocks.MockPickemRepository{}, cfg: bracketScoringConfig()}
+
+		match := &domain.Match{ID: 73, StageCode: domain.MatchStageCodeRoundOf32, Result: &domain.MatchResult{}}
+		events, affected, err := service.scoreBracketPicks(context.Background(), match)
+
+		require.NoError(t, err)
+		assert.Empty(t, events)
+		assert.Empty(t, affected)
+	})
+
+	t.Run("nil result is skipped without querying picks", func(t *testing.T) {
+		t.Parallel()
+
+		service := &ScoringService{pickemRepository: &mocks.MockPickemRepository{}, cfg: bracketScoringConfig()}
+
+		match := &domain.Match{ID: 73, StageCode: domain.MatchStageCodeRoundOf32}
+		events, affected, err := service.scoreBracketPicks(context.Background(), match)
+
+		require.NoError(t, err)
+		assert.Empty(t, events)
+		assert.Empty(t, affected)
+	})
+
+	t.Run("non-bracket stage scores nothing without querying picks", func(t *testing.T) {
+		t.Parallel()
+
+		service := &ScoringService{pickemRepository: &mocks.MockPickemRepository{}, cfg: bracketScoringConfig()}
+
+		match := knockoutMatch(1, domain.MatchStageCodeGroupStage, "MEX")
+		events, affected, err := service.scoreBracketPicks(context.Background(), match)
+
+		require.NoError(t, err)
+		assert.Empty(t, events)
+		assert.Empty(t, affected)
+	})
+
+	t.Run("propagates repository errors", func(t *testing.T) {
+		t.Parallel()
+
+		repoErr := errors.New("db down")
+		pickemRepo := &mocks.MockPickemRepository{
+			GetBracketPickUserIDsByTeamAndStageFunc: func(ctx context.Context, team string, stage domain.MatchStageCode) ([]string, error) {
+				return nil, repoErr
+			},
+		}
+		service := &ScoringService{pickemRepository: pickemRepo, cfg: bracketScoringConfig()}
+
+		events, affected, err := service.scoreBracketPicks(context.Background(), knockoutMatch(73, domain.MatchStageCodeRoundOf32, "KOR"))
+
+		assert.ErrorIs(t, err, repoErr)
+		assert.Nil(t, events)
+		assert.Nil(t, affected)
+	})
+
+	// Each match is scored independently with source_ref = its own ID, so scoring a
+	// whole stage produces one distinct, idempotent key per match (no batch collisions).
+	t.Run("each match in a stage yields a distinct source_ref", func(t *testing.T) {
+		t.Parallel()
+
+		pickemRepo := &mocks.MockPickemRepository{
+			GetBracketPickUserIDsByTeamAndStageFunc: func(ctx context.Context, team string, stage domain.MatchStageCode) ([]string, error) {
+				return []string{"user-1"}, nil
+			},
+		}
+		service := &ScoringService{pickemRepository: pickemRepo, cfg: bracketScoringConfig()}
+
+		var refs []string
+		for _, match := range []*domain.Match{
+			knockoutMatch(73, domain.MatchStageCodeRoundOf32, "KOR"),
+			knockoutMatch(86, domain.MatchStageCodeRoundOf32, "URU"),
+		} {
+			events, _, err := service.scoreBracketPicks(context.Background(), match)
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			refs = append(refs, events[0].SourceRef)
+		}
+
+		sort.Strings(refs)
+		assert.Equal(t, []string{"73", "86"}, refs)
+	})
+}

--- a/internal/test/mocks/pickem_repository_mock.go
+++ b/internal/test/mocks/pickem_repository_mock.go
@@ -7,20 +7,20 @@ import (
 )
 
 type MockPickemRepository struct {
-	UpsertGroupPicksFunc         func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
-	GetGroupPicksFunc            func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
-	GetGroupPicksByGroupFunc     func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
-	UpsertBestThirdsFunc         func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
-	GetBestThirdPicksFunc        func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
-	GetBestThirdPicksByTeamsFunc func(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error)
-	UpsertBracketPicksFunc       func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
-	GetBracketPicksFunc          func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
-	GetBracketPicksByMatchFunc   func(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error)
-	GetChampionPickFunc          func(ctx context.Context, userID string) (*string, error)
-	GetChampionPickCountsFunc    func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
-	GetUserProgressCountsFunc    func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
-	GetLockedGroupCodesFunc      func(ctx context.Context, userID string) ([]string, error)
-	SetGroupLocksFunc            func(ctx context.Context, userID string, lockedCodes []string) error
+	UpsertGroupPicksFunc                    func(ctx context.Context, userID string, picks []*domain.UserGroupPick) error
+	GetGroupPicksFunc                       func(ctx context.Context, userID string) ([]*domain.UserGroupPick, error)
+	GetGroupPicksByGroupFunc                func(ctx context.Context, groupCode string) ([]*domain.UserGroupPick, error)
+	UpsertBestThirdsFunc                    func(ctx context.Context, userID string, bestThirds []*domain.UserBestThirdPick) error
+	GetBestThirdPicksFunc                   func(ctx context.Context, userID string) ([]*domain.UserBestThirdPick, error)
+	GetBestThirdPicksByTeamsFunc            func(ctx context.Context, teamFifaCodes []string) ([]*domain.UserBestThirdPick, error)
+	UpsertBracketPicksFunc                  func(ctx context.Context, userID string, picks []*domain.UserBracketPick) error
+	GetBracketPicksFunc                     func(ctx context.Context, userID string) ([]*domain.UserBracketPick, error)
+	GetBracketPickUserIDsByTeamAndStageFunc func(ctx context.Context, teamFifaCode string, stage domain.MatchStageCode) ([]string, error)
+	GetChampionPickFunc                     func(ctx context.Context, userID string) (*string, error)
+	GetChampionPickCountsFunc               func(ctx context.Context, limit int) ([]*domain.TitleFavorite, error)
+	GetUserProgressCountsFunc               func(ctx context.Context, userID string) (domain.PickemProgressCounts, error)
+	GetLockedGroupCodesFunc                 func(ctx context.Context, userID string) ([]string, error)
+	SetGroupLocksFunc                       func(ctx context.Context, userID string, lockedCodes []string) error
 }
 
 func (m *MockPickemRepository) UpsertGroupPicks(ctx context.Context, userID string, picks []*domain.UserGroupPick) error {
@@ -79,11 +79,11 @@ func (m *MockPickemRepository) GetBracketPicks(ctx context.Context, userID strin
 	panic("GetBracketPicks called unexpectedly")
 }
 
-func (m *MockPickemRepository) GetBracketPicksByMatch(ctx context.Context, matchID int64) ([]*domain.UserBracketPick, error) {
-	if m.GetBracketPicksByMatchFunc != nil {
-		return m.GetBracketPicksByMatchFunc(ctx, matchID)
+func (m *MockPickemRepository) GetBracketPickUserIDsByTeamAndStage(ctx context.Context, teamFifaCode string, stage domain.MatchStageCode) ([]string, error) {
+	if m.GetBracketPickUserIDsByTeamAndStageFunc != nil {
+		return m.GetBracketPickUserIDsByTeamAndStageFunc(ctx, teamFifaCode, stage)
 	}
-	panic("GetBracketPicksByMatch called unexpectedly")
+	panic("GetBracketPickUserIDsByTeamAndStage called unexpectedly")
 }
 
 func (m *MockPickemRepository) GetChampionPick(ctx context.Context, userID string) (*string, error) {


### PR DESCRIPTION
## Related issue

Closes #124

## What changed

- Bracket picks now score **set-based**: you earn a round's points for each team you predicted to advance that actually advanced — regardless of which bracket slot it landed in (was positional: winner of that exact slot only).
- New `GetBracketPickUserIDsByTeamAndStage` query; `scoreBracketPicks` awards by winning team + stage and keeps `source_ref = match.ID` → no migration, idempotent, downstream untouched.
- Point values unchanged (R32 +4 … final +20); third-place/final unaffected (single matches).
- `bracket_hits` (stat + leaderboard tiebreaker) now means "correct advancement predictions" and reads higher — intended. Prod-safe: still group stage, zero bracket events to backfill.

## How to test

- [ ] `go test ./internal/services/ -run TestScoringService_scoreBracketPicks`
- [ ] Rescore a finished knockout match via `POST /admin/pickems/rescore/match/{id}`; verify `score_events` has one `bracket_pick` row per user with `source_ref = match_id` and the stage's points.
- [ ] Re-POST the same match → no duplicate rows, points unchanged (idempotent).
- [ ] Check a pickem leaderboard: bracket totals / `bracket_hits` reflect the new set-based rows.