### PR TITLE
fix: correct seeded kickoff dates for ARG vs ALG and COL vs COD

### DIFF
--- a/cmd/db/migrations/000020_fix_match_kickoff_times.up.sql
+++ b/cmd/db/migrations/000020_fix_match_kickoff_times.up.sql
@@ -1,0 +1,7 @@
+-- ARG vs ALG: was 2026-06-16 (a day early); real fixture is Jun 16, 21:00 ET.
+UPDATE matches SET kickoff_at = '2026-06-17T01:00:00Z'
+  WHERE stage_code = 'group_stage' AND home_team_fifa_code = 'ARG' AND away_team_fifa_code = 'ALG';
+
+-- COL vs COD: was 18:00 ET; real fixture is Jun 23, 22:00 ET.
+UPDATE matches SET kickoff_at = '2026-06-24T02:00:00Z'
+  WHERE stage_code = 'group_stage' AND home_team_fifa_code = 'COL' AND away_team_fifa_code = 'COD';


### PR DESCRIPTION
## Related issue

_No tracked issue._

## What changed

- ARG vs ALG was seeded a full day early (Jun 15) — corrected to its real Jun 16 kickoff, which is what made "tomorrow" show 5 group matches instead of 4.
- COL vs COD corrected to its real Jun 23 kickoff time.
- Shipped as a corrective migration (`UPDATE` by team + stage), so deployed DBs fix on `migrate up`; the sync scheduler re-derives its poll timers from the DB on the next planning run, so result-sync recovers without intervention.

## How to test

- [ ] `make db-migrate-up` applies `000020` cleanly
- [ ] `SELECT kickoff_at FROM matches WHERE home_team_fifa_code='ARG' AND away_team_fifa_code='ALG'` → `2026-06-17 01:00:00+00`
- [ ] Same query for `COL`/`COD` → `2026-06-24 02:00:00+00`
- [ ] `GET /matches`: June 15 (COT) lists 4 group matches; ARG vs ALG now appears on June 16