### PR TITLE
chore: release v1.5.1

### DIFF
--- a/cmd/db/migrations/000021_fix_uzb_col_kickoff.up.sql
+++ b/cmd/db/migrations/000021_fix_uzb_col_kickoff.up.sql
@@ -1,0 +1,3 @@
+-- UZB vs COL: was 18:00 ET; real fixture is Jun 17, 22:00 ET.
+UPDATE matches SET kickoff_at = '2026-06-18T02:00:00Z'
+  WHERE stage_code = 'group_stage' AND home_team_fifa_code = 'UZB' AND away_team_fifa_code = 'COL';


### PR DESCRIPTION
## Release v1.5.1

Patch release correcting a seeded match kickoff time.

### Fixes
- Migration to update the kickoff time for the UZB vs COL match (#128)