### PR TITLE
feat: advance knockout bracket winners into downstream slots

### DIFF
--- a/cmd/db/seed/seeder.go
+++ b/cmd/db/seed/seeder.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	mathrand "math/rand"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -600,85 +599,9 @@ func (s *Seeder) applyScenarioResults(ctx context.Context, matchIDs []int64, res
 		return fmt.Errorf("update match results: %w", err)
 	}
 
-	if err := s.advanceBracket(ctx, matchIDs); err != nil {
+	if err := s.matchService.AdvanceBracket(ctx, matchIDs); err != nil {
 		return fmt.Errorf("advance bracket: %w", err)
 	}
 
 	return nil
-}
-
-// advanceBracket fills downstream knockout slots based on the winners/losers
-// of just-finished matches. MatchService.SyncGroupStageOutcomes already
-// handles group → R32 promotion; this covers R32 → R16, R16 → QF, QF → SF,
-// and SF → 3rd-place/Final, which aren't wired in the production service
-func (s *Seeder) advanceBracket(ctx context.Context, completedMatchIDs []int64) error {
-	if len(completedMatchIDs) == 0 {
-		return nil
-	}
-
-	finishedMatches, err := s.matchRepository.GetMatches(ctx, domain.MatchFilters{MatchIDs: completedMatchIDs})
-	if err != nil {
-		return err
-	}
-
-	completed := map[int64]*domain.Match{}
-	for _, match := range finishedMatches {
-		completed[match.ID] = match
-	}
-
-	var updates []domain.MatchTeamUpdate
-	for downstreamID, rule := range domain.MatchSlotRules {
-		var update domain.MatchTeamUpdate
-		update.MatchID = downstreamID
-		anySet := false
-
-		if homeCode := resolveBracketSource(rule.Home, completed); homeCode != "" {
-			homeCodeCopy := homeCode
-			update.HomeTeamFifaCode = &homeCodeCopy
-			anySet = true
-		}
-
-		if awayCode := resolveBracketSource(rule.Away, completed); awayCode != "" {
-			awayCodeCopy := awayCode
-			update.AwayTeamFifaCode = &awayCodeCopy
-			anySet = true
-		}
-
-		if anySet {
-			updates = append(updates, update)
-		}
-	}
-
-	if len(updates) == 0 {
-		return nil
-	}
-
-	sort.Slice(updates, func(a, b int) bool { return updates[a].MatchID < updates[b].MatchID })
-	return s.matchRepository.UpdateMatchTeams(ctx, updates)
-}
-
-func resolveBracketSource(src domain.Source, completed map[int64]*domain.Match) string {
-	if src.Kind != domain.SourceWinner && src.Kind != domain.SourceLoser {
-		return ""
-	}
-
-	match, ok := completed[src.MatchID]
-	if !ok || match.Result == nil || match.Result.WinnerTeamFifaCode == nil {
-		return ""
-	}
-
-	winner := *match.Result.WinnerTeamFifaCode
-	if src.Kind == domain.SourceWinner {
-		return winner
-	}
-
-	if match.Teams.Home != nil && match.Teams.Home.FifaCode == winner && match.Teams.Away != nil {
-		return match.Teams.Away.FifaCode
-	}
-
-	if match.Teams.Home != nil {
-		return match.Teams.Home.FifaCode
-	}
-
-	return ""
 }

--- a/internal/app/routes_admin.go
+++ b/internal/app/routes_admin.go
@@ -29,6 +29,10 @@ func adminRoutes(c *Container) chi.Router {
 		})
 	})
 
