### PR TITLE
feat: seed dev DB with real prod data via snapshot replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ coverage.out
 coverage.html
 coverage-integration.out
 
+snapshot.json
+
 bin/
 *.exe
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,30 @@ db-seed:
 db-seed-inner:
 	@go run ./cmd/db/seed $(if $(SCENARIO),-scenario=$(SCENARIO))
 
+.PHONY: db-export-snapshot
+db-export-snapshot:
+	@docker compose exec server make db-export-snapshot-inner FILE=$(FILE)
+
+.PHONY: db-export-snapshot-inner
+db-export-snapshot-inner:
+	@go run ./cmd/db/export $(if $(FILE),-out=$(FILE))
+
+.PHONY: db-seed-snapshot
+db-seed-snapshot:
+	@docker compose exec server make db-seed-snapshot-inner FILE=$(FILE)
+
+.PHONY: db-seed-snapshot-inner
+db-seed-snapshot-inner:
+	@go run ./cmd/db/seed -snapshot=$(FILE)
+
+.PHONY: db-seed-from-prod
+db-seed-from-prod:
+	@docker compose exec server make db-seed-from-prod-inner
+
+.PHONY: db-seed-from-prod-inner
+db-seed-from-prod-inner:
+	@go run ./cmd/db/seed -from-prod
+
 .PHONY: db-flush
 db-flush:
 	@docker compose exec server make db-flush-inner
@@ -152,6 +176,9 @@ help:
 	@echo "  make db-seed <scenario>     - Seed a tournament snapshot (e.g. qf_done)"
 	@echo "                                  Scenarios: pre_tournament, group_stage_done,"
 	@echo "                                  r32_done, r16_done, qf_done, sf_done, final_done"
+	@echo "  make db-export-snapshot FILE= - Export real prod data → JSON (needs PROD_DB_ADDRESS)"
+	@echo "  make db-seed-snapshot FILE= - Replay a real prod snapshot into dev"
+	@echo "  make db-seed-from-prod      - Reseed dev live from prod (read-only SELECT; needs PROD_DB_ADDRESS)"
 	@echo "  make db-flush               - Reset DB to post-migration baseline"
 	@echo ""
 	@echo "🔄 Database Migrations:"

--- a/cmd/db/export/main.go
+++ b/cmd/db/export/main.go
@@ -1,0 +1,71 @@
+// Command export reads finished match results and all fair-play rows from prod
+// (read-only; SELECT only) into a JSON snapshot file that `make db-seed-snapshot`
+// replays into a dev DB. Uses PROD_DB_ADDRESS so DB_ADDRESS is never overridden.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+
+	"github.com/fifawcp/api/cmd/db/snapshot"
+	"github.com/fifawcp/api/internal/infrastructure/config"
+	"github.com/fifawcp/api/internal/infrastructure/db"
+	"github.com/fifawcp/api/internal/infrastructure/env"
+	"github.com/fifawcp/api/internal/infrastructure/logging"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	godotenv.Load()
+
+	out := flag.String("out", "snapshot.json", "output file path")
+	flag.Parse()
+
+	cfg := config.NewConfig()
+	logger := logging.NewSlogLogger(cfg)
+
+	prodAddress := env.GetString("PROD_DB_ADDRESS", "")
+	if prodAddress == "" {
+		logger.Error("PROD_DB_ADDRESS is not set — add the prod connection string to .env before exporting")
+		os.Exit(2)
+	}
+
+	logger.Warn("Connecting to PROD_DB_ADDRESS READ-ONLY (SELECT only) to export the real tournament snapshot")
+
+	pgDB, err := db.NewPostgresDB(
+		prodAddress,
+		cfg.DB.MaxOpenConns,
+		cfg.DB.MaxIdleConns,
+		cfg.DB.MaxLifetime,
+	)
+	if err != nil {
+		logger.Error("Error connecting to database", logging.Error, err.Error())
+		os.Exit(1)
+	}
+	defer pgDB.Close()
+
+	snap, err := snapshot.Export(context.Background(), pgDB)
+	if err != nil {
+		logger.Error("Error reading snapshot from database", logging.Error, err.Error())
+		os.Exit(1)
+	}
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		logger.Error("Error marshalling snapshot", logging.Error, err.Error())
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*out, data, 0o644); err != nil {
+		logger.Error("Error writing snapshot file", logging.Error, err.Error())
+		os.Exit(1)
+	}
+
+	logger.Info("Snapshot exported",
+		"path", *out,
+		"matches", len(snap.Matches),
+		"fair_play", len(snap.FairPlay),
+	)
+}

--- a/cmd/db/seed/main.go
+++ b/cmd/db/seed/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
+	"github.com/fifawcp/api/cmd/db/snapshot"
 	"github.com/fifawcp/api/internal/domain"
 	"github.com/fifawcp/api/internal/infrastructure/config"
 	"github.com/fifawcp/api/internal/infrastructure/db"
+	"github.com/fifawcp/api/internal/infrastructure/env"
 	"github.com/fifawcp/api/internal/infrastructure/logging"
 	"github.com/fifawcp/api/internal/repositories"
 	"github.com/fifawcp/api/internal/services"
@@ -20,6 +24,18 @@ func main() {
 
 	cfg := config.NewConfig()
 	logger := logging.NewSlogLogger(cfg)
+
+	// The seeder is destructive (Flush deletes users/boards, resets matches) and
+	// ships to prod as /seed. Refuse to run against production — both by the
+	// environment it runs in and by the target DB matching the known prod one.
+	if cfg.IsProd() {
+		logger.Error("refusing to seed: ENV is production (the seeder is destructive and dev-only)")
+		os.Exit(2)
+	}
+	if prodAddress := env.GetString("PROD_DB_ADDRESS", ""); prodAddress != "" && cfg.DB.Address == prodAddress {
+		logger.Error("refusing to seed: DB_ADDRESS matches PROD_DB_ADDRESS (the seeder is destructive and dev-only)")
+		os.Exit(2)
+	}
 
 	pgDB, err := db.NewPostgresDB(
 		cfg.DB.Address,
@@ -83,16 +99,31 @@ func main() {
 	seeder := NewSeeder(
 		pgDB, logger,
 		userRepository, boardRepository, boardMemberRepository, pickemRepository,
-		matchRepository, awardPickRepository,
+		matchRepository, awardPickRepository, matchFairPlayRepository,
 		matchService, pickemService, boardService, competitionService,
 	)
 
 	flush := flag.Bool("flush", false, "")
 	scenario := flag.String("scenario", "", "")
+	snapshotPath := flag.String("snapshot", "", "")
+	fromProd := flag.Bool("from-prod", false, "")
 	flag.Parse()
 
-	if *flush && *scenario != "" {
-		logger.Error("-flush and -scenario are mutually exclusive")
+	selectedModes := 0
+	if *flush {
+		selectedModes++
+	}
+	if *scenario != "" {
+		selectedModes++
+	}
+	if *snapshotPath != "" {
+		selectedModes++
+	}
+	if *fromProd {
+		selectedModes++
+	}
+	if selectedModes > 1 {
+		logger.Error("-flush, -scenario, -snapshot and -from-prod are mutually exclusive")
 		os.Exit(2)
 	}
 
@@ -104,8 +135,47 @@ func main() {
 			logger.Error("Scenario seed failed", logging.Error, err.Error())
 			os.Exit(1)
 		}
+	case *snapshotPath != "":
+		if err := seeder.RunSnapshot(context.Background(), *snapshotPath); err != nil {
+			logger.Error("Snapshot seed failed", logging.Error, err.Error())
+			os.Exit(1)
+		}
+	case *fromProd:
+		if err := seedFromProd(context.Background(), cfg, logger, seeder); err != nil {
+			logger.Error("Seed from prod failed", logging.Error, err.Error())
+			os.Exit(1)
+		}
 	default:
-		logger.Error("missing scenario: pass -scenario=<name> or use one of `make db-seed <scenario>` / `make db-flush`")
+		logger.Error("missing mode: pass -scenario=<name>, -snapshot=<path>, -from-prod, or -flush")
 		os.Exit(2)
 	}
+}
+
+// seedFromProd reads the real snapshot live from PROD_DB_ADDRESS (read-only) and
+// replays it into the dev DB. The guards above already refuse a prod target.
+func seedFromProd(ctx context.Context, cfg *config.Config, logger logging.Logger, seeder *Seeder) error {
+	prodAddress := env.GetString("PROD_DB_ADDRESS", "")
+	if prodAddress == "" {
+		return errors.New("PROD_DB_ADDRESS is not set — add the prod connection string before seeding from prod")
+	}
+
+	logger.Warn("Connecting to PROD_DB_ADDRESS READ-ONLY (SELECT only) to source the real tournament snapshot")
+
+	prodDB, err := db.NewPostgresDB(
+		prodAddress,
+		cfg.DB.MaxOpenConns,
+		cfg.DB.MaxIdleConns,
+		cfg.DB.MaxLifetime,
+	)
+	if err != nil {
+		return fmt.Errorf("connect to prod: %w", err)
+	}
+	defer prodDB.Close()
+
+	snap, err := snapshot.Export(ctx, prodDB)
+	if err != nil {
+		return fmt.Errorf("read prod snapshot: %w", err)
+	}
+
+	return seeder.RunSnapshotData(ctx, snap)
 }

--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -26,6 +26,7 @@ type Seeder struct {
 	pickemRepository      domain.PickemRepository
 	matchRepository       domain.MatchRepository
 	awardPickRepository   domain.AwardPickRepository
+	fairPlayRepository    domain.MatchFairPlayRepository
 	matchService          services.MatchServiceInterface
 	pickemService         services.PickemServiceInterface
 	boardService          services.BoardServiceInterface
@@ -42,6 +43,7 @@ func NewSeeder(
 	pickemRepository domain.PickemRepository,
 	matchRepository domain.MatchRepository,
 	awardPickRepository domain.AwardPickRepository,
+	fairPlayRepository domain.MatchFairPlayRepository,
 	matchService services.MatchServiceInterface,
 	pickemService services.PickemServiceInterface,
 	boardService services.BoardServiceInterface,
@@ -56,6 +58,7 @@ func NewSeeder(
 		pickemRepository:      pickemRepository,
 		matchRepository:       matchRepository,
 		awardPickRepository:   awardPickRepository,
+		fairPlayRepository:    fairPlayRepository,
 		matchService:          matchService,
 		pickemService:         pickemService,
 		boardService:          boardService,
@@ -276,6 +279,27 @@ func (s *Seeder) RunScenario(ctx context.Context, scenarioName string) error {
 		return fmt.Errorf("shift kickoff dates: %w", err)
 	}
 
+	matchUsers, err := s.seedParticipants(ctx)
+	if err != nil {
+		return err
+	}
+
+	scriptedResultsByMatchID, err := buildScriptedResults(ctx, s.db)
+	if err != nil {
+		return fmt.Errorf("build scripted results: %w", err)
+	}
+
+	if err := s.replayResults(ctx, scenario.StageGroups, scriptedResultsByMatchID, matchUsers); err != nil {
+		return err
+	}
+
+	s.logger.Info("Scenario seeded successfully", "scenario", scenario.Name)
+	return nil
+}
+
+// seedParticipants creates the synthetic users/boards/competitions and their picks,
+// returning the match-score pickers so callers re-seed knockout picks per stage.
+func (s *Seeder) seedParticipants(ctx context.Context) ([]*domain.User, error) {
 	users := s.generateUsers(usersAmount)
 	createdUsers := make([]*domain.User, 0, len(users))
 	for _, user := range users {
@@ -289,43 +313,42 @@ func (s *Seeder) RunScenario(ctx context.Context, scenarioName string) error {
 
 	s.seedBoards(ctx, createdUsers)
 	if err := s.seedCompetitions(ctx); err != nil {
-		return fmt.Errorf("seed competitions: %w", err)
+		return nil, fmt.Errorf("seed competitions: %w", err)
 	}
 
 	pickemUsers, matchUsers, err := partitionUsersByEngagement(createdUsers)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.seedPickemData(ctx, pickemUsers)
 	if err := s.seedBracketPicks(ctx, pickemUsers); err != nil {
-		return fmt.Errorf("seed bracket picks: %w", err)
+		return nil, fmt.Errorf("seed bracket picks: %w", err)
 	}
 	if err := s.seedAwardPicks(ctx, pickemUsers); err != nil {
-		return fmt.Errorf("seed award picks: %w", err)
+		return nil, fmt.Errorf("seed award picks: %w", err)
 	}
 
-	// Group-stage teams are always assigned post-migration, so these picks always land
-	// Knockout picks are seeded per-stage below, once their matchups become known via advanceBracket
+	// Group-stage teams are assigned post-migration so these picks always land;
+	// knockout picks are re-seeded per-stage by replayResults as matchups reveal.
 	s.seedMatchScoresFor(ctx, matchUsers, allMatchIDs())
 
-	scriptedResultsByMatchID, err := buildScriptedResults(ctx, s.db)
-	if err != nil {
-		return fmt.Errorf("build scripted results: %w", err)
-	}
+	return matchUsers, nil
+}
 
-	for stageIndex, stageMatchIDs := range scenario.StageGroups {
-		if err := s.applyScenarioResults(ctx, stageMatchIDs, scriptedResultsByMatchID); err != nil {
+// replayResults applies results one stage at a time (in stageGroups order), re-seeding
+// match-score picks after each stage so newly revealed knockout matchups get scored.
+func (s *Seeder) replayResults(ctx context.Context, stageGroups [][]int64, results map[int64]ScriptedResult, matchUsers []*domain.User) error {
+	for stageIndex, stageMatchIDs := range stageGroups {
+		if err := s.applyScenarioResults(ctx, stageMatchIDs, results); err != nil {
 			return fmt.Errorf("apply stage %d results: %w", stageIndex, err)
 		}
 
-		// After this stage's apply, advanceBracket has filled in the NEXT
-		// stage's home/away teams. Re-seed picks so that next stage's
-		// scoring (in the following iteration) sees them
+		// advanceBracket has now filled the next stage's teams; re-seed so its
+		// scoring sees them on the following iteration.
 		s.seedMatchScoresFor(ctx, matchUsers, allMatchIDs())
 	}
 
-	s.logger.Info("Scenario seeded successfully", "scenario", scenario.Name)
 	return nil
 }
 
@@ -370,6 +393,7 @@ func allMatchIDs() []int64 {
 func (s *Seeder) resetTournamentState(ctx context.Context) error {
 	queries := []string{
 		`DELETE FROM score_events`,
+		`DELETE FROM match_fair_play`,
 		`DELETE FROM competition_match_scores`,
 		`DELETE FROM user_bracket_picks`,
 		`DELETE FROM user_match_score_picks`,

--- a/cmd/db/seed/snapshot_seed.go
+++ b/cmd/db/seed/snapshot_seed.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/fifawcp/api/cmd/db/snapshot"
+	"github.com/fifawcp/api/internal/domain"
+)
+
+// RunSnapshot replays a snapshot file (exported from prod) into the dev DB.
+func (s *Seeder) RunSnapshot(ctx context.Context, path string) error {
+	snap, err := loadSnapshotFile(path)
+	if err != nil {
+		return err
+	}
+	s.logger.Info("Loaded snapshot file", "path", path)
+	return s.RunSnapshotData(ctx, snap)
+}
+
+// RunSnapshotData replays an in-memory snapshot through the same engine prod runs,
+// decoupled from the source so it works from a file (-snapshot) or live (-from-prod).
+func (s *Seeder) RunSnapshotData(ctx context.Context, snap *snapshot.Snapshot) error {
+	s.logger.Info("Running snapshot seed",
+		"matches", len(snap.Matches),
+		"fair_play", len(snap.FairPlay),
+	)
+
+	s.Flush()
+
+	// Flush leaves kickoff_at untouched and a prior scenario may have shifted it;
+	// re-pin to the real 2026 dates so the calendar reflects reality.
+	if err := s.shiftKickoffDates(ctx, Scenario{AnchorMatchID: 1, UseRealDates: true}); err != nil {
+		return fmt.Errorf("restore real kickoff dates: %w", err)
+	}
+
+	if err := s.loadFairPlay(ctx, snap.FairPlay); err != nil {
+		return fmt.Errorf("load fair play: %w", err)
+	}
+
+	matchUsers, err := s.seedParticipants(ctx)
+	if err != nil {
+		return err
+	}
+
+	results, stageGroups := snapshotResults(snap.Matches)
+	if err := s.replayResults(ctx, stageGroups, results, matchUsers); err != nil {
+		return err
+	}
+
+	s.logger.Info("Snapshot seeded successfully")
+	return nil
+}
+
+func loadSnapshotFile(path string) (*snapshot.Snapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read snapshot %q: %w", path, err)
+	}
+
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("parse snapshot %q: %w", path, err)
+	}
+
+	return &snap, nil
+}
+
+func (s *Seeder) loadFairPlay(ctx context.Context, rows []snapshot.FairPlayRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	records := make([]domain.MatchFairPlay, 0, len(rows))
+	for _, row := range rows {
+		records = append(records, domain.MatchFairPlay{
+			MatchID:                     row.MatchID,
+			TeamFIFACode:                row.TeamFIFACode,
+			YellowCards:                 row.YellowCards,
+			IndirectRedCards:            row.IndirectRedCards,
+			DirectRedCards:              row.DirectRedCards,
+			YellowCardAndDirectRedCards: row.YellowCardAndDirectRedCards,
+		})
+	}
+
+	return s.fairPlayRepository.Upsert(ctx, records)
+}
+
+func snapshotResults(matches []snapshot.MatchResult) (map[int64]ScriptedResult, [][]int64) {
+	results := make(map[int64]ScriptedResult, len(matches))
+	for _, match := range matches {
+		results[match.ID] = ScriptedResult{
+			HomeScore:        match.HomeScore,
+			AwayScore:        match.AwayScore,
+			HomePenaltyScore: match.HomePenaltyScore,
+			AwayPenaltyScore: match.AwayPenaltyScore,
+		}
+	}
+
+	stageGroups := make([][]int64, 0, len(stageRanges))
+	for _, stage := range stageRanges {
+		stageMatchIDs := make([]int64, 0, stage.last-stage.first+1)
+		for matchID := stage.first; matchID <= stage.last; matchID++ {
+			if _, finished := results[matchID]; finished {
+				stageMatchIDs = append(stageMatchIDs, matchID)
+			}
+		}
+
+		if len(stageMatchIDs) > 0 {
+			stageGroups = append(stageGroups, stageMatchIDs)
+		}
+	}
+
+	return results, stageGroups
+}

--- a/cmd/db/snapshot/snapshot.go
+++ b/cmd/db/snapshot/snapshot.go
@@ -1,0 +1,96 @@
+package snapshot
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Snapshot struct {
+	Matches  []MatchResult `json:"matches"`
+	FairPlay []FairPlayRow `json:"fair_play"`
+}
+
+type MatchResult struct {
+	ID               int64 `json:"id"`
+	HomeScore        int   `json:"home_score"`
+	AwayScore        int   `json:"away_score"`
+	HomePenaltyScore *int  `json:"home_penalty_score"`
+	AwayPenaltyScore *int  `json:"away_penalty_score"`
+}
+
+type FairPlayRow struct {
+	MatchID                     int64  `json:"match_id"`
+	TeamFIFACode                string `json:"team_fifa_code"`
+	YellowCards                 int    `json:"yellow_cards"`
+	IndirectRedCards            int    `json:"indirect_red_cards"`
+	DirectRedCards              int    `json:"direct_red_cards"`
+	YellowCardAndDirectRedCards int    `json:"yellow_direct_red_cards"`
+}
+
+// Export reads the canonical snapshot — finished matches and all fair-play rows —
+// from a database (read-only; SELECT only). Shared by export and the -from-prod seed.
+func Export(ctx context.Context, pgDB *sql.DB) (*Snapshot, error) {
+	matches, err := exportMatches(ctx, pgDB)
+	if err != nil {
+		return nil, err
+	}
+
+	fairPlay, err := exportFairPlay(ctx, pgDB)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Snapshot{Matches: matches, FairPlay: fairPlay}, nil
+}
+
+func exportMatches(ctx context.Context, pgDB *sql.DB) ([]MatchResult, error) {
+	rows, err := pgDB.QueryContext(ctx, `
+		SELECT id, home_score, away_score, home_penalty_score, away_penalty_score
+		FROM matches
+		WHERE status = 'finished'
+		ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	matches := make([]MatchResult, 0)
+	for rows.Next() {
+		var match MatchResult
+		if err := rows.Scan(
+			&match.ID, &match.HomeScore, &match.AwayScore,
+			&match.HomePenaltyScore, &match.AwayPenaltyScore,
+		); err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+
+	return matches, rows.Err()
+}
+
+func exportFairPlay(ctx context.Context, pgDB *sql.DB) ([]FairPlayRow, error) {
+	rows, err := pgDB.QueryContext(ctx, `
+		SELECT match_id, team_fifa_code, yellow_cards, indirect_red_cards,
+		       direct_red_cards, yellow_direct_red_cards
+		FROM match_fair_play
+		ORDER BY match_id, team_fifa_code`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	fairPlay := make([]FairPlayRow, 0)
+	for rows.Next() {
+		var row FairPlayRow
+		if err := rows.Scan(
+			&row.MatchID, &row.TeamFIFACode, &row.YellowCards,
+			&row.IndirectRedCards, &row.DirectRedCards, &row.YellowCardAndDirectRedCards,
+		); err != nil {
+			return nil, err
+		}
+		fairPlay = append(fairPlay, row)
+	}
+
+	return fairPlay, rows.Err()
+}

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -4,9 +4,32 @@ set -e
 echo "Running migrations..."
 /migrate -path /migrations -database "$DB_ADDRESS" -verbose up
 
-if [ -n "$SEED_SCENARIO" ]; then
-  echo "Seeding database with scenario: $SEED_SCENARIO"
-  /seed -scenario="$SEED_SCENARIO"
+# Seeding flushes data and is only for dev/qa. Omit it in production even if a
+# seed var is set. The /seed binary independently refuses to run when
+# ENV=production, so this is a graceful skip layered on top of that backstop.
+# SEED_FROM_PROD (real prod data, read-only) takes precedence over SEED_SCENARIO.
+seed_cmd=""
+seed_desc=""
+if [ "$SEED_FROM_PROD" = "true" ]; then
+  seed_cmd="/seed -from-prod"
+  seed_desc="live from prod snapshot (read-only)"
+elif [ -n "$SEED_SCENARIO" ]; then
+  seed_cmd="/seed -scenario=$SEED_SCENARIO"
+  seed_desc="with scenario: $SEED_SCENARIO"
+fi
+
+if [ -n "$seed_cmd" ]; then
+  # Match any casing, mirroring IsProd()'s EqualFold, so a prod deploy skips
+  # gracefully instead of invoking /seed and hard-failing under set -e.
+  case "$(printf '%s' "$ENV" | tr '[:upper:]' '[:lower:]')" in
+    production|prod)
+      echo "ENV=$ENV is production — skipping seed (dev only)"
+      ;;
+    *)
+      echo "Seeding database $seed_desc"
+      $seed_cmd
+      ;;
+  esac
 fi
 
 echo "Pre-deploy complete."


### PR DESCRIPTION
## What changed

- `cmd/db/export`: read prod **read-only** (SELECT only) → JSON snapshot file
- `cmd/db/seed -snapshot=<file>` / `-from-prod`: replay a snapshot (from file or live prod) into dev through the same service layer prod uses, so standings/brackets/leaderboards mirror prod
- Extract `seedParticipants`/`replayResults` from `RunScenario` so scenarios and snapshots share one engine (behavior-identical)
- `scripts/predeploy.sh`: `SEED_FROM_PROD=true` opt-in seed for deployed dev envs
- Guards refuse to seed when `ENV` is production or `DB_ADDRESS == PROD_DB_ADDRESS`, so the destructive seeder can never flush prod
- `Flush` now also clears `match_fair_play`

## How to test

- [ ] `make db-export-snapshot FILE=snapshot.json` (with `PROD_DB_ADDRESS` set) → file has `matches[]` + `fair_play[]`
- [ ] `make db-seed-snapshot FILE=snapshot.json` → dashboard shows real next match(es) and standings
- [ ] `make db-seed-from-prod` → dev reseeds live from prod
- [ ] `make db-flush && make db-seed qf_done` → scenario regression still passes
- [ ] Seed guard: run `/seed` with `DB_ADDRESS == PROD_DB_ADDRESS` → exits 2 (refuses)