+	r.Route("/bracket", func(r chi.Router) {
+		r.Post("/advance", c.AdminHandler.AdvanceBracket)
+	})
+
 	r.Route("/pickems", func(r chi.Router) {
 		r.Post("/rescore/best-thirds", c.AdminHandler.RescoreBestThirds)
 

--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -268,6 +268,52 @@ func (h *AdminHandler) RecalculateStandings(w http.ResponseWriter, r *http.Reque
 	httpx.RespondWithData(w, http.StatusOK, outcome)
 }
 
+// AdvanceBracket godoc
+//
+//	@Summary		Advance knockout bracket
+//	@Description	Re-propagates the winners/losers of all finished knockout matches into their downstream Round-of-16+ slots.
+//	@Description	Idempotent — safe to call repeatedly. Use to backfill bracket slots for matches finished before winner-advancement existed.
+//	@Description	Requires authentication and admin role.
+//	@Tags			admin
+//	@Produce		json
+//	@Success		200	{object}	httpx.Response		"Bracket advanced successfully"
+//	@Failure		401	{object}	httpx.ErrorResponse	"Unauthorized - missing or invalid authentication"
+//	@Failure		403	{object}	httpx.ErrorResponse	"Forbidden - admin role required"
+//	@Failure		500	{object}	httpx.ErrorResponse	"Internal server error"
+//	@Security		BearerAuth
+//	@Router			/admin/bracket/advance [post]
+func (h *AdminHandler) AdvanceBracket(w http.ResponseWriter, r *http.Request) {
+	if err := h.matchService.AdvanceBracket(r.Context(), allKnockoutMatchIDs()); err != nil {
+		h.auditLogger.LogEvent(r.Context(), logging.Event{
+			Action:   logging.ActionAdvanceBracket,
+			Resource: logging.ResourceMatch,
+			Outcome:  logging.OutcomeFailure,
+			Metadata: map[string]any{logging.Error: err.Error()},
+		})
+		handleServiceError(w, r, err, h.logger)
+		return
+	}
+
+	h.auditLogger.LogEvent(r.Context(), logging.Event{
+		Action:   logging.ActionAdvanceBracket,
+		Resource: logging.ResourceMatch,
+		Outcome:  logging.OutcomeSuccess,
+	})
+
+	httpx.RespondWithData(w, http.StatusOK, nil)
+}
+
+// allKnockoutMatchIDs returns every knockout match ID (the MatchSlotRules keys,
+// matches 73-104). AdvanceBracket only reads the finished ones, so passing the
+// whole set and letting it filter keeps the repair idempotent.
+func allKnockoutMatchIDs() []int64 {
+	ids := make([]int64, 0, len(domain.MatchSlotRules))
+	for id := range domain.MatchSlotRules {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // ResolveThirdPlaceConflict godoc
 //
 //	@Summary		Resolve third-place conflict

--- a/internal/infrastructure/logging/audit_logger.go
+++ b/internal/infrastructure/logging/audit_logger.go
@@ -23,6 +23,7 @@ const (
 	ActionBulkUpdateMatches    AuditAction = "match.bulk_update_results"
 	ActionRecalculateStandings AuditAction = "standing.recalculate"
 	ActionResolveThirdPlace    AuditAction = "match.resolve_third_place"
+	ActionAdvanceBracket       AuditAction = "match.advance_bracket"
 	ActionRecordAwardWinners   AuditAction = "award.record_winners"
 )
 

--- a/internal/services/match_service.go
+++ b/internal/services/match_service.go
@@ -26,6 +26,7 @@ type MatchServiceInterface interface {
 	ResetMatchResult(ctx context.Context, matchID int64) (*domain.SyncGroupStageOutcomes, error)
 	SyncGroupStageOutcomes(ctx context.Context) (*domain.SyncGroupStageOutcomes, error)
 	ResolveThirdPlaceConflict(ctx context.Context, payload dtos.ResolveThirdPlaceConflictDto) (*domain.SyncGroupStageOutcomes, error)
+	AdvanceBracket(ctx context.Context, completedMatchIDs []int64) error
 }
 
 type MatchService struct {
@@ -88,6 +89,17 @@ func (s *MatchService) UpdateMatchResult(ctx context.Context, matchID int64, pay
 	}
 	if err := s.matchRepository.UpdateMatchesResult(ctx, []domain.MatchResultUpdate{updatedMatch}); err != nil {
 		return nil, err
+	}
+
+	// Knockout matches don't touch group standings; they advance the winner/loser
+	// into the next bracket slot. The group stage is over by the time these finalize.
+	if matches[0].StageCode.IsKnockout() {
+		if err := s.AdvanceBracket(ctx, []int64{matchID}); err != nil {
+			return nil, err
+		}
+
+		s.asyncScoreMatches(nil, []int64{matchID})
+		return &domain.SyncGroupStageOutcomes{IsGroupStageFinished: true}, nil
 	}
 
 	outcomes, err := s.SyncGroupStageOutcomes(ctx)
@@ -168,9 +180,29 @@ func (s *MatchService) prepareBulkUpdate(ctx context.Context, payload dtos.BulkU
 		return nil, nil, err
 	}
 
-	outcomes, err := s.SyncGroupStageOutcomes(ctx)
-	if err != nil {
-		return nil, nil, err
+	var groupIDs, knockoutIDs []int64
+	for _, match := range existingMatches {
+		if match.StageCode.IsKnockout() {
+			knockoutIDs = append(knockoutIDs, match.ID)
+		} else {
+			groupIDs = append(groupIDs, match.ID)
+		}
+	}
+
+	if len(knockoutIDs) > 0 {
+		if err := s.AdvanceBracket(ctx, knockoutIDs); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Only group-stage finalizes affect standings/promotion; skip the recompute
+	// for knockout-only payloads now that the group stage is done.
+	outcomes := &domain.SyncGroupStageOutcomes{IsGroupStageFinished: true}
+	if len(groupIDs) > 0 {
+		outcomes, err = s.SyncGroupStageOutcomes(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return matchIDs, outcomes, nil
@@ -257,6 +289,89 @@ func (s *MatchService) SyncGroupStageOutcomes(ctx context.Context) (*domain.Sync
 		IsGroupStageFinished: true,
 		PromotionOutcome:     promotionOutcome,
 	}, nil
+}
+
+// AdvanceBracket fills downstream knockout slots from the winners/losers of the
+// just-finished matches. SyncGroupStageOutcomes already handles group → R32;
+// this covers R32 → R16, R16 → QF, QF → SF, and SF → 3rd-place/Final. It is
+// idempotent: re-running re-writes the same teams, and UpdateMatchTeams uses
+// COALESCE so a partial (home-only or away-only) fill never nulls the other side.
+func (s *MatchService) AdvanceBracket(ctx context.Context, completedMatchIDs []int64) error {
+	if len(completedMatchIDs) == 0 {
+		return nil
+	}
+
+	finishedMatches, err := s.matchRepository.GetMatches(ctx, domain.MatchFilters{MatchIDs: completedMatchIDs})
+	if err != nil {
+		return err
+	}
+
+	completed := make(map[int64]*domain.Match, len(finishedMatches))
+	for _, match := range finishedMatches {
+		completed[match.ID] = match
+	}
+
+	var updates []domain.MatchTeamUpdate
+	for downstreamID, rule := range domain.MatchSlotRules {
+		update := domain.MatchTeamUpdate{MatchID: downstreamID}
+		anySet := false
+
+		if homeCode := resolveBracketSource(rule.Home, completed); homeCode != "" {
+			homeCodeCopy := homeCode
+			update.HomeTeamFifaCode = &homeCodeCopy
+			anySet = true
+		}
+
+		if awayCode := resolveBracketSource(rule.Away, completed); awayCode != "" {
+			awayCodeCopy := awayCode
+			update.AwayTeamFifaCode = &awayCodeCopy
+			anySet = true
+		}
+
+		if anySet {
+			updates = append(updates, update)
+		}
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	// Sort by matchID to prevent deadlocks when updating matches
+	sort.Slice(updates, func(i, j int) bool {
+		return updates[i].MatchID < updates[j].MatchID
+	})
+
+	return s.matchRepository.UpdateMatchTeams(ctx, updates)
+}
+
+// resolveBracketSource returns the FIFA code feeding a SourceWinner/SourceLoser
+// slot, or "" when the source match isn't among the finished set yet.
+func resolveBracketSource(src domain.Source, completed map[int64]*domain.Match) string {
+	if src.Kind != domain.SourceWinner && src.Kind != domain.SourceLoser {
+		return ""
+	}
+
+	match, ok := completed[src.MatchID]
+	if !ok || match.Result == nil || match.Result.WinnerTeamFifaCode == nil {
+		return ""
+	}
+
+	winner := *match.Result.WinnerTeamFifaCode
+	if src.Kind == domain.SourceWinner {
+		return winner
+	}
+
+	// SourceLoser: the team that isn't the winner.
+	if match.Teams.Home != nil && match.Teams.Home.FifaCode == winner && match.Teams.Away != nil {
+		return match.Teams.Away.FifaCode
+	}
+
+	if match.Teams.Home != nil {
+		return match.Teams.Home.FifaCode
+	}
+
+	return ""
 }
 
 func (s *MatchService) ResolveThirdPlaceConflict(ctx context.Context, payload dtos.ResolveThirdPlaceConflictDto) (*domain.SyncGroupStageOutcomes, error) {

--- a/internal/services/match_service_test.go
+++ b/internal/services/match_service_test.go
@@ -78,6 +78,22 @@ func groupStageMatch() *domain.Match {
 	}
 }
 
+// knockoutMatch73CanBeatRsa is the finished Round-of-32 match 73 (RSA 0 - CAN 1).
+// Its winner (CAN) feeds the home slot of Round-of-16 match 90 via MatchSlotRules.
+func knockoutMatch73CanBeatRsa() *domain.Match {
+	winner := "CAN"
+	return &domain.Match{
+		ID:        73,
+		StageCode: domain.MatchStageCodeRoundOf32,
+		Status:    domain.MatchStatusFinished,
+		Teams: domain.MatchTeams{
+			Home: &domain.Team{FifaCode: "RSA"},
+			Away: &domain.Team{FifaCode: "CAN"},
+		},
+		Result: &domain.MatchResult{HomeScore: 0, AwayScore: 1, WinnerTeamFifaCode: &winner},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestMatchService_GetMatches
 // ---------------------------------------------------------------------------
@@ -424,6 +440,49 @@ func TestMatchService_UpdateMatchResult(t *testing.T) {
 		assert.Contains(t, err.Error(), "db write error")
 		assert.Nil(t, outcomes)
 	})
+
+	t.Run("advances bracket and skips group sync for a knockout match", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedTeams []domain.MatchTeamUpdate
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{knockoutMatch73CanBeatRsa()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				capturedTeams = updates
+				return nil
+			},
+			// IsGroupStageFinishedFunc / IsGroupFinishedFunc / RecalculateStandingsFunc are
+			// intentionally unset: reaching SyncGroupStageOutcomes would panic and fail this test.
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc: func(ctx context.Context, matchIDs []int64) (*domain.ScoreMatchesResult, error) {
+				return &domain.ScoreMatchesResult{}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, ss, &mocks.MockCompetitionScoringService{
+			RecomputeForMatchesFunc: func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
+		}, nil)
+
+		home, away := 0, 1
+		outcomes, err := service.UpdateMatchResult(context.Background(), 73, dtos.UpdateMatchResultDto{
+			HomeScore: &home,
+			AwayScore: &away,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, &domain.SyncGroupStageOutcomes{IsGroupStageFinished: true}, outcomes)
+		assert.Len(t, capturedTeams, 1)
+		assert.Equal(t, int64(90), capturedTeams[0].MatchID)
+		assert.Equal(t, "CAN", *capturedTeams[0].HomeTeamFifaCode)
+		assert.Nil(t, capturedTeams[0].AwayTeamFifaCode) // match 75 not finished yet
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -527,6 +586,48 @@ func TestMatchService_UpdateMatchResultsBulk(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, outcomes.IsGroupStageFinished)
 		assert.Equal(t, outcomes.PromotionOutcome.Status, domain.PromotionStatusCompleted)
+	})
+
+	t.Run("advances bracket and skips group sync for a knockout-only payload", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedTeams []domain.MatchTeamUpdate
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{knockoutMatch73CanBeatRsa()}, nil
+			},
+			UpdateMatchesResultFunc: func(ctx context.Context, updates []domain.MatchResultUpdate) error {
+				return nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				capturedTeams = updates
+				return nil
+			},
+			// Group-sync mocks intentionally unset; SyncGroupStageOutcomes must not run.
+		}
+
+		ss := &mocks.MockScoringService{
+			ScoreMatchesFunc: func(ctx context.Context, matchIDs []int64) (*domain.ScoreMatchesResult, error) {
+				return &domain.ScoreMatchesResult{}, nil
+			},
+		}
+
+		service := newTestMatchService(mr, nil, nil, ss, &mocks.MockCompetitionScoringService{
+			RecomputeForMatchesFunc: func(ctx context.Context, result *domain.ScoreMatchesResult) error { return nil },
+		}, nil)
+
+		home, away := 0, 1
+		outcomes, err := service.UpdateMatchResultsBulk(context.Background(), dtos.BulkUpdateMatchesResultDto{
+			Matches: []dtos.BulkUpdateMatchResultDto{
+				{ID: 73, UpdateMatchResultDto: dtos.UpdateMatchResultDto{HomeScore: &home, AwayScore: &away}},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, &domain.SyncGroupStageOutcomes{IsGroupStageFinished: true}, outcomes)
+		assert.Len(t, capturedTeams, 1)
+		assert.Equal(t, int64(90), capturedTeams[0].MatchID)
+		assert.Equal(t, "CAN", *capturedTeams[0].HomeTeamFifaCode)
 	})
 
 	t.Run("returns ErrMatchesNotFound when a match ID is not in the database", func(t *testing.T) {
@@ -806,5 +907,106 @@ func TestMatchService_ResolveThirdPlaceConflict(t *testing.T) {
 
 		assert.ErrorIs(t, err, domain.ErrThirdPlaceInvalidSelection)
 		assert.Nil(t, outcomes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMatchService_AdvanceBracket
+// ---------------------------------------------------------------------------
+func TestMatchService_AdvanceBracket(t *testing.T) {
+	t.Parallel()
+
+	t.Run("advances a knockout winner into the downstream slot, leaving the undecided side untouched", func(t *testing.T) {
+		t.Parallel()
+
+		var captured []domain.MatchTeamUpdate
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{knockoutMatch73CanBeatRsa()}, nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				captured = updates
+				return nil
+			},
+		}
+		service := newTestMatchService(mr, nil, nil, nil, nil, nil)
+
+		err := service.AdvanceBracket(context.Background(), []int64{73})
+
+		assert.NoError(t, err)
+		assert.Len(t, captured, 1)
+		assert.Equal(t, int64(90), captured[0].MatchID)
+		assert.Equal(t, "CAN", *captured[0].HomeTeamFifaCode)
+		assert.Nil(t, captured[0].AwayTeamFifaCode) // winner of match 75 not known yet
+	})
+
+	t.Run("resolves losers into the third-place match and winners into the final", func(t *testing.T) {
+		t.Parallel()
+
+		winner101, winner102 := "FRA", "ARG"
+		semiFinal101 := &domain.Match{
+			ID: 101, StageCode: domain.MatchStageCodeSemiFinals, Status: domain.MatchStatusFinished,
+			Teams:  domain.MatchTeams{Home: &domain.Team{FifaCode: "FRA"}, Away: &domain.Team{FifaCode: "BRA"}},
+			Result: &domain.MatchResult{HomeScore: 2, AwayScore: 1, WinnerTeamFifaCode: &winner101},
+		}
+		semiFinal102 := &domain.Match{
+			ID: 102, StageCode: domain.MatchStageCodeSemiFinals, Status: domain.MatchStatusFinished,
+			Teams:  domain.MatchTeams{Home: &domain.Team{FifaCode: "ARG"}, Away: &domain.Team{FifaCode: "GER"}},
+			Result: &domain.MatchResult{HomeScore: 3, AwayScore: 0, WinnerTeamFifaCode: &winner102},
+		}
+
+		var captured []domain.MatchTeamUpdate
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{semiFinal101, semiFinal102}, nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				captured = updates
+				return nil
+			},
+		}
+		service := newTestMatchService(mr, nil, nil, nil, nil, nil)
+
+		err := service.AdvanceBracket(context.Background(), []int64{101, 102})
+
+		assert.NoError(t, err)
+		byID := make(map[int64]domain.MatchTeamUpdate, len(captured))
+		for _, update := range captured {
+			byID[update.MatchID] = update
+		}
+		assert.Equal(t, "BRA", *byID[103].HomeTeamFifaCode) // loser of semifinal 101
+		assert.Equal(t, "GER", *byID[103].AwayTeamFifaCode) // loser of semifinal 102
+		assert.Equal(t, "FRA", *byID[104].HomeTeamFifaCode) // winner of semifinal 101
+		assert.Equal(t, "ARG", *byID[104].AwayTeamFifaCode) // winner of semifinal 102
+	})
+
+	t.Run("is idempotent across repeated runs", func(t *testing.T) {
+		t.Parallel()
+
+		var runs [][]domain.MatchTeamUpdate
+		mr := &mocks.MockMatchRepository{
+			GetMatchesFunc: func(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
+				return []*domain.Match{knockoutMatch73CanBeatRsa()}, nil
+			},
+			UpdateMatchTeamsFunc: func(ctx context.Context, updates []domain.MatchTeamUpdate) error {
+				runs = append(runs, updates)
+				return nil
+			},
+		}
+		service := newTestMatchService(mr, nil, nil, nil, nil, nil)
+
+		assert.NoError(t, service.AdvanceBracket(context.Background(), []int64{73}))
+		assert.NoError(t, service.AdvanceBracket(context.Background(), []int64{73}))
+		assert.Len(t, runs, 2)
+		assert.Equal(t, runs[0], runs[1])
+	})
+
+	t.Run("is a no-op for empty input and never touches the repository", func(t *testing.T) {
+		t.Parallel()
+
+		// All repository funcs are nil, so any repository call would panic.
+		service := newTestMatchService(&mocks.MockMatchRepository{}, nil, nil, nil, nil, nil)
+
+		assert.NoError(t, service.AdvanceBracket(context.Background(), nil))
 	})
 }

--- a/internal/test/mocks/match_service_mock.go
+++ b/internal/test/mocks/match_service_mock.go
@@ -15,6 +15,7 @@ type MockMatchService struct {
 	ResetMatchResultFunc           func(ctx context.Context, matchID int64) (*domain.SyncGroupStageOutcomes, error)
 	SyncGroupStageOutcomesFunc     func(ctx context.Context) (*domain.SyncGroupStageOutcomes, error)
 	ResolveThirdPlaceConflictFunc  func(ctx context.Context, payload dtos.ResolveThirdPlaceConflictDto) (*domain.SyncGroupStageOutcomes, error)
+	AdvanceBracketFunc             func(ctx context.Context, completedMatchIDs []int64) error
 }
 
 func (m *MockMatchService) GetMatches(ctx context.Context, filters domain.MatchFilters) ([]*domain.Match, error) {
@@ -64,4 +65,11 @@ func (m *MockMatchService) ResolveThirdPlaceConflict(ctx context.Context, payloa
 		return m.ResolveThirdPlaceConflictFunc(ctx, payload)
 	}
 	panic("ResolveThirdPlaceConflict called unexpectedly")
+}
+
+func (m *MockMatchService) AdvanceBracket(ctx context.Context, completedMatchIDs []int64) error {
+	if m.AdvanceBracketFunc != nil {
+		return m.AdvanceBracketFunc(ctx, completedMatchIDs)
+	}
+	panic("AdvanceBracket called unexpectedly")
 }


### PR DESCRIPTION
## Related issue

Closes #138

## What changed

- Add `MatchService.AdvanceBracket`: propagates knockout winners/losers into downstream `MatchSlotRules` slots (R32→R16 … SF→3rd-place/Final) — production previously never advanced the bracket
- Make finalize stage-aware: group matches still run `SyncGroupStageOutcomes`; knockout matches advance the bracket and skip the now-finished group-stage logic
- Seeder reuses the shared service method instead of its own private `advanceBracket`
- Add idempotent `POST /admin/bracket/advance` to backfill matches finished before this existed

## How to test

- [ ] `make test-unit` — new `AdvanceBracket` + stage-aware finalize tests pass
- [ ] Reseed local, set match 90 home to NULL, finalize match 73 via `POST /admin/matches/73/result` → match 90 home becomes CAN
- [ ] `POST /admin/bracket/advance` on a DB where match 73 is finished + match 90 is NULL → match 90 home = CAN; call again → no change
- [ ] Confirm finalizing a knockout match no longer recomputes group standings (check logs / standings unchanged)